### PR TITLE
fix: store Gemini API key in Keychain

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -18,10 +18,9 @@ struct AI___App: App {
             fatalError("無法存取 Documents 資料夾")
         }
         
-        // 2. 🔥 關鍵修正：關閉檔案保護 (File Protection)
-        // 免費帳號簽名時，預設的加密保護會導致 Permission Denied
+        // 2. 使用較安全的檔案保護，避免 FileProtection.none
         do {
-            let attributes = [FileAttributeKey.protectionKey: FileProtectionType.none]
+            let attributes = [FileAttributeKey.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
             try fileManager.setAttributes(attributes, ofItemAtPath: documentsURL.path)
         } catch {
             print("⚠️ 無法設定檔案保護屬性: \(error)")

--- a/AI 記帳/Services/GeminiService.swift
+++ b/AI 記帳/Services/GeminiService.swift
@@ -13,10 +13,27 @@ struct ReceiptInfo: Codable {
 
 class GeminiService {
     static let shared = GeminiService()
+    private let keychainServiceName = "org.duckdns.lhfser.AIMoney"
+    private let keychainAccountName = "gemini_api_key"
+    private let legacyUserDefaultsKey = "UserGeminiAPIKey"
     
     private var apiKey: String {
-        let rawKey = UserDefaults.standard.string(forKey: "UserGeminiAPIKey") ?? ""
-        return rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let keychainValue = KeychainService.shared.read(service: keychainServiceName, account: keychainAccountName)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !keychainValue.isEmpty {
+            return keychainValue
+        }
+        
+        let legacyValue = (UserDefaults.standard.string(forKey: legacyUserDefaultsKey) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if !legacyValue.isEmpty {
+            _ = KeychainService.shared.save(service: keychainServiceName, account: keychainAccountName, value: legacyValue)
+            UserDefaults.standard.removeObject(forKey: legacyUserDefaultsKey)
+            return legacyValue
+        }
+        
+        return ""
     }
     
     // 🔥 最終答案：根據你的列表，選用最標準的 2.0 Flash

--- a/AI 記帳/Services/KeychainService.swift
+++ b/AI 記帳/Services/KeychainService.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Security
+
+struct KeychainService {
+    static let shared = KeychainService()
+    
+    private init() {}
+    
+    func save(service: String, account: String, value: String) -> Bool {
+        let data = Data(value.utf8)
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        
+        SecItemDelete(baseQuery as CFDictionary)
+        
+        var attributes = baseQuery
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+    
+    func read(service: String, account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+    
+    func delete(service: String, account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/AI 記帳/Views/SettingsView.swift
+++ b/AI 記帳/Views/SettingsView.swift
@@ -5,7 +5,7 @@ import UniformTypeIdentifiers
 struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
     @AppStorage("mainCurrency") private var mainCurrency: String = "HKD"
-    @AppStorage("UserGeminiAPIKey") private var apiKey: String = ""
+    @AppStorage("UserGeminiAPIKey") private var legacyApiKey: String = ""
     @AppStorage("enableAutoBackup") private var enableAutoBackup: Bool = false
     @AppStorage("lastBackupDate") private var lastBackupDate: Double = 0
     @AppStorage("backupRetentionDays") private var backupRetentionDays: Int = 30
@@ -20,8 +20,11 @@ struct SettingsView: View {
     @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var showingDeleteAlert = false
+    @State private var apiKey: String = ""
     
     let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+    private let keychainServiceName = "org.duckdns.lhfser.AIMoney"
+    private let keychainAccountName = "gemini_api_key"
     
     // MARK: - 精確倒數計時邏輯
     struct TimeLeftInfo {
@@ -87,6 +90,7 @@ struct SettingsView: View {
                 Section("AI 設定") {
                     SecureField("Gemini API Key", text: $apiKey)
                         .textContentType(.password)
+                        .onChange(of: apiKey) { saveAPIKey($0) }
                         .onSubmit { hideKeyboard() }
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
@@ -178,6 +182,38 @@ struct SettingsView: View {
                     showingAlert = true
                 }
             }
+            .onAppear { loadAPIKey() }
+        }
+    }
+    
+    private func loadAPIKey() {
+        if let keychainValue = KeychainService.shared.read(service: keychainServiceName, account: keychainAccountName),
+           !keychainValue.isEmpty {
+            apiKey = keychainValue
+            return
+        }
+        
+        let legacy = legacyApiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !legacy.isEmpty else { return }
+        
+        if KeychainService.shared.save(service: keychainServiceName, account: keychainAccountName, value: legacy) {
+            legacyApiKey = ""
+        }
+        apiKey = legacy
+    }
+    
+    private func saveAPIKey(_ rawValue: String) {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if value.isEmpty {
+            _ = KeychainService.shared.delete(service: keychainServiceName, account: keychainAccountName)
+        } else if !KeychainService.shared.save(service: keychainServiceName, account: keychainAccountName, value: value) {
+            alertMessage = "無法儲存 API Key 至 Keychain"
+            showingAlert = true
+        }
+        
+        if !legacyApiKey.isEmpty {
+            legacyApiKey = ""
         }
     }
     


### PR DESCRIPTION
## Summary
- migrate Gemini API key storage from `UserDefaults` to iOS Keychain
- add `KeychainService` with save/read/delete helpers
- auto-migrate legacy `UserGeminiAPIKey` value into Keychain and clear plaintext legacy value
- update settings screen to read/write key from Keychain
- replace `FileProtection.none` with `FileProtection.completeUntilFirstUserAuthentication` for app documents directory

## Data Safety
- no schema/model changes
- existing JSON backup import/export flow is unchanged
- migration keeps existing API key usable by reading legacy value once and storing it securely

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' build

Closes #9
