### PR TITLE
feat: support transfer groups for 1->many and many->1 flows

### DIFF
--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -98,7 +98,7 @@ struct AccountDetailView: View {
                     TransactionRow(transaction: transaction)
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             Button(role: .destructive) {
-                                modelContext.delete(transaction)
+                                deleteTransaction(transaction)
                             } label: {
                                 Label("刪除", systemImage: "trash")
                             }
@@ -108,5 +108,30 @@ struct AccountDetailView: View {
         }
         .navigationTitle(account.name)
         .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private func deleteTransaction(_ transaction: FinancialTransaction) {
+        if transaction.type == .transfer, let groupID = transaction.transferGroupID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.transferGroupID == groupID }
+            )
+            if let groupedTransfers = try? modelContext.fetch(descriptor) {
+                for transfer in groupedTransfers {
+                    modelContext.delete(transfer)
+                }
+                return
+            }
+        }
+        
+        if transaction.type == .transfer, let linkedID = transaction.linkedTransactionID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.id == linkedID }
+            )
+            if let linkedTx = try? modelContext.fetch(descriptor).first {
+                modelContext.delete(linkedTx)
+            }
+        }
+        
+        modelContext.delete(transaction)
     }
 }

--- a/AI 記帳/Views/Accounts/AccountsView.swift
+++ b/AI 記帳/Views/Accounts/AccountsView.swift
@@ -144,7 +144,26 @@ struct AccountsView: View {
     
     private func deleteAccount(_ account: Account) {
         let transfers = account.transactions.filter { $0.type == .transfer }
+        var handledGroupIDs = Set<UUID>()
+        
         for tx in transfers {
+            if let groupID = tx.transferGroupID {
+                if handledGroupIDs.contains(groupID) {
+                    continue
+                }
+                handledGroupIDs.insert(groupID)
+                
+                let descriptor = FetchDescriptor<FinancialTransaction>(
+                    predicate: #Predicate { $0.transferGroupID == groupID }
+                )
+                if let groupedTransfers = try? modelContext.fetch(descriptor) {
+                    for transfer in groupedTransfers {
+                        modelContext.delete(transfer)
+                    }
+                }
+                continue
+            }
+            
             if let linkedID = tx.linkedTransactionID {
                 let descriptor = FetchDescriptor<FinancialTransaction>(predicate: #Predicate { $0.id == linkedID })
                 if let linkedTx = try? modelContext.fetch(descriptor).first { modelContext.delete(linkedTx) }

--- a/AI 記帳/Views/Transactions/AddTransferView.swift
+++ b/AI 記帳/Views/Transactions/AddTransferView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import UIKit
 
 struct AddTransferView: View {
     @Environment(\.modelContext) private var modelContext
@@ -7,126 +8,116 @@ struct AddTransferView: View {
     
     @Query(sort: \Account.name) private var accounts: [Account]
     
+    private enum TransferMode: String, CaseIterable, Identifiable {
+        case oneToOne
+        case oneToMany
+        case manyToOne
+        
+        var id: String { rawValue }
+        
+        var title: String {
+            switch self {
+            case .oneToOne: return "一般 (1 -> 1)"
+            case .oneToMany: return "分拆 (1 -> 多)"
+            case .manyToOne: return "合併 (多 -> 1)"
+            }
+        }
+    }
+    
+    private struct TransferLegInput: Identifiable {
+        let id = UUID()
+        var account: Account?
+        var currency: String = "HKD"
+        var amountString: String = ""
+    }
+    
+    @State private var mode: TransferMode = .oneToOne
+    
+    // 1 -> 1
     @State private var fromAccount: Account?
     @State private var toAccount: Account?
-    
-    // 🔥 新增：獨立的幣種選擇，不綁死帳戶
     @State private var currencyOut: String = "HKD"
     @State private var currencyIn: String = "HKD"
+    @State private var amountOutString: String = ""
+    @State private var amountInString: String = ""
     
-    @State private var amountOutString: String = "" // 轉出金額
-    @State private var amountInString: String = ""  // 轉入金額
+    // 1 -> many
+    @State private var sourceAccount: Account?
+    @State private var sourceCurrency: String = "HKD"
+    @State private var sourceAmountString: String = ""
+    @State private var destinationLegs: [TransferLegInput] = [TransferLegInput()]
+    
+    // many -> 1
+    @State private var destinationAccount: Account?
+    @State private var destinationCurrency: String = "HKD"
+    @State private var destinationAmountString: String = ""
+    @State private var sourceLegs: [TransferLegInput] = [TransferLegInput()]
+    
     @State private var date: Date = Date()
     @State private var note: String = ""
     @State private var showingValidationAlert = false
     @State private var validationMessage = ""
     
-    let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
     
-    // 焦點控制
-    @FocusState private var focusedField: Field?
-    enum Field {
-        case amountOut, amountIn, note
+    private var activeAccounts: [Account] {
+        accounts.filter { !$0.isArchived }
+    }
+    
+    private var canSubmit: Bool {
+        switch mode {
+        case .oneToOne:
+            guard fromAccount != nil, toAccount != nil, positiveDecimal(from: amountOutString) != nil else {
+                return false
+            }
+            if currencyOut != currencyIn {
+                return positiveDecimal(from: amountInString) != nil
+            }
+            return true
+        case .oneToMany:
+            guard sourceAccount != nil, positiveDecimal(from: sourceAmountString) != nil else {
+                return false
+            }
+            return !destinationLegs.isEmpty && destinationLegs.allSatisfy {
+                $0.account != nil && positiveDecimal(from: $0.amountString) != nil
+            }
+        case .manyToOne:
+            guard destinationAccount != nil, positiveDecimal(from: destinationAmountString) != nil else {
+                return false
+            }
+            return !sourceLegs.isEmpty && sourceLegs.allSatisfy {
+                $0.account != nil && positiveDecimal(from: $0.amountString) != nil
+            }
+        }
     }
     
     var body: some View {
         NavigationStack {
             Form {
-                // MARK: - 轉出方
-                Section("轉出方 (支出)") {
-                    Picker("從帳戶", selection: $fromAccount) {
-                        Text("選擇帳戶").tag(nil as Account?)
-                        ForEach(accounts.filter { !$0.isArchived }) { acc in Text(acc.name).tag(acc as Account?) }
-                    }
-                    .onChange(of: fromAccount) {
-                        if let acc = fromAccount { currencyOut = acc.currency }
-                    }
-                    
-                    if let _ = fromAccount {
-                        HStack {
-                            // 轉出幣種選擇
-                            Picker("", selection: $currencyOut) {
-                                ForEach(currencies, id: \.self) { code in Text(code).tag(code) }
-                            }
-                            .labelsHidden().frame(width: 80)
-                            
-                            TextField("轉出金額", text: $amountOutString)
-                                .keyboardType(.decimalPad)
-                                .focused($focusedField, equals: .amountOut)
-                                .onChange(of: amountOutString) { _, newValue in
-                                    let sanitized = sanitizePositiveDecimalInput(newValue)
-                                    if sanitized != newValue {
-                                        amountOutString = sanitized
-                                        return
-                                    }
-                                    // 若幣種相同，自動同步輸入
-                                    if currencyOut == currencyIn {
-                                        amountInString = sanitized
-                                    }
-                                }
+                Section("模式") {
+                    Picker("模式", selection: $mode) {
+                        ForEach(TransferMode.allCases) { item in
+                            Text(item.title).tag(item)
                         }
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: mode) { _, _ in
+                        dismissKeyboard()
                     }
                 }
                 
-                // MARK: - 轉入方
-                Section("轉入方 (收入)") {
-                    Picker("到帳戶", selection: $toAccount) {
-                        Text("選擇帳戶").tag(nil as Account?)
-                        ForEach(accounts.filter { $0 != fromAccount }) { acc in
-                            Text(acc.name).tag(acc as Account?)
-                        }
-                    }
-                    .onChange(of: toAccount) {
-                        if let acc = toAccount { currencyIn = acc.currency }
-                    }
-                    
-                    if let _ = toAccount {
-                        HStack {
-                            // 轉入幣種選擇
-                            Picker("", selection: $currencyIn) {
-                                ForEach(currencies, id: \.self) { code in Text(code).tag(code) }
-                            }
-                            .labelsHidden().frame(width: 80)
-                            
-                            TextField("轉入金額 (實收)", text: $amountInString)
-                                .keyboardType(.decimalPad)
-                                .focused($focusedField, equals: .amountIn)
-                                .onChange(of: amountInString) { _, newValue in
-                                    let sanitized = sanitizePositiveDecimalInput(newValue)
-                                    if sanitized != newValue {
-                                        amountInString = sanitized
-                                    }
-                                }
-                        }
-                        
-                        // 雙幣種匯率顯示
-                        if currencyOut != currencyIn {
-                            if let outVal = Double(amountOutString), let inVal = Double(amountInString), outVal > 0 {
-                                let calculatedRate = inVal / outVal
-                                let marketRate = CurrencyService.shared.getMarketRate(from: currencyOut, to: currencyIn)
-                                
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text("交易匯率: 1 \(currencyOut) ≈ \(calculatedRate, specifier: "%.4f") \(currencyIn)")
-                                        .foregroundStyle(.blue)
-                                    
-                                    if let market = marketRate {
-                                        Text("市場匯率: 1 \(currencyOut) ≈ \(market, specifier: "%.4f") \(currencyIn)")
-                                            .foregroundStyle(.secondary)
-                                            .font(.caption)
-                                    }
-                                }
-                            }
-                        } else {
-                            Text("幣種相同，金額自動對應")
-                                .font(.caption).foregroundStyle(.secondary)
-                        }
-                    }
+                switch mode {
+                case .oneToOne:
+                    oneToOneSections
+                case .oneToMany:
+                    oneToManySections
+                case .manyToOne:
+                    manyToOneSections
                 }
                 
                 Section("其他") {
                     DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
                     TextField("備註", text: $note)
-                        .focused($focusedField, equals: .note)
                 }
             }
             .navigationTitle("轉帳")
@@ -136,21 +127,297 @@ struct AddTransferView: View {
                 Text(validationMessage)
             }
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("確認") { saveTransfer() }
-                        .disabled(fromAccount == nil || toAccount == nil || amountOutString.isEmpty)
+                        .disabled(!canSubmit)
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
-                    Button("完成") { focusedField = nil }
+                    Button("完成") { dismissKeyboard() }
                 }
             }
         }
     }
     
+    @ViewBuilder
+    private var oneToOneSections: some View {
+        Section("轉出方 (支出)") {
+            Picker("從帳戶", selection: $fromAccount) {
+                Text("選擇帳戶").tag(nil as Account?)
+                ForEach(activeAccounts) { acc in
+                    Text(acc.name).tag(acc as Account?)
+                }
+            }
+            .onChange(of: fromAccount) {
+                if let acc = fromAccount {
+                    currencyOut = acc.currency
+                    if toAccount?.id == acc.id {
+                        toAccount = nil
+                    }
+                }
+            }
+            
+            if fromAccount != nil {
+                HStack {
+                    Picker("", selection: $currencyOut) {
+                        ForEach(currencies, id: \.self) { code in
+                            Text(code).tag(code)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 80)
+                    
+                    TextField("轉出金額", text: Binding(
+                        get: { amountOutString },
+                        set: { newValue in
+                            let sanitized = sanitizePositiveDecimalInput(newValue)
+                            amountOutString = sanitized
+                            if currencyOut == currencyIn {
+                                amountInString = sanitized
+                            }
+                        }
+                    ))
+                    .keyboardType(.decimalPad)
+                }
+            }
+        }
+        
+        Section("轉入方 (收入)") {
+            Picker("到帳戶", selection: $toAccount) {
+                Text("選擇帳戶").tag(nil as Account?)
+                ForEach(activeAccounts.filter { $0.id != fromAccount?.id }) { acc in
+                    Text(acc.name).tag(acc as Account?)
+                }
+            }
+            .onChange(of: toAccount) {
+                if let acc = toAccount {
+                    currencyIn = acc.currency
+                    if currencyOut == currencyIn {
+                        amountInString = amountOutString
+                    }
+                }
+            }
+            
+            if toAccount != nil {
+                HStack {
+                    Picker("", selection: $currencyIn) {
+                        ForEach(currencies, id: \.self) { code in
+                            Text(code).tag(code)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 80)
+                    
+                    TextField("轉入金額 (實收)", text: Binding(
+                        get: { amountInString },
+                        set: { amountInString = sanitizePositiveDecimalInput($0) }
+                    ))
+                    .keyboardType(.decimalPad)
+                }
+                
+                if currencyOut == currencyIn {
+                    Text("幣種相同，金額自動對應")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var oneToManySections: some View {
+        Section("單一轉出") {
+            Picker("從帳戶", selection: $sourceAccount) {
+                Text("選擇帳戶").tag(nil as Account?)
+                ForEach(activeAccounts) { acc in
+                    Text(acc.name).tag(acc as Account?)
+                }
+            }
+            .onChange(of: sourceAccount) {
+                if let acc = sourceAccount {
+                    sourceCurrency = acc.currency
+                    for index in destinationLegs.indices {
+                        if destinationLegs[index].account?.id == acc.id {
+                            destinationLegs[index].account = nil
+                        }
+                    }
+                }
+            }
+            
+            HStack {
+                Picker("", selection: $sourceCurrency) {
+                    ForEach(currencies, id: \.self) { code in
+                        Text(code).tag(code)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 80)
+                
+                TextField("轉出總額", text: Binding(
+                    get: { sourceAmountString },
+                    set: { sourceAmountString = sanitizePositiveDecimalInput($0) }
+                ))
+                .keyboardType(.decimalPad)
+            }
+        }
+        
+        Section("分拆轉入") {
+            ForEach($destinationLegs) { $leg in
+                VStack(spacing: 10) {
+                    Picker("到帳戶", selection: $leg.account) {
+                        Text("選擇帳戶").tag(nil as Account?)
+                        ForEach(activeAccounts.filter { $0.id != sourceAccount?.id }) { acc in
+                            Text(acc.name).tag(acc as Account?)
+                        }
+                    }
+                    .onChange(of: leg.account) {
+                        if let acc = leg.account {
+                            leg.currency = acc.currency
+                        }
+                    }
+                    
+                    HStack {
+                        Picker("", selection: $leg.currency) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 80)
+                        
+                        TextField("轉入金額", text: Binding(
+                            get: { leg.amountString },
+                            set: { leg.amountString = sanitizePositiveDecimalInput($0) }
+                        ))
+                        .keyboardType(.decimalPad)
+                    }
+                    
+                    if destinationLegs.count > 1 {
+                        Button(role: .destructive) {
+                            destinationLegs.removeAll { $0.id == leg.id }
+                        } label: {
+                            Text("移除此轉入帳戶")
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            
+            Button {
+                destinationLegs.append(TransferLegInput(currency: sourceCurrency))
+            } label: {
+                Label("新增轉入帳戶", systemImage: "plus.circle")
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var manyToOneSections: some View {
+        Section("多個轉出") {
+            ForEach($sourceLegs) { $leg in
+                VStack(spacing: 10) {
+                    Picker("從帳戶", selection: $leg.account) {
+                        Text("選擇帳戶").tag(nil as Account?)
+                        ForEach(activeAccounts.filter { $0.id != destinationAccount?.id }) { acc in
+                            Text(acc.name).tag(acc as Account?)
+                        }
+                    }
+                    .onChange(of: leg.account) {
+                        if let acc = leg.account {
+                            leg.currency = acc.currency
+                        }
+                    }
+                    
+                    HStack {
+                        Picker("", selection: $leg.currency) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 80)
+                        
+                        TextField("轉出金額", text: Binding(
+                            get: { leg.amountString },
+                            set: { leg.amountString = sanitizePositiveDecimalInput($0) }
+                        ))
+                        .keyboardType(.decimalPad)
+                    }
+                    
+                    if sourceLegs.count > 1 {
+                        Button(role: .destructive) {
+                            sourceLegs.removeAll { $0.id == leg.id }
+                        } label: {
+                            Text("移除此轉出帳戶")
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            
+            Button {
+                sourceLegs.append(TransferLegInput(currency: destinationCurrency))
+            } label: {
+                Label("新增轉出帳戶", systemImage: "plus.circle")
+            }
+        }
+        
+        Section("單一轉入") {
+            Picker("到帳戶", selection: $destinationAccount) {
+                Text("選擇帳戶").tag(nil as Account?)
+                ForEach(activeAccounts) { acc in
+                    Text(acc.name).tag(acc as Account?)
+                }
+            }
+            .onChange(of: destinationAccount) {
+                if let acc = destinationAccount {
+                    destinationCurrency = acc.currency
+                    for index in sourceLegs.indices {
+                        if sourceLegs[index].account?.id == acc.id {
+                            sourceLegs[index].account = nil
+                        }
+                    }
+                }
+            }
+            
+            HStack {
+                Picker("", selection: $destinationCurrency) {
+                    ForEach(currencies, id: \.self) { code in
+                        Text(code).tag(code)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 80)
+                
+                TextField("轉入總額", text: Binding(
+                    get: { destinationAmountString },
+                    set: { destinationAmountString = sanitizePositiveDecimalInput($0) }
+                ))
+                .keyboardType(.decimalPad)
+            }
+        }
+    }
+    
     private func saveTransfer() {
+        switch mode {
+        case .oneToOne:
+            saveOneToOneTransfer()
+        case .oneToMany:
+            saveOneToManyTransfer()
+        case .manyToOne:
+            saveManyToOneTransfer()
+        }
+    }
+    
+    private func saveOneToOneTransfer() {
         guard let from = fromAccount, let to = toAccount else { return }
+        guard from.id != to.id else {
+            showValidation("轉出與轉入帳戶不可相同。")
+            return
+        }
         guard let amountOut = positiveDecimal(from: amountOutString) else {
             showValidation("請輸入大於 0 的轉出金額。")
             return
@@ -165,19 +432,15 @@ struct AddTransferView: View {
             amountIn = customIn
         }
         
-        let normalizedAmountOut = abs(amountOut)
-        let normalizedAmountIn = abs(amountIn)
-        
         let txID1 = UUID()
         let txID2 = UUID()
         let transferGroupID = UUID()
         let memo = note.isEmpty ? "轉帳" : note
         
-        // 1. 轉出 (支出) - 使用 currencyOut
         let outTx = FinancialTransaction(
             id: txID1,
-            amount: -normalizedAmountOut,
-            currencyCode: currencyOut, // 🔥 明確指定轉出幣種
+            amount: -abs(amountOut),
+            currencyCode: currencyOut,
             date: date,
             note: "\(memo) (轉至 \(to.name))",
             type: .transfer,
@@ -187,11 +450,10 @@ struct AddTransferView: View {
             account: from
         )
         
-        // 2. 轉入 (收入) - 使用 currencyIn
         let inTx = FinancialTransaction(
             id: txID2,
-            amount: normalizedAmountIn,
-            currencyCode: currencyIn, // 🔥 明確指定轉入幣種
+            amount: abs(amountIn),
+            currencyCode: currencyIn,
             date: date,
             note: "\(memo) (來自 \(from.name))",
             type: .transfer,
@@ -203,9 +465,170 @@ struct AddTransferView: View {
         
         modelContext.insert(outTx)
         modelContext.insert(inTx)
-        try? modelContext.save()
+        saveContextAndDismiss()
+    }
+    
+    private func saveOneToManyTransfer() {
+        guard let source = sourceAccount else {
+            showValidation("請選擇轉出帳戶。")
+            return
+        }
+        guard let sourceAmount = positiveDecimal(from: sourceAmountString) else {
+            showValidation("請輸入大於 0 的轉出總額。")
+            return
+        }
         
-        dismiss()
+        let parsedLegs = destinationLegs.enumerated().compactMap { index, leg -> (index: Int, account: Account, currency: String, amount: Decimal)? in
+            guard let account = leg.account,
+                  let amount = positiveDecimal(from: leg.amountString) else {
+                return nil
+            }
+            return (index + 1, account, leg.currency, amount)
+        }
+        
+        if parsedLegs.count != destinationLegs.count || parsedLegs.isEmpty {
+            showValidation("請完整填寫每一個轉入帳戶與金額。")
+            return
+        }
+        
+        var accountIDs = Set<UUID>()
+        for leg in parsedLegs {
+            if leg.account.id == source.id {
+                showValidation("轉入帳戶不可與轉出帳戶相同。")
+                return
+            }
+            if accountIDs.contains(leg.account.id) {
+                showValidation("分拆轉入帳戶不可重複，請合併該帳戶的金額。")
+                return
+            }
+            accountIDs.insert(leg.account.id)
+        }
+        
+        let sameCurrencyOnly = parsedLegs.allSatisfy { $0.currency == sourceCurrency }
+        if sameCurrencyOnly {
+            let totalIn = parsedLegs.reduce(Decimal.zero) { $0 + $1.amount }
+            if totalIn != sourceAmount {
+                showValidation("同幣種分拆時，轉入總額需等於轉出總額。")
+                return
+            }
+        }
+        
+        let transferGroupID = UUID()
+        let memo = note.isEmpty ? "轉帳" : note
+        
+        let outTx = FinancialTransaction(
+            amount: -abs(sourceAmount),
+            currencyCode: sourceCurrency,
+            date: date,
+            note: "\(memo) (分拆轉至 \(parsedLegs.count) 個帳戶)",
+            type: .transfer,
+            transferGroupID: transferGroupID,
+            transferSide: .outgoing,
+            account: source
+        )
+        modelContext.insert(outTx)
+        
+        for leg in parsedLegs {
+            let inTx = FinancialTransaction(
+                amount: abs(leg.amount),
+                currencyCode: leg.currency,
+                date: date,
+                note: "\(memo) (來自 \(source.name))",
+                type: .transfer,
+                transferGroupID: transferGroupID,
+                transferSide: .incoming,
+                account: leg.account
+            )
+            modelContext.insert(inTx)
+        }
+        
+        saveContextAndDismiss()
+    }
+    
+    private func saveManyToOneTransfer() {
+        guard let destination = destinationAccount else {
+            showValidation("請選擇轉入帳戶。")
+            return
+        }
+        guard let destinationAmount = positiveDecimal(from: destinationAmountString) else {
+            showValidation("請輸入大於 0 的轉入總額。")
+            return
+        }
+        
+        let parsedLegs = sourceLegs.enumerated().compactMap { index, leg -> (index: Int, account: Account, currency: String, amount: Decimal)? in
+            guard let account = leg.account,
+                  let amount = positiveDecimal(from: leg.amountString) else {
+                return nil
+            }
+            return (index + 1, account, leg.currency, amount)
+        }
+        
+        if parsedLegs.count != sourceLegs.count || parsedLegs.isEmpty {
+            showValidation("請完整填寫每一個轉出帳戶與金額。")
+            return
+        }
+        
+        var accountIDs = Set<UUID>()
+        for leg in parsedLegs {
+            if leg.account.id == destination.id {
+                showValidation("轉出帳戶不可與轉入帳戶相同。")
+                return
+            }
+            if accountIDs.contains(leg.account.id) {
+                showValidation("轉出帳戶不可重複，請合併該帳戶的金額。")
+                return
+            }
+            accountIDs.insert(leg.account.id)
+        }
+        
+        let sameCurrencyOnly = parsedLegs.allSatisfy { $0.currency == destinationCurrency }
+        if sameCurrencyOnly {
+            let totalOut = parsedLegs.reduce(Decimal.zero) { $0 + $1.amount }
+            if totalOut != destinationAmount {
+                showValidation("同幣種合併時，轉出總額需等於轉入總額。")
+                return
+            }
+        }
+        
+        let transferGroupID = UUID()
+        let memo = note.isEmpty ? "轉帳" : note
+        
+        for leg in parsedLegs {
+            let outTx = FinancialTransaction(
+                amount: -abs(leg.amount),
+                currencyCode: leg.currency,
+                date: date,
+                note: "\(memo) (轉至 \(destination.name))",
+                type: .transfer,
+                transferGroupID: transferGroupID,
+                transferSide: .outgoing,
+                account: leg.account
+            )
+            modelContext.insert(outTx)
+        }
+        
+        let inTx = FinancialTransaction(
+            amount: abs(destinationAmount),
+            currencyCode: destinationCurrency,
+            date: date,
+            note: "\(memo) (來自 \(parsedLegs.count) 個帳戶)",
+            type: .transfer,
+            transferGroupID: transferGroupID,
+            transferSide: .incoming,
+            account: destination
+        )
+        modelContext.insert(inTx)
+        
+        saveContextAndDismiss()
+    }
+    
+    private func saveContextAndDismiss() {
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            showValidation("儲存失敗：\(error.localizedDescription)")
+        }
     }
     
     private func positiveDecimal(from value: String) -> Decimal? {
@@ -227,6 +650,10 @@ struct AddTransferView: View {
         }
         
         return result == "." ? "" : result
+    }
+    
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
     
     private func showValidation(_ message: String) {

--- a/AI 記帳/Views/Transactions/TransactionRow.swift
+++ b/AI 記帳/Views/Transactions/TransactionRow.swift
@@ -11,19 +11,37 @@ struct TransactionRow: View {
         return formatter.string(from: transaction.date)
     }
     
-    // 獲取關聯轉帳的資訊
+    // 嘗試取得「對向」轉帳資訊；多邊轉帳僅在唯一對向時顯示。
     private func getLinkedTransferInfo() -> (amount: Decimal, currency: String)? {
-        guard transaction.type == .transfer,
-              let linkedID = transaction.linkedTransactionID else { return nil }
+        guard transaction.type == .transfer else { return nil }
         
-        let descriptor = FetchDescriptor<FinancialTransaction>(
-            predicate: #Predicate { $0.id == linkedID }
-        )
-        
-        if let linkedTx = try? modelContext.fetch(descriptor).first {
-            // 🔥 使用交易本身的 currencyCode，而不是帳戶的
-            return (linkedTx.amount, linkedTx.currencyCode)
+        if let linkedID = transaction.linkedTransactionID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.id == linkedID }
+            )
+            if let linkedTx = try? modelContext.fetch(descriptor).first {
+                return (linkedTx.amount, linkedTx.currencyCode)
+            }
         }
+        
+        guard let groupID = transaction.transferGroupID else { return nil }
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        guard let groupedTransfers = try? modelContext.fetch(descriptor) else { return nil }
+        
+        let counterparts = groupedTransfers.filter { candidate in
+            guard candidate.id != transaction.id else { return false }
+            if let currentSide = transaction.transferSide, let candidateSide = candidate.transferSide {
+                return currentSide != candidateSide
+            }
+            return true
+        }
+        
+        if counterparts.count == 1, let counterparty = counterparts.first {
+            return (counterparty.amount, counterparty.currencyCode)
+        }
+        
         return nil
     }
     

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -121,13 +121,13 @@ struct TransactionsListView: View {
                                 TransactionRow(transaction: transaction)
                                     .onTapGesture {
                                         transactionToEdit = transaction
-                                        isEditingTransfer = (transaction.type == .transfer)
+                                        isEditingTransfer = canEditTransfer(transaction)
                                     }
                                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                         Button(role: .destructive) { deleteTransaction(transaction) } label: { Label("刪除", systemImage: "trash") }
                                         Button {
                                             transactionToEdit = transaction
-                                            isEditingTransfer = (transaction.type == .transfer)
+                                            isEditingTransfer = canEditTransfer(transaction)
                                         } label: { Label("編輯", systemImage: "pencil") }.tint(.blue)
                                     }
                             }
@@ -145,7 +145,7 @@ struct TransactionsListView: View {
                 AddShortcutView()
             }
             .sheet(item: $transactionToEdit) { tx in
-                if isEditingTransfer {
+                if tx.type == .transfer && isEditingTransfer {
                     EditTransferView(originalTransaction: tx)
                 } else {
                     EditTransactionView(transaction: tx)
@@ -218,13 +218,13 @@ struct TransactionsListView: View {
             case .day: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .day)
             }
         }
-        if searchText.isEmpty { return timeFiltered }
-        return timeFiltered.filter { tx in
+        let searched = searchText.isEmpty ? timeFiltered : timeFiltered.filter { tx in
             tx.note.localizedCaseInsensitiveContains(searchText) ||
             (tx.category?.name.localizedCaseInsensitiveContains(searchText) ?? false) ||
             tx.tags.contains { $0.name.localizedCaseInsensitiveContains(searchText) } ||
             String(describing: abs(tx.amount)).contains(searchText)
         }
+        return collapseTransferGroups(in: searched)
     }
     
     struct TransactionGroup { let title: String; let transactions: [FinancialTransaction] }
@@ -270,10 +270,60 @@ struct TransactionsListView: View {
     }
     
     private func deleteTransaction(_ tx: FinancialTransaction) {
-        if tx.type == .transfer, let linkedID = tx.linkedTransactionID,
-           let linked = transactions.first(where: { $0.id == linkedID }) {
-            modelContext.delete(linked)
+        if tx.type == .transfer, let groupID = tx.transferGroupID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.transferGroupID == groupID }
+            )
+            if let groupedTransfers = try? modelContext.fetch(descriptor) {
+                for transfer in groupedTransfers {
+                    modelContext.delete(transfer)
+                }
+                return
+            }
+        }
+        
+        if tx.type == .transfer, let linkedID = tx.linkedTransactionID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.id == linkedID }
+            )
+            if let linked = try? modelContext.fetch(descriptor).first {
+                modelContext.delete(linked)
+            }
         }
         modelContext.delete(tx)
+    }
+    
+    private func canEditTransfer(_ tx: FinancialTransaction) -> Bool {
+        tx.type == .transfer && tx.linkedTransactionID != nil
+    }
+    
+    private func collapseTransferGroups(in items: [FinancialTransaction]) -> [FinancialTransaction] {
+        let representatives = Dictionary(grouping: items.compactMap { tx -> (UUID, FinancialTransaction)? in
+            guard let groupID = tx.transferGroupID else { return nil }
+            return (groupID, tx)
+        }, by: { $0.0 }).mapValues { entries in
+            let transfers = entries.map { $0.1 }
+            return transfers.first(where: { $0.transferSide == .outgoing })
+                ?? transfers.first(where: { $0.amount < 0 })
+                ?? transfers.first!
+        }
+        
+        var seenGroupIDs = Set<UUID>()
+        var output: [FinancialTransaction] = []
+        
+        for tx in items {
+            guard tx.type == .transfer, let groupID = tx.transferGroupID else {
+                output.append(tx)
+                continue
+            }
+            
+            if seenGroupIDs.contains(groupID) {
+                continue
+            }
+            seenGroupIDs.insert(groupID)
+            output.append(representatives[groupID] ?? tx)
+        }
+        
+        return output
     }
 }


### PR DESCRIPTION
## Summary
- add 3 transfer creation modes in AddTransferView:
  - 1 -> 1 (existing behavior)
  - 1 -> many (single source split to multiple destination accounts)
  - many -> 1 (multiple source accounts merge to one destination)
- write multi-leg transfers as one transfer group with transferGroupID and outgoing/incoming transferSide
- keep legacy 1 -> 1 pair edit flow unchanged; only pair transfers remain editable in EditTransferView
- collapse same transfer group to one row in transaction list to prevent duplicate rows for many -> 1 scenarios
- make transfer deletion group-aware in TransactionsListView, AccountsView, and AccountDetailView
- update TransactionRow counterparty lookup to support group-based transfers safely

## Compatibility and behavior
- existing pair transfers with linkedTransactionID still work and can be edited as before
- new multi-leg transfers intentionally do not use linkedTransactionID and are managed by transferGroupID
- deleting any transfer row in a transfer group removes the full group to avoid orphan records

## Verification
- xcodebuild -project AI 記帳.xcodeproj -scheme AI 記帳 -configuration Debug -destination generic/platform=iOS Simulator build (success)
