### PR TITLE
feat: separate income/expense categories with JSON-compatible model upgrade

### DIFF
--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -27,6 +27,38 @@ enum TransactionType: String, Codable {
     case transfer = "Transfer"
 }
 
+enum TransferSide: String, Codable {
+    case outgoing = "Outgoing"
+    case incoming = "Incoming"
+}
+
+enum CategoryKind: String, Codable, CaseIterable, Identifiable {
+    case expense = "Expense"
+    case income = "Income"
+    case both = "Both"
+    
+    var id: String { self.rawValue }
+    
+    var displayName: String {
+        switch self {
+        case .expense: return "支出"
+        case .income: return "收入"
+        case .both: return "通用"
+        }
+    }
+    
+    func supports(_ transactionType: TransactionType) -> Bool {
+        switch transactionType {
+        case .expense:
+            return self == .expense || self == .both
+        case .income:
+            return self == .income || self == .both
+        case .transfer:
+            return false
+        }
+    }
+}
+
 // MARK: - Models
 
 @Model
@@ -64,15 +96,17 @@ final class Category {
     var name: String
     var icon: String
     var colorHex: String
+    var kind: CategoryKind = CategoryKind.both
     
     @Relationship(deleteRule: .nullify, inverse: \FinancialTransaction.category)
     var transactions: [FinancialTransaction] = []
     
-    init(id: UUID = UUID(), name: String, icon: String, colorHex: String) {
+    init(id: UUID = UUID(), name: String, icon: String, colorHex: String, kind: CategoryKind = CategoryKind.both) {
         self.id = id
         self.name = name
         self.icon = icon
         self.colorHex = colorHex
+        self.kind = kind
     }
 }
 
@@ -101,6 +135,10 @@ final class FinancialTransaction {
     
     var type: TransactionType
     var linkedTransactionID: UUID?
+    var transferGroupID: UUID?
+    var transferSide: TransferSide?
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
     
     var account: Account?
     var category: Category?
@@ -114,9 +152,13 @@ final class FinancialTransaction {
          photoPath: String? = nil,
          type: TransactionType = .expense,
          linkedTransactionID: UUID? = nil,
+         transferGroupID: UUID? = nil,
+         transferSide: TransferSide? = nil,
          account: Account? = nil,
          category: Category? = nil,
-         tags: [Tag] = []) {
+         tags: [Tag] = [],
+         createdAt: Date = Date(),
+         updatedAt: Date = Date()) {
         self.id = id
         self.amount = amount
         self.currencyCode = currencyCode
@@ -125,9 +167,13 @@ final class FinancialTransaction {
         self.photoPath = photoPath
         self.type = type
         self.linkedTransactionID = linkedTransactionID
+        self.transferGroupID = transferGroupID
+        self.transferSide = transferSide
         self.account = account
         self.category = category
         self.tags = tags
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
     }
 }
 

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -21,6 +21,7 @@ struct FullBackupData: Codable {
     }
     struct CategoryCodable: Codable {
         let id: UUID; let name: String; let icon: String; let colorHex: String
+        let kind: String?
     }
     struct TagCodable: Codable {
         let id: UUID; let name: String
@@ -28,6 +29,11 @@ struct FullBackupData: Codable {
     struct TransactionCodable: Codable {
         let id: UUID; let amount: Decimal; let currencyCode: String; let date: Date; let note: String
         let type: String; let linkedTransactionID: UUID?
+        let transferGroupID: UUID?
+        let transferSide: String?
+        let photoPath: String?
+        let createdAt: Date?
+        let updatedAt: Date?
         let accountID: UUID?; let categoryID: UUID?; let tagIDs: [UUID]
     }
     struct ShortcutCodable: Codable {
@@ -101,11 +107,29 @@ class BackupManager: NSObject, ObservableObject {
         let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
         let shortcuts = (try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []
         
-        return FullBackupData(version: "1.1", timestamp: Date(),
+        return FullBackupData(version: "1.2", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
-            categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex) },
+            categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
-            transactions: transactions.map { FullBackupData.TransactionCodable(id: $0.id, amount: $0.amount, currencyCode: $0.currencyCode, date: $0.date, note: $0.note, type: $0.type.rawValue, linkedTransactionID: $0.linkedTransactionID, accountID: $0.account?.id, categoryID: $0.category?.id, tagIDs: $0.tags.map { $0.id }) },
+            transactions: transactions.map {
+                FullBackupData.TransactionCodable(
+                    id: $0.id,
+                    amount: $0.amount,
+                    currencyCode: $0.currencyCode,
+                    date: $0.date,
+                    note: $0.note,
+                    type: $0.type.rawValue,
+                    linkedTransactionID: $0.linkedTransactionID,
+                    transferGroupID: $0.transferGroupID,
+                    transferSide: $0.transferSide?.rawValue,
+                    photoPath: $0.photoPath,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt,
+                    accountID: $0.account?.id,
+                    categoryID: $0.category?.id,
+                    tagIDs: $0.tags.map { $0.id }
+                )
+            },
             shortcuts: shortcuts.map { FullBackupData.ShortcutCodable(id: $0.id, name: $0.name, icon: $0.icon, amount: $0.amount, type: $0.type.rawValue, note: $0.note, currencyCode: $0.currencyCode, accountID: $0.account?.id, categoryID: $0.category?.id, tagIDs: $0.tags.map { $0.id }) }
         )
     }
@@ -129,7 +153,8 @@ class BackupManager: NSObject, ObservableObject {
         }
         for catDTO in backup.categories {
             if !allCategories.contains(where: { $0.id == catDTO.id }) {
-                modelContext.insert(Category(id: catDTO.id, name: catDTO.name, icon: catDTO.icon, colorHex: catDTO.colorHex))
+                let kind = CategoryKind(rawValue: catDTO.kind ?? "") ?? .both
+                modelContext.insert(Category(id: catDTO.id, name: catDTO.name, icon: catDTO.icon, colorHex: catDTO.colorHex, kind: kind))
             }
         }
         for tagDTO in backup.tags {
@@ -147,7 +172,25 @@ class BackupManager: NSObject, ObservableObject {
                 let account = updatedAccounts.first(where: { $0.id == txDTO.accountID })
                 let category = updatedCategories.first(where: { $0.id == txDTO.categoryID })
                 let tags = updatedTags.filter { txDTO.tagIDs.contains($0.id) }
-                let tx = FinancialTransaction(id: txDTO.id, amount: txDTO.amount, currencyCode: txDTO.currencyCode, date: txDTO.date, note: txDTO.note, type: TransactionType(rawValue: txDTO.type) ?? .expense, linkedTransactionID: txDTO.linkedTransactionID, account: account, category: category, tags: tags)
+                let createdAt = txDTO.createdAt ?? txDTO.date
+                let updatedAt = txDTO.updatedAt ?? createdAt
+                let tx = FinancialTransaction(
+                    id: txDTO.id,
+                    amount: txDTO.amount,
+                    currencyCode: txDTO.currencyCode,
+                    date: txDTO.date,
+                    note: txDTO.note,
+                    photoPath: txDTO.photoPath,
+                    type: TransactionType(rawValue: txDTO.type) ?? .expense,
+                    linkedTransactionID: txDTO.linkedTransactionID,
+                    transferGroupID: txDTO.transferGroupID,
+                    transferSide: TransferSide(rawValue: txDTO.transferSide ?? ""),
+                    account: account,
+                    category: category,
+                    tags: tags,
+                    createdAt: createdAt,
+                    updatedAt: updatedAt
+                )
                 modelContext.insert(tx)
             }
         }
@@ -166,7 +209,7 @@ class BackupManager: NSObject, ObservableObject {
                 modelContext.insert(sc)
             }
         }
-        try? modelContext.save()
+        try modelContext.save()
     }
     
     @MainActor func generateCSV(modelContext: ModelContext) -> String {

--- a/AI 記帳/Services/CSVManager.swift
+++ b/AI 記帳/Services/CSVManager.swift
@@ -59,6 +59,7 @@ struct CSVManager {
                   let amount = Decimal(string: cols[2]) else { continue }
             
             let typeString = cols[1]
+            let type = TransactionType(rawValue: typeString) ?? .expense
             // CSV 欄位: 0:Date, 1:Type, 2:Amount, 3:Currency, 4:Category, 5:Account, 6:Note, 7:Tags
             let csvCurrency = cols[3]
             let categoryName = cols[4]
@@ -89,9 +90,18 @@ struct CSVManager {
             }
             
             // 3. 處理分類
-            var category = categories.first(where: { $0.name == categoryName })
+            var category = categories.first(where: { $0.name == categoryName && $0.kind.supports(type) })
             if category == nil && categoryName != "Uncategorized" {
-                let newCat = Category(name: categoryName, icon: "tag", colorHex: "808080")
+                let inferredKind: CategoryKind
+                switch type {
+                case .income:
+                    inferredKind = .income
+                case .expense:
+                    inferredKind = .expense
+                case .transfer:
+                    inferredKind = .both
+                }
+                let newCat = Category(name: categoryName, icon: "tag", colorHex: "808080", kind: inferredKind)
                 modelContext.insert(newCat)
                 category = newCat
                 categories.append(newCat)
@@ -130,8 +140,6 @@ struct CSVManager {
             
             // 雙重保險：如果還是空的，設為 HKD
             if finalCurrencyCode.isEmpty { finalCurrencyCode = "HKD" }
-            
-            let type = TransactionType(rawValue: typeString) ?? .expense
             
             let tx = FinancialTransaction(
                 amount: amount,

--- a/AI 記帳/Views/Accounts/AddAccountView.swift
+++ b/AI 記帳/Views/Accounts/AddAccountView.swift
@@ -148,13 +148,14 @@ struct AddAccountView: View {
             let absAmount = abs(mainBalance)
             let isBorrowing = mainBalance < 0
             let txID1 = UUID(); let txID2 = UUID()
+            let transferGroupID = UUID()
             if isBorrowing {
-                let debtTx = FinancialTransaction(id: txID1, amount: -absAmount, currencyCode: currency, date: now, note: "\(note) (轉至 \(linked.name))", type: .transfer, linkedTransactionID: txID2, account: newAccount)
-                let myTx = FinancialTransaction(id: txID2, amount: absAmount, currencyCode: currency, date: now, note: "\(note) (來自 \(newAccount.name))", type: .transfer, linkedTransactionID: txID1, account: linked)
+                let debtTx = FinancialTransaction(id: txID1, amount: -absAmount, currencyCode: currency, date: now, note: "\(note) (轉至 \(linked.name))", type: .transfer, linkedTransactionID: txID2, transferGroupID: transferGroupID, transferSide: .outgoing, account: newAccount)
+                let myTx = FinancialTransaction(id: txID2, amount: absAmount, currencyCode: currency, date: now, note: "\(note) (來自 \(newAccount.name))", type: .transfer, linkedTransactionID: txID1, transferGroupID: transferGroupID, transferSide: .incoming, account: linked)
                 modelContext.insert(debtTx); modelContext.insert(myTx)
             } else {
-                let myTx = FinancialTransaction(id: txID1, amount: -absAmount, currencyCode: currency, date: now, note: "\(note) (借給 \(newAccount.name))", type: .transfer, linkedTransactionID: txID2, account: linked)
-                let debtTx = FinancialTransaction(id: txID2, amount: absAmount, currencyCode: currency, date: now, note: "\(note) (來自 \(linked.name))", type: .transfer, linkedTransactionID: txID1, account: newAccount)
+                let myTx = FinancialTransaction(id: txID1, amount: -absAmount, currencyCode: currency, date: now, note: "\(note) (借給 \(newAccount.name))", type: .transfer, linkedTransactionID: txID2, transferGroupID: transferGroupID, transferSide: .outgoing, account: linked)
+                let debtTx = FinancialTransaction(id: txID2, amount: absAmount, currencyCode: currency, date: now, note: "\(note) (來自 \(linked.name))", type: .transfer, linkedTransactionID: txID1, transferGroupID: transferGroupID, transferSide: .incoming, account: newAccount)
                 modelContext.insert(myTx); modelContext.insert(debtTx)
             }
         }

--- a/AI 記帳/Views/Categories/AddCategoryView.swift
+++ b/AI 記帳/Views/Categories/AddCategoryView.swift
@@ -9,6 +9,7 @@ struct AddCategoryView: View {
     @State private var name: String = ""
     @State private var selectedIcon: String = "fork.knife"
     @State private var selectedColorHex: String = "007AFF" // 預設藍色
+    @State private var selectedKind: CategoryKind = .expense
     
     // 預定義的圖示列表
     private let commonIcons: [String] = [
@@ -45,6 +46,15 @@ struct AddCategoryView: View {
                         TextField("例如: 早餐、交通", text: $name)
                             .padding(.leading, 8)
                     }
+                }
+                
+                Section("類型") {
+                    Picker("類型", selection: $selectedKind) {
+                        ForEach(CategoryKind.allCases) { kind in
+                            Text(kind.displayName).tag(kind)
+                        }
+                    }
+                    .pickerStyle(.menu)
                 }
                 
                 // MARK: - 2. 圖示選擇
@@ -126,7 +136,8 @@ struct AddCategoryView: View {
         let newCategory = Category(
             name: name,
             icon: selectedIcon,
-            colorHex: selectedColorHex
+            colorHex: selectedColorHex,
+            kind: selectedKind
         )
         
         modelContext.insert(newCategory)

--- a/AI 記帳/Views/Categories/CategoriesView.swift
+++ b/AI 記帳/Views/Categories/CategoriesView.swift
@@ -10,43 +10,27 @@ struct CategoriesView: View {
     
     var body: some View {
         List {
-            ForEach(categories) { category in
-                HStack(spacing: 16) {
-                    // Icon Circle
-                    ZStack {
-                        Circle()
-                            .fill(Color(hex: category.colorHex))
-                            .frame(width: 40, height: 40)
-                        
-                        Image(systemName: category.icon)
-                            .font(.system(size: 18, weight: .semibold))
-                            .foregroundColor(.white)
+            if !expenseCategories.isEmpty {
+                Section("支出分類") {
+                    ForEach(expenseCategories) { category in
+                        categoryRow(category)
                     }
-                    
-                    Text(category.name)
-                        .font(.body)
-                        .fontWeight(.medium)
-                    
-                    Spacer()
                 }
-                .padding(.vertical, 4)
-                .contentShape(Rectangle()) // 讓整個區域可點擊
-                .onTapGesture {
-                    categoryToEdit = category
+            }
+            
+            if !incomeCategories.isEmpty {
+                Section("收入分類") {
+                    ForEach(incomeCategories) { category in
+                        categoryRow(category)
+                    }
                 }
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button(role: .destructive) {
-                        deleteCategory(category)
-                    } label: {
-                        Label("刪除", systemImage: "trash")
+            }
+            
+            if !sharedCategories.isEmpty {
+                Section("通用分類") {
+                    ForEach(sharedCategories) { category in
+                        categoryRow(category)
                     }
-                    
-                    Button {
-                        categoryToEdit = category
-                    } label: {
-                        Label("編輯", systemImage: "pencil")
-                    }
-                    .tint(.blue)
                 }
             }
         }
@@ -79,5 +63,56 @@ struct CategoriesView: View {
     
     private func deleteCategory(_ category: Category) {
         modelContext.delete(category)
+    }
+    
+    private func categoryRow(_ category: Category) -> some View {
+        HStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(Color(hex: category.colorHex))
+                    .frame(width: 40, height: 40)
+                
+                Image(systemName: category.icon)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(.white)
+            }
+            
+            Text(category.name)
+                .font(.body)
+                .fontWeight(.medium)
+            
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            categoryToEdit = category
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                deleteCategory(category)
+            } label: {
+                Label("刪除", systemImage: "trash")
+            }
+            
+            Button {
+                categoryToEdit = category
+            } label: {
+                Label("編輯", systemImage: "pencil")
+            }
+            .tint(.blue)
+        }
+    }
+    
+    private var expenseCategories: [Category] {
+        categories.filter { $0.kind == .expense }
+    }
+    
+    private var incomeCategories: [Category] {
+        categories.filter { $0.kind == .income }
+    }
+    
+    private var sharedCategories: [Category] {
+        categories.filter { $0.kind == .both }
     }
 }

--- a/AI 記帳/Views/Categories/EditCategoryView.swift
+++ b/AI 記帳/Views/Categories/EditCategoryView.swift
@@ -11,6 +11,7 @@ struct EditCategoryView: View {
     @State private var name: String = ""
     @State private var selectedIcon: String = ""
     @State private var selectedColorHex: String = ""
+    @State private var selectedKind: CategoryKind = .both
     
     // 圖示列表 (與新增頁面保持一致)
     private let commonIcons: [String] = [
@@ -45,6 +46,15 @@ struct EditCategoryView: View {
                         TextField("分類名稱", text: $name)
                             .padding(.leading, 8)
                     }
+                }
+                
+                Section("類型") {
+                    Picker("類型", selection: $selectedKind) {
+                        ForEach(CategoryKind.allCases) { kind in
+                            Text(kind.displayName).tag(kind)
+                        }
+                    }
+                    .pickerStyle(.menu)
                 }
                 
                 // 2. 圖示選擇
@@ -112,6 +122,7 @@ struct EditCategoryView: View {
                 name = category.name
                 selectedIcon = category.icon
                 selectedColorHex = category.colorHex
+                selectedKind = category.kind
             }
         }
     }
@@ -120,6 +131,7 @@ struct EditCategoryView: View {
         category.name = name
         category.icon = selectedIcon
         category.colorHex = selectedColorHex
+        category.kind = selectedKind
         dismiss()
     }
 }

--- a/AI 記帳/Views/Shortcuts/AddShortcutView.swift
+++ b/AI 記帳/Views/Shortcuts/AddShortcutView.swift
@@ -51,6 +51,11 @@ struct AddShortcutView: View {
                         Text("收入").tag(TransactionType.income)
                     }
                     .pickerStyle(.segmented)
+                    .onChange(of: selectedType) {
+                        if let current = selectedCategory, !current.kind.supports(selectedType) {
+                            selectedCategory = nil
+                        }
+                    }
                     
                     HStack {
                         // 🔥 幣種選擇
@@ -76,7 +81,7 @@ struct AddShortcutView: View {
                     
                     Picker("分類", selection: $selectedCategory) {
                         Text("無分類").tag(nil as Category?)
-                        ForEach(categories) { cat in
+                        ForEach(filteredCategories) { cat in
                             HStack { Image(systemName: cat.icon); Text(cat.name) }.tag(cat as Category?)
                         }
                     }
@@ -119,5 +124,9 @@ struct AddShortcutView: View {
         let shortcut = Shortcut(name: name, icon: finalIcon, amount: amount, currencyCode: selectedCurrency, type: selectedType, note: note, account: account, category: selectedCategory, tags: Array(selectedTags))
         modelContext.insert(shortcut)
         dismiss()
+    }
+    
+    private var filteredCategories: [Category] {
+        categories.filter { $0.kind.supports(selectedType) }
     }
 }

--- a/AI 記帳/Views/Transactions/AddDebtView.swift
+++ b/AI 記帳/Views/Transactions/AddDebtView.swift
@@ -130,6 +130,7 @@ struct AddDebtView: View {
         let normalizedAmount = abs(amount)
         
         let txID1 = UUID(); let txID2 = UUID()
+        let transferGroupID = UUID()
         let memo = note.isEmpty ? mode.rawValue : note
         
         // 注意：這裡我們將 transaction 的 currencyCode 設為用戶選擇的 selectedCurrency
@@ -138,21 +139,21 @@ struct AddDebtView: View {
         if mode == .borrow {
             let debtTx = FinancialTransaction(
                 id: txID1, amount: -normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
-                date: date, note: "\(memo) (借入至 \(myAcc.name))", type: .transfer, linkedTransactionID: txID2, account: debtAcc
+                date: date, note: "\(memo) (借入至 \(myAcc.name))", type: .transfer, linkedTransactionID: txID2, transferGroupID: transferGroupID, transferSide: .outgoing, account: debtAcc
             )
             let myTx = FinancialTransaction(
                 id: txID2, amount: normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
-                date: date, note: "\(memo) (來自 \(debtAcc.name))", type: .transfer, linkedTransactionID: txID1, account: myAcc
+                date: date, note: "\(memo) (來自 \(debtAcc.name))", type: .transfer, linkedTransactionID: txID1, transferGroupID: transferGroupID, transferSide: .incoming, account: myAcc
             )
             modelContext.insert(debtTx); modelContext.insert(myTx)
         } else {
             let myTx = FinancialTransaction(
                 id: txID1, amount: -normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
-                date: date, note: "\(memo) (還款給 \(debtAcc.name))", type: .transfer, linkedTransactionID: txID2, account: myAcc
+                date: date, note: "\(memo) (還款給 \(debtAcc.name))", type: .transfer, linkedTransactionID: txID2, transferGroupID: transferGroupID, transferSide: .outgoing, account: myAcc
             )
             let debtTx = FinancialTransaction(
                 id: txID2, amount: normalizedAmount, currencyCode: selectedCurrency, // 🔥 設定幣種
-                date: date, note: "\(memo) (來自 \(myAcc.name))", type: .transfer, linkedTransactionID: txID1, account: debtAcc
+                date: date, note: "\(memo) (來自 \(myAcc.name))", type: .transfer, linkedTransactionID: txID1, transferGroupID: transferGroupID, transferSide: .incoming, account: debtAcc
             )
             modelContext.insert(myTx); modelContext.insert(debtTx)
         }

--- a/AI 記帳/Views/Transactions/AddTransactionView.swift
+++ b/AI 記帳/Views/Transactions/AddTransactionView.swift
@@ -39,6 +39,11 @@ struct AddTransactionView: View {
                         Text("收入").tag(TransactionType.income)
                     }
                     .pickerStyle(.segmented)
+                    .onChange(of: selectedType) {
+                        if let current = selectedCategory, !current.kind.supports(selectedType) {
+                            selectedCategory = nil
+                        }
+                    }
                     
                     HStack {
                         // 🔥 修改：幣種選擇器
@@ -76,7 +81,7 @@ struct AddTransactionView: View {
                     HStack {
                         Picker("分類", selection: $selectedCategory) {
                             Text("無分類").tag(nil as Category?)
-                            ForEach(categories) { cat in
+                            ForEach(filteredCategories) { cat in
                                 HStack {
                                     Image(systemName: cat.icon)
                                     Text(cat.name)
@@ -181,5 +186,9 @@ struct AddTransactionView: View {
         
         modelContext.insert(tx)
         dismiss()
+    }
+    
+    private var filteredCategories: [Category] {
+        categories.filter { $0.kind.supports(selectedType) }
     }
 }

--- a/AI 記帳/Views/Transactions/AddTransferView.swift
+++ b/AI 記帳/Views/Transactions/AddTransferView.swift
@@ -170,6 +170,7 @@ struct AddTransferView: View {
         
         let txID1 = UUID()
         let txID2 = UUID()
+        let transferGroupID = UUID()
         let memo = note.isEmpty ? "轉帳" : note
         
         // 1. 轉出 (支出) - 使用 currencyOut
@@ -181,6 +182,8 @@ struct AddTransferView: View {
             note: "\(memo) (轉至 \(to.name))",
             type: .transfer,
             linkedTransactionID: txID2,
+            transferGroupID: transferGroupID,
+            transferSide: .outgoing,
             account: from
         )
         
@@ -193,6 +196,8 @@ struct AddTransferView: View {
             note: "\(memo) (來自 \(from.name))",
             type: .transfer,
             linkedTransactionID: txID1,
+            transferGroupID: transferGroupID,
+            transferSide: .incoming,
             account: to
         )
         

--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -28,7 +28,12 @@ struct EditTransactionView: View {
                             Text("收入").tag(TransactionType.income)
                         }
                         .pickerStyle(.segmented)
-                        .onChange(of: transaction.type) { _, _ in updateAmountSign() }
+                        .onChange(of: transaction.type) { _, newType in
+                            updateAmountSign()
+                            if let category = transaction.category, !category.kind.supports(newType) {
+                                transaction.category = nil
+                            }
+                        }
                         
                         HStack {
                             Text(transaction.account?.currency ?? "$")
@@ -49,7 +54,7 @@ struct EditTransactionView: View {
                         
                         Picker("分類", selection: $transaction.category) {
                             Text("無").tag(nil as Category?)
-                            ForEach(categories) { cat in
+                            ForEach(filteredCategories) { cat in
                                 HStack {
                                     Image(systemName: cat.icon)
                                     Text(cat.name)
@@ -86,7 +91,10 @@ struct EditTransactionView: View {
             .navigationTitle("編輯交易")
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("完成") { dismiss() }
+                    Button("完成") {
+                        transaction.updatedAt = Date()
+                        dismiss()
+                    }
                 }
                 
                 // 🔥 新增：鍵盤工具列 (收起按鈕)
@@ -112,5 +120,9 @@ struct EditTransactionView: View {
     private func updateTransactionAmount() {
         guard let val = Decimal(string: amountString) else { return }
         transaction.amount = (transaction.type == .expense) ? -abs(val) : abs(val)
+    }
+    
+    private var filteredCategories: [Category] {
+        categories.filter { $0.kind.supports(transaction.type) }
     }
 }

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -221,12 +221,26 @@ struct EditTransferView: View {
         outTx.currencyCode = currencyOut
         outTx.date = date
         outTx.note = note.isEmpty ? "轉帳 (轉至 \(to.name))" : "\(note) (轉至 \(to.name))"
+        outTx.transferSide = .outgoing
+        outTx.updatedAt = Date()
         
         // 更新轉入
         inTx.amount = normalizedAmountIn
         inTx.currencyCode = currencyIn
         inTx.date = date
         inTx.note = note.isEmpty ? "轉帳 (來自 \(from.name))" : "\(note) (來自 \(from.name))"
+        inTx.transferSide = .incoming
+        inTx.updatedAt = Date()
+        
+        if outTx.transferGroupID == nil && inTx.transferGroupID == nil {
+            let groupID = UUID()
+            outTx.transferGroupID = groupID
+            inTx.transferGroupID = groupID
+        } else if outTx.transferGroupID == nil {
+            outTx.transferGroupID = inTx.transferGroupID
+        } else if inTx.transferGroupID == nil {
+            inTx.transferGroupID = outTx.transferGroupID
+        }
         
         dismiss()
     }

--- a/AI 記帳/Views/Transactions/ScannedResultView.swift
+++ b/AI 記帳/Views/Transactions/ScannedResultView.swift
@@ -44,7 +44,7 @@ struct ScannedResultView: View {
                 
                 Picker("分類", selection: $selectedCategory) {
                     Text("選擇分類").tag(nil as Category?)
-                    ForEach(categories) { cat in
+                    ForEach(expenseCategories) { cat in
                         HStack {
                             Image(systemName: cat.icon)
                             Text(cat.name)
@@ -83,7 +83,7 @@ struct ScannedResultView: View {
             }
             
             // 嘗試自動匹配分類
-            if let match = categories.first(where: { $0.name == info.categoryName }) {
+            if let match = expenseCategories.first(where: { $0.name == info.categoryName }) {
                 selectedCategory = match
             }
             
@@ -143,5 +143,9 @@ struct ScannedResultView: View {
             }
             return fallback.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
         }
+    }
+    
+    private var expenseCategories: [Category] {
+        categories.filter { $0.kind.supports(.expense) }
     }
 }


### PR DESCRIPTION
## Summary
- separate category model into expense/income/shared via new CategoryKind
- filter category selection by transaction type in add/edit transaction, shortcut, and receipt scan flows
- split category management UI into expense/income/shared sections
- preserve backup/restore compatibility by extending JSON schema to v1.2 with backward-safe fallbacks
- add transfer metadata (transferGroupID, transferSide) and timestamps (createdAt, updatedAt) for future grouped-transfer workflows

## Data compatibility
- old JSON backups without kind / transfer metadata still import correctly
- old transactions fallback createdAt/updatedAt safely during restore
- CSV import now matches category by both name and transaction type to avoid income/expense mixups for same-name categories

## Verification
- xcodebuild -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -configuration Debug -destination "generic/platform=iOS Simulator" build (success)
