### PR TITLE
fix: handle quoted CSV fields in import parser

### DIFF
--- a/AI 記帳/Services/CSVManager.swift
+++ b/AI 記帳/Services/CSVManager.swift
@@ -39,7 +39,7 @@ struct CSVManager {
     @MainActor
     func importCSV(url: URL, modelContext: ModelContext) throws {
         let data = try String(contentsOf: url, encoding: .utf8)
-        var rows = data.components(separatedBy: "\n")
+        var rows = parseCSVRows(data)
         guard rows.count > 1 else { return }
         rows.removeFirst() // 移除標題
         
@@ -51,8 +51,7 @@ struct CSVManager {
         var categories = (try? modelContext.fetch(FetchDescriptor<Category>())) ?? []
         var tags = (try? modelContext.fetch(FetchDescriptor<Tag>())) ?? []
         
-        for row in rows {
-            let cols = row.components(separatedBy: ",")
+        for cols in rows {
             if cols.count < 7 { continue }
             
             guard let date = formatter.date(from: cols[0]),
@@ -144,5 +143,59 @@ struct CSVManager {
             )
             modelContext.insert(tx)
         }
+    }
+    
+    private func parseCSVRows(_ input: String) -> [[String]] {
+        let text = input.replacingOccurrences(of: "\u{FEFF}", with: "")
+        var rows: [[String]] = []
+        var row: [String] = []
+        var field = ""
+        var inQuotes = false
+        
+        var index = text.startIndex
+        while index < text.endIndex {
+            let ch = text[index]
+            
+            if ch == "\"" {
+                let next = text.index(after: index)
+                if inQuotes && next < text.endIndex && text[next] == "\"" {
+                    field.append("\"")
+                    index = next
+                } else {
+                    inQuotes.toggle()
+                }
+            } else if ch == "," && !inQuotes {
+                row.append(field)
+                field = ""
+            } else if (ch == "\n" || ch == "\r") && !inQuotes {
+                row.append(field)
+                field = ""
+                
+                if !row.allSatisfy(\.isEmpty) {
+                    rows.append(row)
+                }
+                row = []
+                
+                if ch == "\r" {
+                    let next = text.index(after: index)
+                    if next < text.endIndex && text[next] == "\n" {
+                        index = next
+                    }
+                }
+            } else {
+                field.append(ch)
+            }
+            
+            index = text.index(after: index)
+        }
+        
+        if !field.isEmpty || !row.isEmpty {
+            row.append(field)
+            if !row.allSatisfy(\.isEmpty) {
+                rows.append(row)
+            }
+        }
+        
+        return rows
     }
 }


### PR DESCRIPTION
## Summary
- replace naive CSV splitting (`\n` and `,`) with a quote-aware CSV parser
- support standard quoted CSV fields including:
  - commas inside quoted fields
  - newlines inside quoted fields
  - escaped double quotes (`""`)
  - CRLF line endings and UTF-8 BOM
- wire import flow to use parsed columns directly

## Compatibility
- no model/schema changes
- existing backup JSON import/export remains unchanged

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' build

Closes #6
