### PR TITLE
fix: enforce transfer/debt sign invariants

### DIFF
--- a/AI 記帳/Views/Transactions/AddDebtView.swift
+++ b/AI 記帳/Views/Transactions/AddDebtView.swift
@@ -16,6 +16,8 @@ struct AddDebtView: View {
     @State private var amountString: String = ""
     @State private var date: Date = Date()
     @State private var note: String = ""
+    @State private var showingValidationAlert = false
+    @State private var validationMessage = ""
     
     // 🔥 新增：幣種選擇 (預設為我的帳戶幣種，但可更改)
     @State private var selectedCurrency: String = "HKD"
@@ -68,6 +70,12 @@ struct AddDebtView: View {
                         TextField("0", text: $amountString)
                             .keyboardType(.decimalPad)
                             .focused($isAmountFocused)
+                            .onChange(of: amountString) { _, newValue in
+                                let sanitized = sanitizePositiveDecimalInput(newValue)
+                                if sanitized != newValue {
+                                    amountString = sanitized
+                                }
+                            }
                     }
                     
                     DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
@@ -91,6 +99,11 @@ struct AddDebtView: View {
                 }
             }
             .navigationTitle("借貸管理")
+            .alert("輸入錯誤", isPresented: $showingValidationAlert) {
+                Button("確定", role: .cancel) { }
+            } message: {
+                Text(validationMessage)
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
@@ -108,7 +121,13 @@ struct AddDebtView: View {
     }
     
     private func saveTransaction() {
-        guard let debtAcc = selectedDebtAccount, let myAcc = selectedMyAccount, let amount = Decimal(string: amountString) else { return }
+        guard let debtAcc = selectedDebtAccount, let myAcc = selectedMyAccount else { return }
+        guard let amount = positiveDecimal(from: amountString) else {
+            showValidation("請輸入大於 0 的金額。")
+            return
+        }
+        
+        let normalizedAmount = abs(amount)
         
         let txID1 = UUID(); let txID2 = UUID()
         let memo = note.isEmpty ? mode.rawValue : note
@@ -118,25 +137,51 @@ struct AddDebtView: View {
         
         if mode == .borrow {
             let debtTx = FinancialTransaction(
-                id: txID1, amount: -amount, currencyCode: selectedCurrency, // 🔥 設定幣種
+                id: txID1, amount: -normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
                 date: date, note: "\(memo) (借入至 \(myAcc.name))", type: .transfer, linkedTransactionID: txID2, account: debtAcc
             )
             let myTx = FinancialTransaction(
-                id: txID2, amount: amount, currencyCode: selectedCurrency, // 🔥 設定幣種
+                id: txID2, amount: normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
                 date: date, note: "\(memo) (來自 \(debtAcc.name))", type: .transfer, linkedTransactionID: txID1, account: myAcc
             )
             modelContext.insert(debtTx); modelContext.insert(myTx)
         } else {
             let myTx = FinancialTransaction(
-                id: txID1, amount: -amount, currencyCode: selectedCurrency, // 🔥 設定幣種
+                id: txID1, amount: -normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
                 date: date, note: "\(memo) (還款給 \(debtAcc.name))", type: .transfer, linkedTransactionID: txID2, account: myAcc
             )
             let debtTx = FinancialTransaction(
-                id: txID2, amount: amount, currencyCode: selectedCurrency, // 🔥 設定幣種
+                id: txID2, amount: normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
                 date: date, note: "\(memo) (來自 \(myAcc.name))", type: .transfer, linkedTransactionID: txID1, account: debtAcc
             )
             modelContext.insert(myTx); modelContext.insert(debtTx)
         }
         dismiss()
+    }
+    
+    private func positiveDecimal(from value: String) -> Decimal? {
+        guard let parsed = Decimal(string: value), parsed > 0 else { return nil }
+        return parsed
+    }
+    
+    private func sanitizePositiveDecimalInput(_ value: String) -> String {
+        let allowed = value.filter { "0123456789.".contains($0) }
+        var result = ""
+        var hasDot = false
+        
+        for char in allowed {
+            if char == "." {
+                if hasDot { continue }
+                hasDot = true
+            }
+            result.append(char)
+        }
+        
+        return result == "." ? "" : result
+    }
+    
+    private func showValidation(_ message: String) {
+        validationMessage = message
+        showingValidationAlert = true
     }
 }

--- a/AI 記帳/Views/Transactions/AddTransferView.swift
+++ b/AI 記帳/Views/Transactions/AddTransferView.swift
@@ -18,6 +18,8 @@ struct AddTransferView: View {
     @State private var amountInString: String = ""  // 轉入金額
     @State private var date: Date = Date()
     @State private var note: String = ""
+    @State private var showingValidationAlert = false
+    @State private var validationMessage = ""
     
     let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
     
@@ -51,10 +53,15 @@ struct AddTransferView: View {
                             TextField("轉出金額", text: $amountOutString)
                                 .keyboardType(.decimalPad)
                                 .focused($focusedField, equals: .amountOut)
-                                .onChange(of: amountOutString) { _, _ in
+                                .onChange(of: amountOutString) { _, newValue in
+                                    let sanitized = sanitizePositiveDecimalInput(newValue)
+                                    if sanitized != newValue {
+                                        amountOutString = sanitized
+                                        return
+                                    }
                                     // 若幣種相同，自動同步輸入
                                     if currencyOut == currencyIn {
-                                        amountInString = amountOutString
+                                        amountInString = sanitized
                                     }
                                 }
                         }
@@ -84,6 +91,12 @@ struct AddTransferView: View {
                             TextField("轉入金額 (實收)", text: $amountInString)
                                 .keyboardType(.decimalPad)
                                 .focused($focusedField, equals: .amountIn)
+                                .onChange(of: amountInString) { _, newValue in
+                                    let sanitized = sanitizePositiveDecimalInput(newValue)
+                                    if sanitized != newValue {
+                                        amountInString = sanitized
+                                    }
+                                }
                         }
                         
                         // 雙幣種匯率顯示
@@ -117,6 +130,11 @@ struct AddTransferView: View {
                 }
             }
             .navigationTitle("轉帳")
+            .alert("輸入錯誤", isPresented: $showingValidationAlert) {
+                Button("確定", role: .cancel) { }
+            } message: {
+                Text(validationMessage)
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
@@ -132,13 +150,23 @@ struct AddTransferView: View {
     }
     
     private func saveTransfer() {
-        guard let from = fromAccount, let to = toAccount,
-              let amountOut = Decimal(string: amountOutString) else { return }
+        guard let from = fromAccount, let to = toAccount else { return }
+        guard let amountOut = positiveDecimal(from: amountOutString) else {
+            showValidation("請輸入大於 0 的轉出金額。")
+            return
+        }
         
         var amountIn = amountOut
-        if currencyOut != currencyIn, let customIn = Decimal(string: amountInString) {
+        if currencyOut != currencyIn {
+            guard let customIn = positiveDecimal(from: amountInString) else {
+                showValidation("跨幣種轉帳請輸入大於 0 的轉入金額。")
+                return
+            }
             amountIn = customIn
         }
+        
+        let normalizedAmountOut = abs(amountOut)
+        let normalizedAmountIn = abs(amountIn)
         
         let txID1 = UUID()
         let txID2 = UUID()
@@ -147,7 +175,7 @@ struct AddTransferView: View {
         // 1. 轉出 (支出) - 使用 currencyOut
         let outTx = FinancialTransaction(
             id: txID1,
-            amount: -amountOut,
+            amount: -normalizedAmountOut,
             currencyCode: currencyOut, // 🔥 明確指定轉出幣種
             date: date,
             note: "\(memo) (轉至 \(to.name))",
@@ -159,7 +187,7 @@ struct AddTransferView: View {
         // 2. 轉入 (收入) - 使用 currencyIn
         let inTx = FinancialTransaction(
             id: txID2,
-            amount: amountIn,
+            amount: normalizedAmountIn,
             currencyCode: currencyIn, // 🔥 明確指定轉入幣種
             date: date,
             note: "\(memo) (來自 \(from.name))",
@@ -173,5 +201,31 @@ struct AddTransferView: View {
         try? modelContext.save()
         
         dismiss()
+    }
+    
+    private func positiveDecimal(from value: String) -> Decimal? {
+        guard let parsed = Decimal(string: value), parsed > 0 else { return nil }
+        return parsed
+    }
+    
+    private func sanitizePositiveDecimalInput(_ value: String) -> String {
+        let allowed = value.filter { "0123456789.".contains($0) }
+        var result = ""
+        var hasDot = false
+        
+        for char in allowed {
+            if char == "." {
+                if hasDot { continue }
+                hasDot = true
+            }
+            result.append(char)
+        }
+        
+        return result == "." ? "" : result
+    }
+    
+    private func showValidation(_ message: String) {
+        validationMessage = message
+        showingValidationAlert = true
     }
 }

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -20,6 +20,8 @@ struct EditTransferView: View {
     @State private var amountInString: String = ""
     @State private var date: Date = Date()
     @State private var note: String = ""
+    @State private var showingValidationAlert = false
+    @State private var validationMessage: String = ""
     
     @State private var isLoading = true
     @State private var errorMessage: String?
@@ -45,9 +47,14 @@ struct EditTransferView: View {
                             TextField("轉出金額", text: $amountOutString)
                                 .keyboardType(.decimalPad)
                                 .focused($focusedField, equals: .amountOut)
-                                .onChange(of: amountOutString) { _, _ in
+                                .onChange(of: amountOutString) { _, newValue in
+                                    let sanitized = sanitizePositiveDecimalInput(newValue)
+                                    if sanitized != newValue {
+                                        amountOutString = sanitized
+                                        return
+                                    }
                                     if let to = toAccount, from.currency == to.currency {
-                                        amountInString = amountOutString
+                                        amountInString = sanitized
                                     }
                                 }
                         }
@@ -65,6 +72,12 @@ struct EditTransferView: View {
                                 TextField("轉入金額 (實際收到)", text: $amountInString)
                                     .keyboardType(.decimalPad)
                                     .focused($focusedField, equals: .amountIn)
+                                    .onChange(of: amountInString) { _, newValue in
+                                        let sanitized = sanitizePositiveDecimalInput(newValue)
+                                        if sanitized != newValue {
+                                            amountInString = sanitized
+                                        }
+                                    }
                                 
                                 // 🔥 匯率顯示
                                 if let outVal = Double(amountOutString), let inVal = Double(amountInString), outVal > 0 {
@@ -99,6 +112,11 @@ struct EditTransferView: View {
                 }
             }
             .navigationTitle("編輯轉帳")
+            .alert("輸入錯誤", isPresented: $showingValidationAlert) {
+                Button("確定", role: .cancel) { }
+            } message: {
+                Text(validationMessage)
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
@@ -149,7 +167,7 @@ struct EditTransferView: View {
                 
                 // 設定初始值 (轉出顯示正數)
                 self.amountOutString = "\(abs(outTx.amount))"
-                self.amountInString = "\(inTx.amount)"
+                self.amountInString = "\(abs(inTx.amount))"
                 self.date = tx1.date
                 
                 // 備註處理 (去除系統自動加的後綴)
@@ -174,25 +192,62 @@ struct EditTransferView: View {
     private func saveChanges() {
         guard let outTx = (originalTransaction.amount < 0 ? originalTransaction : linkedTransaction),
               let inTx = (originalTransaction.amount > 0 ? originalTransaction : linkedTransaction),
-              let amountOut = Decimal(string: amountOutString),
               let to = toAccount, let from = fromAccount
         else { return }
         
+        guard let amountOut = positiveDecimal(from: amountOutString) else {
+            showValidation("請輸入大於 0 的轉出金額。")
+            return
+        }
+        
         var amountIn = amountOut
-        if from.currency != to.currency, let customIn = Decimal(string: amountInString) {
+        if from.currency != to.currency {
+            guard let customIn = positiveDecimal(from: amountInString) else {
+                showValidation("跨幣種轉帳請輸入大於 0 的轉入金額。")
+                return
+            }
             amountIn = customIn
         }
         
+        let normalizedAmountOut = abs(amountOut)
+        let normalizedAmountIn = abs(amountIn)
+        
         // 更新轉出
-        outTx.amount = -amountOut
+        outTx.amount = -normalizedAmountOut
         outTx.date = date
         outTx.note = note.isEmpty ? "轉帳 (轉至 \(to.name))" : "\(note) (轉至 \(to.name))"
         
         // 更新轉入
-        inTx.amount = amountIn
+        inTx.amount = normalizedAmountIn
         inTx.date = date
         inTx.note = note.isEmpty ? "轉帳 (來自 \(from.name))" : "\(note) (來自 \(from.name))"
         
         dismiss()
+    }
+    
+    private func positiveDecimal(from value: String) -> Decimal? {
+        guard let parsed = Decimal(string: value), parsed > 0 else { return nil }
+        return parsed
+    }
+    
+    private func sanitizePositiveDecimalInput(_ value: String) -> String {
+        let allowed = value.filter { "0123456789.".contains($0) }
+        var result = ""
+        var hasDot = false
+        
+        for char in allowed {
+            if char == "." {
+                if hasDot { continue }
+                hasDot = true
+            }
+            result.append(char)
+        }
+        
+        return result == "." ? "" : result
+    }
+    
+    private func showValidation(_ message: String) {
+        validationMessage = message
+        showingValidationAlert = true
     }
 }


### PR DESCRIPTION
## Summary
- enforce positive numeric input for transfer/debt amount fields (Add/Edit Transfer, Add Debt)
- sanitize pasted sign characters and invalid amount input
- add user-facing validation alerts for invalid/zero amounts
- normalize persisted amounts by role:
  - outgoing leg always negative
  - incoming leg always positive

## Why
Negative raw input could invert transfer/debt semantics and break list/report assumptions.

## Data compatibility
- no model/schema changes
- no backup JSON format changes
- existing JSON backups remain import-compatible

## Verification
- xcodebuild simulator build succeeded
- manual checks:
  1. paste negative value in transfer/debt amount fields -> input sanitized to positive
  2. save transfer/debt -> persisted legs keep out<0 / in>0

Closes #1