### PR TITLE
fix: prevent account sortOrder collisions

### DIFF
--- a/AI 記帳/Services/CSVManager.swift
+++ b/AI 記帳/Services/CSVManager.swift
@@ -50,6 +50,7 @@ struct CSVManager {
         var accounts = (try? modelContext.fetch(FetchDescriptor<Account>())) ?? []
         var categories = (try? modelContext.fetch(FetchDescriptor<Category>())) ?? []
         var tags = (try? modelContext.fetch(FetchDescriptor<Tag>())) ?? []
+        var nextSortOrder = (accounts.map(\.sortOrder).max() ?? -1) + 1
         
         for row in rows {
             let cols = row.components(separatedBy: ",")
@@ -81,10 +82,11 @@ struct CSVManager {
                 // 但如果 CSV 的 currency 欄位有值，我們應該用 CSV 的
                 let initialCurrency = csvCurrency.isEmpty ? "HKD" : csvCurrency
                 
-                let newAcc = Account(name: accountName, currency: initialCurrency, type: .cash, baseBalance: 0, sortOrder: 0)
+                let newAcc = Account(name: accountName, currency: initialCurrency, type: .cash, baseBalance: 0, sortOrder: nextSortOrder)
                 modelContext.insert(newAcc)
                 account = newAcc
                 accounts.append(newAcc)
+                nextSortOrder += 1
             }
             
             // 3. 處理分類

--- a/AI 記帳/Views/Accounts/AccountsView.swift
+++ b/AI 記帳/Views/Accounts/AccountsView.swift
@@ -94,7 +94,10 @@ struct AccountsView: View {
             }
             .sheet(isPresented: $showingAddAccount) { AddAccountView() }
             .sheet(item: $accountToEdit) { account in EditAccountView(account: account) }
-            .task { await currencyService.fetchRates() }
+            .task {
+                await currencyService.fetchRates()
+                normalizeSortOrdersIfNeeded()
+            }
         }
     }
     
@@ -151,9 +154,55 @@ struct AccountsView: View {
     }
     
     private func moveAccounts(in subset: [Account], from source: IndexSet, to destination: Int) {
+        guard let first = subset.first else { return }
         var revisedItems = subset
         revisedItems.move(fromOffsets: source, toOffset: destination)
-        for (index, item) in revisedItems.enumerated() { item.sortOrder = index }
+        
+        var activeAssets = sortedBucket(isArchived: false, isDebt: false)
+        var activeDebts = sortedBucket(isArchived: false, isDebt: true)
+        var archivedAssets = sortedBucket(isArchived: true, isDebt: false)
+        var archivedDebts = sortedBucket(isArchived: true, isDebt: true)
+        
+        if first.isArchived {
+            if first.type == .debt { archivedDebts = revisedItems }
+            else { archivedAssets = revisedItems }
+        } else {
+            if first.type == .debt { activeDebts = revisedItems }
+            else { activeAssets = revisedItems }
+        }
+        
+        let combined = activeAssets + activeDebts + archivedAssets + archivedDebts
+        for (index, item) in combined.enumerated() { item.sortOrder = index }
+    }
+    
+    private func normalizeSortOrdersIfNeeded() {
+        let combined = groupedAccounts()
+        
+        for (index, account) in combined.enumerated() {
+            if account.sortOrder != index {
+                for (newIndex, item) in combined.enumerated() { item.sortOrder = newIndex }
+                return
+            }
+        }
+    }
+    
+    private func groupedAccounts() -> [Account] {
+        let activeAssets = sortedBucket(isArchived: false, isDebt: false)
+        let activeDebts = sortedBucket(isArchived: false, isDebt: true)
+        let archivedAssets = sortedBucket(isArchived: true, isDebt: false)
+        let archivedDebts = sortedBucket(isArchived: true, isDebt: true)
+        return activeAssets + activeDebts + archivedAssets + archivedDebts
+    }
+    
+    private func sortedBucket(isArchived: Bool, isDebt: Bool) -> [Account] {
+        allAccounts
+            .filter { $0.isArchived == isArchived && (($0.type == .debt) == isDebt) }
+            .sorted(by: accountOrder)
+    }
+    
+    private func accountOrder(_ lhs: Account, _ rhs: Account) -> Bool {
+        if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
+        return lhs.id.uuidString < rhs.id.uuidString
     }
     
     private func calculateTotalEstimatedAssets() -> String {

--- a/AI 記帳/Views/Accounts/AddAccountView.swift
+++ b/AI 記帳/Views/Accounts/AddAccountView.swift
@@ -137,7 +137,8 @@ struct AddAccountView: View {
     private func saveAccount() {
         let mainBalance = Decimal(string: balanceString) ?? 0
         let initialBaseBalance = (type == .debt && linkedAccount != nil) ? 0 : mainBalance
-        let newAccount = Account(name: name, currency: currency, type: type, baseBalance: initialBaseBalance, sortOrder: 0)
+        let nextSortOrder = (allAccounts.map(\.sortOrder).max() ?? -1) + 1
+        let newAccount = Account(name: name, currency: currency, type: type, baseBalance: initialBaseBalance, sortOrder: nextSortOrder)
         modelContext.insert(newAccount)
         
         let now = Date()


### PR DESCRIPTION
## Summary
- assign new account `sortOrder` using next available value instead of constant `0`
- fix CSV-imported new accounts to use incremental `sortOrder` values
- rework account move logic to reorder within the correct bucket (active/debt/archived) and then normalize globally to unique contiguous sortOrder values
- add sort-order normalization on account page load to recover existing collision data

## Compatibility
- no backup JSON schema changes
- existing backup import/export remains compatible

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' build

Closes #7
