### PR TITLE
docs: add multilingual open-source docs (en/zh-Hant/zh-Hans)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,28 @@
 # Contributing
 
-## 開發流程
+Language: **English** | [繁體中文](./CONTRIBUTING.zh-Hant.md) | [简体中文](./CONTRIBUTING.zh-Hans.md)
 
-1. Fork 本專案
-2. 建立分支（建議 `feature/...` 或 `fix/...`）
-3. 提交變更與測試結果
-4. 開立 Pull Request
+## Workflow
 
-## 提交前檢查
+1. Fork this repository.
+2. Create a branch (`feature/...` or `fix/...`).
+3. Commit your changes with validation notes.
+4. Open a Pull Request.
 
-- Xcode 可成功 build
-- 主要流程可手動驗證：新增交易、轉帳、報表、備份匯入
-- 不提交任何敏感資料（API key、token、個資）
+## Before Submitting
 
-## Commit 建議格式
+- Project builds successfully in Xcode.
+- Core flows are manually verified: transaction, transfer, reports, backup/restore.
+- No sensitive data is committed (API keys, tokens, personal data, real backup files).
+
+## Recommended Commit Prefixes
 
 - `feat: ...`
 - `fix: ...`
 - `docs: ...`
 - `chore: ...`
 
-## 問題回報
+## Reporting Issues
 
-- Bug：請使用 GitHub Issue 模板並附重現步驟
-- 安全問題：請參考 [SECURITY.md](./SECURITY.md)
+- For bugs, use the GitHub issue template with reproducible steps.
+- For security concerns, follow [SECURITY.md](./SECURITY.md).

--- a/CONTRIBUTING.zh-Hans.md
+++ b/CONTRIBUTING.zh-Hans.md
@@ -1,0 +1,28 @@
+# 贡献指南
+
+语言： [English](./CONTRIBUTING.md) | [繁體中文](./CONTRIBUTING.zh-Hant.md) | **简体中文**
+
+## 开发流程
+
+1. Fork 本项目
+2. 创建分支（建议 `feature/...` 或 `fix/...`）
+3. 提交变更与测试结果
+4. 发起 Pull Request
+
+## 提交前检查
+
+- Xcode 可以成功 build
+- 主要流程手动验证通过：新增交易、转账、报表、备份导入
+- 不提交任何敏感数据（API key、token、个人信息、真实备份文件）
+
+## Commit 建议格式
+
+- `feat: ...`
+- `fix: ...`
+- `docs: ...`
+- `chore: ...`
+
+## 问题反馈
+
+- Bug：请使用 GitHub Issue 模板并附复现步骤
+- 安全问题：请参考 [SECURITY.zh-Hans.md](./SECURITY.zh-Hans.md)

--- a/CONTRIBUTING.zh-Hant.md
+++ b/CONTRIBUTING.zh-Hant.md
@@ -1,0 +1,28 @@
+# 貢獻指南
+
+語言： [English](./CONTRIBUTING.md) | **繁體中文** | [简体中文](./CONTRIBUTING.zh-Hans.md)
+
+## 開發流程
+
+1. Fork 本專案
+2. 建立分支（建議 `feature/...` 或 `fix/...`）
+3. 提交變更與測試結果
+4. 開立 Pull Request
+
+## 提交前檢查
+
+- Xcode 可成功 build
+- 主要流程可手動驗證：新增交易、轉帳、報表、備份匯入
+- 不提交任何敏感資料（API key、token、個資、真實備份檔）
+
+## Commit 建議格式
+
+- `feat: ...`
+- `fix: ...`
+- `docs: ...`
+- `chore: ...`
+
+## 問題回報
+
+- Bug：請使用 GitHub Issue 模板並附重現步驟
+- 安全問題：請參考 [SECURITY.zh-Hant.md](./SECURITY.zh-Hant.md)

--- a/README.md
+++ b/README.md
@@ -1,68 +1,74 @@
-# AI 記帳 (AI Accounting iOS)
+# AI Accounting iOS
 
-AI 記帳是一個以 SwiftUI + SwiftData 開發的 iOS 個人記帳 App，支援多幣別、轉帳、借貸、報表分析、備份還原與 AI 收據掃描。
+Language: **English** | [繁體中文](./README.zh-Hant.md) | [简体中文](./README.zh-Hans.md)
 
-## 主要功能
+AI Accounting iOS is a personal finance app built with SwiftUI + SwiftData.
+It supports multi-currency bookkeeping, transfers, loan tracking, reports, backup/restore, and AI receipt scanning.
 
-- 多帳戶記帳：現金/銀行/信用卡等帳戶類型
-- 多幣別交易：每筆交易可使用獨立幣別
-- 轉帳與借貸流程：含正負號一致性與雙邊交易聯動
-- 報表分析：依分類/標籤查看支出結構
-- 捷徑記帳：快速記錄常用交易
-- 備份與還原：JSON 全機備份、CSV 匯出
-- AI 收據掃描：可選填 Gemini API Key 啟用
+## Features
 
-## 語言支援
+- Multiple account types (cash, bank, credit card, etc.)
+- Multi-currency transactions (currency per transaction)
+- Transfer and loan flows with sign-invariant handling
+- Category/tag based reports
+- Shortcut entries for quick bookkeeping
+- Full JSON backup/restore and CSV export
+- Optional AI receipt scanning with Gemini API key
 
-- 繁體中文（`zh-Hant`）
-- 簡體中文（`zh-Hans`）
-- 英式英文（`en-GB`）
-- 日文（`ja`）
+## Localization
 
-## 技術棧
+App UI currently supports:
+
+- Traditional Chinese (`zh-Hant`)
+- Simplified Chinese (`zh-Hans`)
+- British English (`en-GB`)
+- Japanese (`ja`)
+
+## Tech Stack
 
 - SwiftUI
 - SwiftData
 - Charts
 - Google Generative AI Swift SDK (`generative-ai-swift`)
 
-## 環境需求
+## Requirements
 
 - macOS
-- Xcode（已在 `Xcode 26.2` 驗證）
-- iOS Simulator 或實機
+- Xcode (verified with `Xcode 26.2`)
+- iOS Simulator or physical iPhone
 
-## 快速開始
+## Quick Start
 
-1. Clone 專案
-2. 用 Xcode 開啟 `AI 記帳.xcodeproj`
-3. 選擇 Simulator 或 iPhone 裝置
-4. `Cmd + R` 執行
+1. Clone this repository.
+2. Open `AI 記帳.xcodeproj` in Xcode.
+3. Select a simulator or device.
+4. Run with `Cmd + R`.
 
 ## CI
 
-- GitHub Actions 會在 `push` / `pull_request` 到 `main` 時執行：
-  - `Localizable.xcstrings` 結構驗證
-  - iOS 專案 build 檢查
+GitHub Actions runs on `push` and `pull_request` to `main`:
 
-## AI Key 與隱私
+- `Localizable.xcstrings` validation
+- iOS simulator build
 
-- Gemini API Key 由使用者在 App 內設定
-- API Key 儲存在 iOS Keychain（不寫入 repo）
-- 專案不包含任何預設 API Key、token 或私鑰
+## Privacy and Secrets
 
-## 資料相容性
+- Gemini API key is provided by each user inside the app.
+- API key is stored in iOS Keychain.
+- The repository does not include default API keys, tokens, or private keys.
 
-- `2026-02-24` 快照版 (`4417c97`) 到目前版本未做破壞性資料模型遷移
-- 舊版 JSON 備份可匯入目前版本
+## Data Compatibility
 
-## 開源文件
+- No breaking data-model migration from snapshot `4417c97` (2026-02-24) to current releases.
+- Existing JSON backups remain import-compatible.
+
+## Open-Source Documents
 
 - License: [MIT](./LICENSE)
-- Security policy: [SECURITY.md](./SECURITY.md)
-- Contribution guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Pull Request template: [`.github/pull_request_template.md`](./.github/pull_request_template.md)
+- Security policy: [English](./SECURITY.md) | [繁體中文](./SECURITY.zh-Hant.md) | [简体中文](./SECURITY.zh-Hans.md)
+- Contribution guide: [English](./CONTRIBUTING.md) | [繁體中文](./CONTRIBUTING.zh-Hant.md) | [简体中文](./CONTRIBUTING.zh-Hans.md)
+- Pull request template: [`.github/pull_request_template.md`](./.github/pull_request_template.md)
 
-## 免責聲明
+## Disclaimer
 
-本專案為個人財務管理工具，請自行評估使用風險並定期備份資料。
+This project is provided as-is for personal finance management. Please evaluate your own risk and keep regular backups.

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,0 +1,71 @@
+# AI 记账 (AI Accounting iOS)
+
+语言： [English](./README.md) | [繁體中文](./README.zh-Hant.md) | **简体中文**
+
+AI 记账是一个使用 SwiftUI + SwiftData 开发的 iOS 个人记账 App，支持多币种、转账、借贷、报表分析、备份还原与 AI 小票扫描。
+
+## 主要功能
+
+- 多账户记账：现金 / 银行 / 信用卡等账户类型
+- 多币种交易：每笔交易可使用独立币种
+- 转账与借贷流程：包含正负号一致性与双边交易联动
+- 报表分析：按分类 / 标签查看支出结构
+- 快捷记账：快速记录常用交易
+- 备份与还原：JSON 全量备份、CSV 导出
+- AI 小票扫描：可选填 Gemini API Key 启用
+
+## 语言支持
+
+- 繁体中文（`zh-Hant`）
+- 简体中文（`zh-Hans`）
+- 英式英文（`en-GB`）
+- 日文（`ja`）
+
+## 技术栈
+
+- SwiftUI
+- SwiftData
+- Charts
+- Google Generative AI Swift SDK（`generative-ai-swift`）
+
+## 环境要求
+
+- macOS
+- Xcode（已在 `Xcode 26.2` 验证）
+- iOS Simulator 或真机
+
+## 快速开始
+
+1. Clone 仓库
+2. 用 Xcode 打开 `AI 記帳.xcodeproj`
+3. 选择 Simulator 或 iPhone 设备
+4. 使用 `Cmd + R` 运行
+
+## CI
+
+GitHub Actions 会在 `push` / `pull_request` 到 `main` 时执行：
+
+- `Localizable.xcstrings` 结构校验
+- iOS 项目 build 检查
+
+## 隐私与密钥
+
+- Gemini API Key 由用户在 App 内自行设置
+- API Key 存储在 iOS Keychain（不会写入仓库）
+- 仓库不包含任何默认 API Key、token 或私钥
+
+## 数据兼容性
+
+- 从 `2026-02-24` 快照版（`4417c97`）到当前版本无破坏性数据模型迁移
+- 旧版 JSON 备份可正常导入
+
+## 开源文件
+
+- 许可证： [MIT](./LICENSE)
+- 安全策略： [English](./SECURITY.md) | [繁體中文](./SECURITY.zh-Hant.md) | [简体中文](./SECURITY.zh-Hans.md)
+- 贡献指南： [English](./CONTRIBUTING.md) | [繁體中文](./CONTRIBUTING.zh-Hant.md) | [简体中文](./CONTRIBUTING.zh-Hans.md)
+- Pull Request 模板： [`.github/pull_request_template.md`](./.github/pull_request_template.md)
+
+## 免责声明
+
+本项目为个人财务管理工具，请自行评估使用风险并定期备份数据。

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,0 +1,71 @@
+# AI 記帳 (AI Accounting iOS)
+
+語言： [English](./README.md) | **繁體中文** | [简体中文](./README.zh-Hans.md)
+
+AI 記帳是一個以 SwiftUI + SwiftData 開發的 iOS 個人記帳 App，支援多幣別、轉帳、借貸、報表分析、備份還原與 AI 收據掃描。
+
+## 主要功能
+
+- 多帳戶記帳：現金 / 銀行 / 信用卡等帳戶類型
+- 多幣別交易：每筆交易可使用獨立幣別
+- 轉帳與借貸流程：含正負號一致性與雙邊交易聯動
+- 報表分析：依分類 / 標籤查看支出結構
+- 捷徑記帳：快速記錄常用交易
+- 備份與還原：JSON 全機備份、CSV 匯出
+- AI 收據掃描：可選填 Gemini API Key 啟用
+
+## 語言支援
+
+- 繁體中文（`zh-Hant`）
+- 簡體中文（`zh-Hans`）
+- 英式英文（`en-GB`）
+- 日文（`ja`）
+
+## 技術棧
+
+- SwiftUI
+- SwiftData
+- Charts
+- Google Generative AI Swift SDK（`generative-ai-swift`）
+
+## 環境需求
+
+- macOS
+- Xcode（已在 `Xcode 26.2` 驗證）
+- iOS Simulator 或實機
+
+## 快速開始
+
+1. Clone 專案
+2. 用 Xcode 開啟 `AI 記帳.xcodeproj`
+3. 選擇 Simulator 或 iPhone 裝置
+4. `Cmd + R` 執行
+
+## CI
+
+GitHub Actions 會在 `push` / `pull_request` 到 `main` 時執行：
+
+- `Localizable.xcstrings` 結構驗證
+- iOS 專案 build 檢查
+
+## 隱私與金鑰
+
+- Gemini API Key 由使用者在 App 內設定
+- API Key 儲存在 iOS Keychain（不寫入 repo）
+- 專案不包含任何預設 API Key、token 或私鑰
+
+## 資料相容性
+
+- `2026-02-24` 快照版（`4417c97`）到目前版本未做破壞性資料模型遷移
+- 舊版 JSON 備份可匯入目前版本
+
+## 開源文件
+
+- 授權： [MIT](./LICENSE)
+- 安全政策： [English](./SECURITY.md) | [繁體中文](./SECURITY.zh-Hant.md) | [简体中文](./SECURITY.zh-Hans.md)
+- 貢獻指南： [English](./CONTRIBUTING.md) | [繁體中文](./CONTRIBUTING.zh-Hant.md) | [简体中文](./CONTRIBUTING.zh-Hans.md)
+- Pull Request 模板： [`.github/pull_request_template.md`](./.github/pull_request_template.md)
+
+## 免責聲明
+
+本專案為個人財務管理工具，請自行評估使用風險並定期備份資料。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,23 @@
 # Security Policy
 
+Language: **English** | [繁體中文](./SECURITY.zh-Hant.md) | [简体中文](./SECURITY.zh-Hans.md)
+
 ## Supported Versions
 
-目前維護中的版本：`1.x`
+Maintained major version: `1.x`
 
 ## Reporting a Vulnerability
 
-請不要公開張貼可直接利用的安全漏洞細節。
+Please do not post exploit details publicly.
 
-建議流程：
+Recommended process:
 
-1. 優先使用 GitHub 的 Private Vulnerability Reporting（若已啟用）
-2. 或先開一個標題含 `[SECURITY]` 的 issue（不附 exploit 細節）
-3. 維護者確認後再進一步私下提供細節
+1. Use GitHub Private Vulnerability Reporting when available.
+2. Or open an issue titled with `[SECURITY]` without exploit details.
+3. Share full details privately after maintainer contact.
 
 ## Sensitive Data Rules
 
-- 禁止提交 API keys、access tokens、private keys
-- 禁止提交含個資的真實備份資料（JSON/CSV）
-- 若發現已提交敏感資料，請立即通知維護者並進行撤換/輪替
+- Do not commit API keys, access tokens, or private keys.
+- Do not commit real user backup data (JSON/CSV) containing personal information.
+- If leaked data is discovered, rotate/revoke credentials immediately and notify maintainers.

--- a/SECURITY.zh-Hans.md
+++ b/SECURITY.zh-Hans.md
@@ -1,0 +1,23 @@
+# 安全策略
+
+语言： [English](./SECURITY.md) | [繁體中文](./SECURITY.zh-Hant.md) | **简体中文**
+
+## 支持版本
+
+当前维护中的主要版本：`1.x`
+
+## 漏洞上报
+
+请不要公开发布可直接利用的漏洞细节。
+
+建议流程：
+
+1. 优先使用 GitHub Private Vulnerability Reporting（如已启用）
+2. 或先创建标题含 `[SECURITY]` 的 issue（不附 exploit 细节）
+3. 维护者联系后再私下提供完整细节
+
+## 敏感数据规则
+
+- 禁止提交 API keys、access tokens、private keys
+- 禁止提交包含个人信息的真实备份数据（JSON/CSV）
+- 若发现敏感数据泄露，请立即轮换凭证并通知维护者

--- a/SECURITY.zh-Hant.md
+++ b/SECURITY.zh-Hant.md
@@ -1,0 +1,23 @@
+# 安全政策
+
+語言： [English](./SECURITY.md) | **繁體中文** | [简体中文](./SECURITY.zh-Hans.md)
+
+## 支援版本
+
+目前維護中的主要版本：`1.x`
+
+## 漏洞回報
+
+請不要公開張貼可直接利用的漏洞細節。
+
+建議流程：
+
+1. 優先使用 GitHub Private Vulnerability Reporting（若已啟用）
+2. 或先開一個標題含 `[SECURITY]` 的 issue（不附 exploit 細節）
+3. 維護者聯繫後再私下提供完整細節
+
+## 敏感資料規則
+
+- 禁止提交 API keys、access tokens、private keys
+- 禁止提交含個資的真實備份資料（JSON/CSV）
+- 若發現敏感資料已外洩，請立即撤換憑證並通知維護者


### PR DESCRIPTION
## Summary
- Remove remaining stale remote branches (already done separately)
- Add multilingual open-source documentation for public readers

## Changes
- `README.md` switched to English default with language switch links
- Added `README.zh-Hant.md` and `README.zh-Hans.md`
- `CONTRIBUTING.md` switched to English with language links
- Added `CONTRIBUTING.zh-Hant.md` and `CONTRIBUTING.zh-Hans.md`
- `SECURITY.md` switched to English with language links
- Added `SECURITY.zh-Hant.md` and `SECURITY.zh-Hans.md`

## Notes
- License remains MIT (English canonical text)
- Branch protection on `main` remains enabled
