### PR TITLE
feat: income charts, monthly budgets, and data health check

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -9,7 +9,8 @@ struct AI___App: App {
             FinancialTransaction.self,
             Category.self,
             Tag.self,
-            Shortcut.self
+            Shortcut.self,
+            CategoryMonthlyBudget.self
         ])
         
         // 1. 獲取 Documents 資料夾

--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -204,3 +204,36 @@ final class Shortcut {
         self.tags = tags
     }
 }
+
+@Model
+final class CategoryMonthlyBudget {
+    @Attribute(.unique) var id: UUID
+    var monthKey: String // yyyy-MM
+    var amount: Decimal
+    var currencyCode: String
+    var isEnabled: Bool
+    var createdAt: Date
+    var updatedAt: Date
+    
+    var category: Category?
+    
+    init(
+        id: UUID = UUID(),
+        monthKey: String,
+        amount: Decimal,
+        currencyCode: String = "HKD",
+        isEnabled: Bool = true,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        category: Category? = nil
+    ) {
+        self.id = id
+        self.monthKey = monthKey
+        self.amount = amount
+        self.currencyCode = currencyCode
+        self.isEnabled = isEnabled
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.category = category
+    }
+}

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -13,6 +13,7 @@ struct FullBackupData: Codable {
     let tags: [TagCodable]
     let transactions: [TransactionCodable]
     let shortcuts: [ShortcutCodable]
+    let budgets: [BudgetCodable]?
     
     struct AccountCodable: Codable {
         let id: UUID; let name: String; let currency: String; let type: String; let baseBalance: Decimal; let sortOrder: Int
@@ -41,6 +42,16 @@ struct FullBackupData: Codable {
         // 🔥 新增 Optional，兼容舊 JSON
         let currencyCode: String?
         let accountID: UUID?; let categoryID: UUID?; let tagIDs: [UUID]
+    }
+    struct BudgetCodable: Codable {
+        let id: UUID
+        let monthKey: String
+        let amount: Decimal
+        let currencyCode: String
+        let isEnabled: Bool?
+        let categoryID: UUID?
+        let createdAt: Date?
+        let updatedAt: Date?
     }
 }
 
@@ -106,8 +117,9 @@ class BackupManager: NSObject, ObservableObject {
         let tags = (try? modelContext.fetch(FetchDescriptor<Tag>())) ?? []
         let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
         let shortcuts = (try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []
+        let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
         
-        return FullBackupData(version: "1.2", timestamp: Date(),
+        return FullBackupData(version: "1.3", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
             categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
@@ -130,7 +142,19 @@ class BackupManager: NSObject, ObservableObject {
                     tagIDs: $0.tags.map { $0.id }
                 )
             },
-            shortcuts: shortcuts.map { FullBackupData.ShortcutCodable(id: $0.id, name: $0.name, icon: $0.icon, amount: $0.amount, type: $0.type.rawValue, note: $0.note, currencyCode: $0.currencyCode, accountID: $0.account?.id, categoryID: $0.category?.id, tagIDs: $0.tags.map { $0.id }) }
+            shortcuts: shortcuts.map { FullBackupData.ShortcutCodable(id: $0.id, name: $0.name, icon: $0.icon, amount: $0.amount, type: $0.type.rawValue, note: $0.note, currencyCode: $0.currencyCode, accountID: $0.account?.id, categoryID: $0.category?.id, tagIDs: $0.tags.map { $0.id }) },
+            budgets: budgets.map {
+                FullBackupData.BudgetCodable(
+                    id: $0.id,
+                    monthKey: $0.monthKey,
+                    amount: $0.amount,
+                    currencyCode: $0.currencyCode,
+                    isEnabled: $0.isEnabled,
+                    categoryID: $0.category?.id,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            }
         )
     }
     
@@ -207,6 +231,29 @@ class BackupManager: NSObject, ObservableObject {
                 
                 let sc = Shortcut(id: scDTO.id, name: scDTO.name, icon: scDTO.icon, amount: scDTO.amount, currencyCode: currency, type: TransactionType(rawValue: scDTO.type) ?? .expense, note: scDTO.note, account: account, category: category, tags: tags)
                 modelContext.insert(sc)
+            }
+        }
+        
+        // 6. 還原預算 (向下兼容：舊 JSON 可能沒有 budgets)
+        if let budgetDTOs = backup.budgets {
+            let existingBudgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
+            for budgetDTO in budgetDTOs {
+                if existingBudgets.contains(where: { $0.id == budgetDTO.id }) {
+                    continue
+                }
+                
+                let category = updatedCategories.first(where: { $0.id == budgetDTO.categoryID })
+                let budget = CategoryMonthlyBudget(
+                    id: budgetDTO.id,
+                    monthKey: budgetDTO.monthKey,
+                    amount: budgetDTO.amount,
+                    currencyCode: budgetDTO.currencyCode,
+                    isEnabled: budgetDTO.isEnabled ?? true,
+                    createdAt: budgetDTO.createdAt ?? Date(),
+                    updatedAt: budgetDTO.updatedAt ?? (budgetDTO.createdAt ?? Date()),
+                    category: category
+                )
+                modelContext.insert(budget)
             }
         }
         try modelContext.save()

--- a/AI 記帳/Services/BudgetService.swift
+++ b/AI 記帳/Services/BudgetService.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+struct BudgetStatus: Identifiable {
+    let budget: CategoryMonthlyBudget
+    let spent: Decimal
+    let remaining: Decimal
+    let ratio: Decimal
+    let isOverBudget: Bool
+    
+    var id: UUID { budget.id }
+}
+
+enum BudgetService {
+    static func monthKey(from date: Date) -> String {
+        let components = Calendar.current.dateComponents([.year, .month], from: date)
+        let year = components.year ?? 1970
+        let month = components.month ?? 1
+        return String(format: "%04d-%02d", year, month)
+    }
+    
+    static func monthStart(from monthKey: String) -> Date? {
+        let parts = monthKey.split(separator: "-")
+        guard parts.count == 2,
+              let year = Int(parts[0]),
+              let month = Int(parts[1])
+        else { return nil }
+        
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        return Calendar.current.date(from: components)
+    }
+    
+    static func statuses(
+        for targetMonthKey: String,
+        budgets: [CategoryMonthlyBudget],
+        transactions: [FinancialTransaction],
+        currencyService: CurrencyService
+    ) -> [BudgetStatus] {
+        let activeBudgets = budgets.filter { $0.isEnabled && $0.monthKey == targetMonthKey }
+        
+        let results: [BudgetStatus] = activeBudgets.map { budget in
+            let spent = transactions
+                .filter { tx in
+                    tx.type == .expense &&
+                    monthKey(from: tx.date) == targetMonthKey &&
+                    tx.category?.id == budget.category?.id
+                }
+                .reduce(Decimal.zero) { partial, tx in
+                    partial + currencyService.convert(amount: abs(tx.amount), from: tx.currencyCode, to: budget.currencyCode)
+                }
+            
+            let remaining = budget.amount - spent
+            let ratio: Decimal = budget.amount > 0 ? (spent / budget.amount) : 0
+            return BudgetStatus(
+                budget: budget,
+                spent: spent,
+                remaining: remaining,
+                ratio: ratio,
+                isOverBudget: remaining < 0
+            )
+        }
+        
+        return results.sorted {
+            if $0.isOverBudget != $1.isOverBudget {
+                return $0.isOverBudget && !$1.isOverBudget
+            }
+            return $0.ratio > $1.ratio
+        }
+    }
+}

--- a/AI 記帳/Services/CurrencyService.swift
+++ b/AI 記帳/Services/CurrencyService.swift
@@ -104,6 +104,23 @@ class CurrencyService: ObservableObject {
         return amount / Decimal(rate)
     }
     
+    func convert(amount: Decimal, from source: String, to target: String) -> Decimal {
+        if source == target { return amount }
+        
+        if source == mainCurrency {
+            guard let targetRate = rates[target] else { return amount }
+            return amount * Decimal(targetRate)
+        }
+        
+        if target == mainCurrency {
+            return convert(amount: amount, from: source)
+        }
+        
+        guard let targetRate = rates[target] else { return amount }
+        let inMain = convert(amount: amount, from: source)
+        return inMain * Decimal(targetRate)
+    }
+    
     func getMarketRate(from source: String, to target: String) -> Double? {
         if source == target { return 1.0 }
         guard let rateSource = rates[source], let rateTarget = rates[target] else { return nil }

--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -1,0 +1,211 @@
+import Foundation
+import SwiftData
+
+enum HealthSeverity: String {
+    case error = "錯誤"
+    case warning = "警告"
+    case info = "資訊"
+}
+
+struct HealthIssue: Identifiable {
+    let id = UUID()
+    let severity: HealthSeverity
+    let title: String
+    let detail: String
+    let recommendation: String
+}
+
+struct HealthReport {
+    let generatedAt: Date
+    let issues: [HealthIssue]
+    
+    var errorCount: Int { issues.filter { $0.severity == .error }.count }
+    var warningCount: Int { issues.filter { $0.severity == .warning }.count }
+    var infoCount: Int { issues.filter { $0.severity == .info }.count }
+}
+
+enum DataHealthCheckService {
+    @MainActor
+    static func run(modelContext: ModelContext) -> HealthReport {
+        let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
+        let categories = (try? modelContext.fetch(FetchDescriptor<Category>())) ?? []
+        let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
+        
+        var issues: [HealthIssue] = []
+        
+        checkTransactionBasics(transactions, into: &issues)
+        checkLinkedTransfers(transactions, into: &issues)
+        checkTransferGroups(transactions, into: &issues)
+        checkCategories(categories, into: &issues)
+        checkBudgets(budgets, into: &issues)
+        
+        if issues.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .info,
+                    title: "資料健康",
+                    detail: "未發現結構性問題。",
+                    recommendation: "維持定期 JSON 備份即可。"
+                )
+            )
+        }
+        
+        return HealthReport(generatedAt: Date(), issues: issues)
+    }
+    
+    private static func checkTransactionBasics(_ transactions: [FinancialTransaction], into issues: inout [HealthIssue]) {
+        let expenseSignErrors = transactions.filter { $0.type == .expense && $0.amount > 0 }
+        if !expenseSignErrors.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "支出金額符號異常",
+                    detail: "共有 \(expenseSignErrors.count) 筆支出為正數。",
+                    recommendation: "建議打開交易檢查金額方向，支出應為負數。"
+                )
+            )
+        }
+        
+        let incomeSignErrors = transactions.filter { $0.type == .income && $0.amount < 0 }
+        if !incomeSignErrors.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "收入金額符號異常",
+                    detail: "共有 \(incomeSignErrors.count) 筆收入為負數。",
+                    recommendation: "建議打開交易檢查金額方向，收入應為正數。"
+                )
+            )
+        }
+        
+        let missingAccounts = transactions.filter { $0.account == nil }
+        if !missingAccounts.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .error,
+                    title: "交易缺少帳戶",
+                    detail: "共有 \(missingAccounts.count) 筆交易沒有帳戶。",
+                    recommendation: "請手動補上帳戶，避免報表與餘額失真。"
+                )
+            )
+        }
+        
+        let emptyCurrency = transactions.filter { $0.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        if !emptyCurrency.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .error,
+                    title: "交易幣種遺失",
+                    detail: "共有 \(emptyCurrency.count) 筆交易缺少 currencyCode。",
+                    recommendation: "請修正幣種後再匯出報表。"
+                )
+            )
+        }
+        
+        let futureTransactions = transactions.filter { $0.date.timeIntervalSinceNow > 60 * 60 * 24 }
+        if !futureTransactions.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "交易日期在未來",
+                    detail: "共有 \(futureTransactions.count) 筆交易日期晚於現在 24 小時以上。",
+                    recommendation: "請確認是否誤設日期。"
+                )
+            )
+        }
+    }
+    
+    private static func checkLinkedTransfers(_ transactions: [FinancialTransaction], into issues: inout [HealthIssue]) {
+        let txByID = Dictionary(uniqueKeysWithValues: transactions.map { ($0.id, $0) })
+        let linkedTransfers = transactions.filter { $0.type == .transfer && $0.linkedTransactionID != nil }
+        
+        let brokenLinks = linkedTransfers.filter { tx in
+            guard let linkedID = tx.linkedTransactionID else { return false }
+            return txByID[linkedID] == nil
+        }
+        
+        if !brokenLinks.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .error,
+                    title: "轉帳雙向連結損壞",
+                    detail: "共有 \(brokenLinks.count) 筆轉帳找不到 linkedTransactionID 對應記錄。",
+                    recommendation: "建議在『資料健康檢查』後手動修正或刪除該組轉帳。"
+                )
+            )
+        }
+    }
+    
+    private static func checkTransferGroups(_ transactions: [FinancialTransaction], into issues: inout [HealthIssue]) {
+        let groupedTransfers = Dictionary(grouping: transactions.filter { $0.type == .transfer && $0.transferGroupID != nil }) {
+            $0.transferGroupID!
+        }
+        
+        var brokenGroups = 0
+        for (_, group) in groupedTransfers {
+            let outgoingCount = group.filter { $0.transferSide == .outgoing || $0.amount < 0 }.count
+            let incomingCount = group.filter { $0.transferSide == .incoming || $0.amount > 0 }.count
+            if outgoingCount == 0 || incomingCount == 0 {
+                brokenGroups += 1
+            }
+        }
+        
+        if brokenGroups > 0 {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "轉帳群組不完整",
+                    detail: "共有 \(brokenGroups) 個 transferGroup 缺少轉出或轉入側。",
+                    recommendation: "建議檢查該群組交易是否被不完整刪除。"
+                )
+            )
+        }
+    }
+    
+    private static func checkCategories(_ categories: [Category], into issues: inout [HealthIssue]) {
+        let duplicates = Dictionary(grouping: categories) { "\($0.name.lowercased())::\($0.kind.rawValue)" }
+            .filter { $0.value.count > 1 }
+        
+        if !duplicates.isEmpty {
+            let duplicateCount = duplicates.values.reduce(0) { $0 + $1.count }
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "分類重複",
+                    detail: "共有 \(duplicateCount) 個分類名稱與類型重複。",
+                    recommendation: "建議合併重複分類，避免預算與圖表分散。"
+                )
+            )
+        }
+    }
+    
+    private static func checkBudgets(_ budgets: [CategoryMonthlyBudget], into issues: inout [HealthIssue]) {
+        let orphanBudgets = budgets.filter { $0.category == nil }
+        if !orphanBudgets.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "預算缺少分類",
+                    detail: "共有 \(orphanBudgets.count) 筆預算沒有綁定分類。",
+                    recommendation: "請為預算補上分類或刪除該筆預算。"
+                )
+            )
+        }
+        
+        let duplicates = Dictionary(grouping: budgets) { budget in
+            "\(budget.monthKey)::\(budget.category?.id.uuidString ?? "nil")"
+        }.filter { $0.value.count > 1 }
+        
+        if !duplicates.isEmpty {
+            let duplicateCount = duplicates.values.reduce(0) { $0 + $1.count }
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "月預算重複",
+                    detail: "共有 \(duplicateCount) 筆重複的「分類 + 月份」預算。",
+                    recommendation: "同一分類同月份建議只保留一筆，避免提醒重複。"
+                )
+            )
+        }
+    }
+}

--- a/AI 記帳/Views/Budgets/BudgetsView.swift
+++ b/AI 記帳/Views/Budgets/BudgetsView.swift
@@ -1,0 +1,291 @@
+import SwiftUI
+import SwiftData
+
+struct BudgetsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Category.name) private var categories: [Category]
+    @Query(sort: \CategoryMonthlyBudget.monthKey, order: .reverse) private var budgets: [CategoryMonthlyBudget]
+    @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
+    @StateObject private var currencyService = CurrencyService.shared
+    
+    @State private var selectedMonthDate = Date()
+    @State private var budgetToEdit: CategoryMonthlyBudget?
+    @State private var showingAddBudget = false
+    @State private var showingOnlyAlerts = false
+    
+    private var monthKey: String {
+        BudgetService.monthKey(from: selectedMonthDate)
+    }
+    
+    private var monthStatuses: [BudgetStatus] {
+        BudgetService.statuses(
+            for: monthKey,
+            budgets: budgets,
+            transactions: transactions,
+            currencyService: currencyService
+        )
+    }
+    
+    private var visibleStatuses: [BudgetStatus] {
+        if showingOnlyAlerts {
+            return monthStatuses.filter { $0.ratio >= 1 }
+        }
+        return monthStatuses
+    }
+    
+    private var availableExpenseCategories: [Category] {
+        categories.filter { $0.kind.supports(.expense) }
+    }
+    
+    var body: some View {
+        List {
+            Section("月份") {
+                DatePicker("預算月份", selection: $selectedMonthDate, displayedComponents: [.date])
+                    .datePickerStyle(.compact)
+                Toggle("只顯示提醒", isOn: $showingOnlyAlerts)
+            }
+            
+            if visibleStatuses.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "本月無預算",
+                        systemImage: "chart.bar.doc.horizontal",
+                        description: Text("請先新增分類月預算")
+                    )
+                }
+            } else {
+                Section("分類預算") {
+                    ForEach(visibleStatuses) { status in
+                        Button {
+                            budgetToEdit = status.budget
+                        } label: {
+                            budgetRow(status)
+                        }
+                        .buttonStyle(.plain)
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                deleteBudget(status.budget)
+                            } label: {
+                                Label("刪除", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("預算與超支提醒")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingAddBudget = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .disabled(availableExpenseCategories.isEmpty)
+            }
+        }
+        .sheet(isPresented: $showingAddBudget) {
+            BudgetEditorView(
+                existingBudget: nil,
+                monthDate: selectedMonthDate,
+                allBudgets: budgets,
+                categories: availableExpenseCategories
+            )
+        }
+        .sheet(item: $budgetToEdit) { budget in
+            BudgetEditorView(
+                existingBudget: budget,
+                monthDate: selectedMonthDate,
+                allBudgets: budgets,
+                categories: availableExpenseCategories
+            )
+        }
+    }
+    
+    @ViewBuilder
+    private func budgetRow(_ status: BudgetStatus) -> some View {
+        let budget = status.budget
+        let categoryName = budget.category?.name ?? "未分類"
+        let progress = min(max(Double(NSDecimalNumber(decimal: status.ratio).doubleValue), 0), 1.5)
+        let overBy = abs(status.remaining)
+        let color: Color = status.isOverBudget ? .red : (status.ratio >= 0.85 ? .orange : .green)
+        
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(categoryName)
+                    .font(.body)
+                    .fontWeight(.semibold)
+                Spacer()
+                Text(status.spent.formatted(.currency(code: budget.currencyCode)))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(status.isOverBudget ? .red : .primary)
+            }
+            
+            ProgressView(value: progress, total: 1.0)
+                .tint(color)
+            
+            HStack {
+                Text("預算：\(budget.amount.formatted(.currency(code: budget.currencyCode)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if status.isOverBudget {
+                    Text("超支：\(overBy.formatted(.currency(code: budget.currencyCode)))")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                } else {
+                    Text("剩餘：\(status.remaining.formatted(.currency(code: budget.currencyCode)))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+    
+    private func deleteBudget(_ budget: CategoryMonthlyBudget) {
+        modelContext.delete(budget)
+    }
+}
+
+struct BudgetEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @AppStorage("mainCurrency") private var mainCurrency: String = "HKD"
+    
+    let existingBudget: CategoryMonthlyBudget?
+    let monthDate: Date
+    let allBudgets: [CategoryMonthlyBudget]
+    let categories: [Category]
+    
+    @State private var selectedCategory: Category?
+    @State private var selectedMonthDate = Date()
+    @State private var amountString = ""
+    @State private var currencyCode = "HKD"
+    @State private var isEnabled = true
+    @State private var showingError = false
+    @State private var errorMessage = ""
+    
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("分類與月份") {
+                    Picker("分類", selection: $selectedCategory) {
+                        Text("選擇分類").tag(nil as Category?)
+                        ForEach(categories) { category in
+                            Text(category.name).tag(category as Category?)
+                        }
+                    }
+                    
+                    DatePicker("月份", selection: $selectedMonthDate, displayedComponents: [.date])
+                        .datePickerStyle(.compact)
+                }
+                
+                Section("預算") {
+                    HStack {
+                        Picker("幣種", selection: $currencyCode) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
+                        }
+                        .frame(width: 90)
+                        
+                        TextField("金額", text: $amountString)
+                            .keyboardType(.decimalPad)
+                    }
+                    Toggle("啟用", isOn: $isEnabled)
+                }
+            }
+            .navigationTitle(existingBudget == nil ? "新增預算" : "編輯預算")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("儲存") { save() }
+                }
+            }
+            .alert("無法儲存", isPresented: $showingError) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .onAppear(perform: setup)
+        }
+    }
+    
+    private func setup() {
+        if let existingBudget {
+            selectedCategory = existingBudget.category
+            selectedMonthDate = BudgetService.monthStart(from: existingBudget.monthKey) ?? monthDate
+            amountString = NSDecimalNumber(decimal: existingBudget.amount).stringValue
+            currencyCode = existingBudget.currencyCode
+            isEnabled = existingBudget.isEnabled
+        } else {
+            selectedMonthDate = monthDate
+            currencyCode = mainCurrency
+            isEnabled = true
+        }
+    }
+    
+    private func save() {
+        guard let selectedCategory else {
+            showError("請選擇分類")
+            return
+        }
+        
+        guard let amount = Decimal(string: amountString), amount > 0 else {
+            showError("請輸入大於 0 的預算金額")
+            return
+        }
+        
+        let key = BudgetService.monthKey(from: selectedMonthDate)
+        
+        // 避免同一分類同月份重複，找到既有資料就覆寫
+        let duplicate = allBudgets.first { budget in
+            budget.id != existingBudget?.id &&
+            budget.monthKey == key &&
+            budget.category?.id == selectedCategory.id
+        }
+        
+        if let duplicate {
+            duplicate.amount = amount
+            duplicate.currencyCode = currencyCode
+            duplicate.isEnabled = isEnabled
+            duplicate.updatedAt = Date()
+            if let existingBudget, existingBudget.id != duplicate.id {
+                modelContext.delete(existingBudget)
+            }
+            dismiss()
+            return
+        }
+        
+        if let existingBudget {
+            existingBudget.category = selectedCategory
+            existingBudget.monthKey = key
+            existingBudget.amount = amount
+            existingBudget.currencyCode = currencyCode
+            existingBudget.isEnabled = isEnabled
+            existingBudget.updatedAt = Date()
+        } else {
+            let budget = CategoryMonthlyBudget(
+                monthKey: key,
+                amount: amount,
+                currencyCode: currencyCode,
+                isEnabled: isEnabled,
+                category: selectedCategory
+            )
+            modelContext.insert(budget)
+        }
+        
+        dismiss()
+    }
+    
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+    }
+}

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -4,12 +4,14 @@ import Charts
 
 struct ChartsView: View {
     @Query(sort: \FinancialTransaction.date) private var transactions: [FinancialTransaction]
+    @Query(sort: \CategoryMonthlyBudget.monthKey, order: .reverse) private var budgets: [CategoryMonthlyBudget]
     @StateObject private var currencyService = CurrencyService.shared
     
     @State private var filterType: FilterType = .month
     @State private var selectedDate: Date = Date()
     @State private var showingFilterSheet = false
     @State private var chartMode: ChartMode = .category
+    @State private var flowMode: FlowMode = .expense
     
     // 互動狀態
     @State private var selectedSegmentName: String?
@@ -20,41 +22,102 @@ struct ChartsView: View {
         case tag = "依標籤"
     }
     
+    enum FlowMode: String, CaseIterable {
+        case expense = "支出"
+        case income = "收入"
+        
+        var transactionType: TransactionType {
+            switch self {
+            case .expense: return .expense
+            case .income: return .income
+            }
+        }
+        
+        var emptyTitle: String {
+            switch self {
+            case .expense: return "本期無支出"
+            case .income: return "本期無收入"
+            }
+        }
+        
+        var totalTitle: String {
+            switch self {
+            case .expense: return "總支出"
+            case .income: return "總收入"
+            }
+        }
+    }
+    
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 // 頂部控制列
-                HStack {
-                    Button(action: { showingFilterSheet = true }) {
-                        HStack(spacing: 4) {
-                            Text(filterDisplayString).font(.headline)
-                            Image(systemName: "chevron.down").font(.caption).bold()
+                VStack(spacing: 10) {
+                    HStack {
+                        Button(action: { showingFilterSheet = true }) {
+                            HStack(spacing: 4) {
+                                Text(filterDisplayString).font(.headline)
+                                Image(systemName: "chevron.down").font(.caption).bold()
+                            }
+                            .foregroundStyle(.primary)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 12)
+                            .background(Color.gray.opacity(0.1))
+                            .clipShape(Capsule())
                         }
-                        .foregroundStyle(.primary)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 12)
-                        .background(Color.gray.opacity(0.1))
-                        .clipShape(Capsule())
+                        Spacer()
                     }
-                    Spacer()
-                    Picker("模式", selection: $chartMode) {
-                        ForEach(ChartMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
+                    
+                    HStack(spacing: 8) {
+                        Picker("收支", selection: $flowMode) {
+                            ForEach(FlowMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(of: flowMode) { selectedTagForDetail = nil; selectedSegmentName = nil }
+                        
+                        Picker("模式", selection: $chartMode) {
+                            ForEach(ChartMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(of: chartMode) { selectedTagForDetail = nil; selectedSegmentName = nil }
                     }
-                    .pickerStyle(.segmented).frame(width: 160)
-                    .onChange(of: chartMode) { selectedTagForDetail = nil; selectedSegmentName = nil }
                 }
                 .padding()
                 
                 // 內容區
                 ScrollView {
                     if currentData.isEmpty {
-                        ContentUnavailableView("本期無支出", systemImage: "chart.pie", description: Text("試試切換日期或記一筆帳"))
+                        ContentUnavailableView(flowMode.emptyTitle, systemImage: "chart.pie", description: Text("試試切換日期或記一筆帳"))
                             .padding(.top, 40)
                     } else if chartMode == .tag && selectedTagForDetail != nil {
                         tagDetailView
                     } else {
                         mainChartView
                     }
+                }
+                
+                if !budgetAlerts.isEmpty && flowMode == .expense {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("本月超支提醒")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        ForEach(budgetAlerts.prefix(3)) { status in
+                            HStack {
+                                Text(status.budget.category?.name ?? "未分類")
+                                    .font(.caption)
+                                Spacer()
+                                Text("超支 \(abs(status.remaining).formatted(.currency(code: status.budget.currencyCode)))")
+                                    .font(.caption2)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.red.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.horizontal)
+                    .padding(.bottom, 12)
                 }
             }
             .navigationTitle("報表")
@@ -146,7 +209,7 @@ struct ChartsView: View {
             }
             .chartAngleSelection(value: $selectedSegmentName)
             VStack {
-                Text(selectedSegmentName ?? "總支出").font(.callout).foregroundStyle(.secondary)
+                Text(selectedSegmentName ?? flowMode.totalTitle).font(.callout).foregroundStyle(.secondary)
                 Text(displayTotal.formatted(.currency(code: currencyService.mainCurrency)))
                     .font(.title2).bold().foregroundStyle(.primary)
             }
@@ -191,7 +254,7 @@ struct ChartsView: View {
     
     var currentData: [ChartData] {
         if chartMode == .category {
-            let grouped = Dictionary(grouping: filteredExpenses) { $0.category }
+            let grouped = Dictionary(grouping: filteredTransactions) { $0.category }
             let sorted = grouped.sorted {
                 let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
                 let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
@@ -210,7 +273,7 @@ struct ChartsView: View {
             }
         } else {
             var tagDict: [String: Decimal] = [:]
-            for tx in filteredExpenses {
+            for tx in filteredTransactions {
                 let amount = currencyService.convert(amount: abs(tx.amount), from: tx.currencyCode)
                 if tx.tags.isEmpty { tagDict["無標籤", default: 0] += amount }
                 else { for tag in tx.tags { tagDict[tag.name, default: 0] += amount } }
@@ -223,7 +286,7 @@ struct ChartsView: View {
     }
     
     func getCategoryBreakdown(for tagName: String) -> [ChartData] {
-        let tagTransactions = filteredExpenses.filter { tx in
+        let tagTransactions = filteredTransactions.filter { tx in
             if tagName == "無標籤" { return tx.tags.isEmpty }
             return tx.tags.contains { $0.name == tagName }
         }
@@ -262,7 +325,7 @@ struct ChartsView: View {
     var filteredExpenses: [FinancialTransaction] {
         let calendar = Calendar.current
         return transactions.filter { tx in
-            if tx.type != .expense { return false }
+            if tx.type != flowMode.transactionType { return false }
             switch filterType {
             case .all: return true
             case .year: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .year)
@@ -270,6 +333,14 @@ struct ChartsView: View {
             case .day: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .day)
             }
         }
+    }
+    
+    var filteredTransactions: [FinancialTransaction] { filteredExpenses }
+    
+    var budgetAlerts: [BudgetStatus] {
+        let key = BudgetService.monthKey(from: Date())
+        return BudgetService.statuses(for: key, budgets: budgets, transactions: transactions, currencyService: currencyService)
+            .filter { $0.ratio >= 1 }
     }
 }
 

--- a/AI 記帳/Views/SettingsView.swift
+++ b/AI 記帳/Views/SettingsView.swift
@@ -4,6 +4,9 @@ import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
+    @Query(sort: \CategoryMonthlyBudget.monthKey, order: .reverse) private var budgets: [CategoryMonthlyBudget]
+    @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
+    @StateObject private var currencyService = CurrencyService.shared
     @AppStorage("mainCurrency") private var mainCurrency: String = "HKD"
     @AppStorage("UserGeminiAPIKey") private var legacyApiKey: String = ""
     @AppStorage("enableAutoBackup") private var enableAutoBackup: Bool = false
@@ -25,6 +28,12 @@ struct SettingsView: View {
     let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
     private let keychainServiceName = "org.duckdns.lhfser.AIMoney"
     private let keychainAccountName = "gemini_api_key"
+    
+    private var monthlyBudgetAlerts: [BudgetStatus] {
+        let key = BudgetService.monthKey(from: Date())
+        return BudgetService.statuses(for: key, budgets: budgets, transactions: transactions, currencyService: currencyService)
+            .filter { $0.ratio >= 1 }
+    }
     
     // MARK: - 精確倒數計時邏輯
     struct TimeLeftInfo {
@@ -165,6 +174,26 @@ struct SettingsView: View {
                 Section("資料管理") {
                     NavigationLink(destination: CategoriesView()) { Label("分類管理", systemImage: "list.bullet") }
                     NavigationLink(destination: TagsView()) { Label("標籤管理", systemImage: "tag") }
+                    NavigationLink(destination: BudgetsView()) {
+                        Label("預算與超支提醒", systemImage: "chart.bar.doc.horizontal")
+                    }
+                    NavigationLink(destination: DataHealthCheckView()) {
+                        Label("資料健康檢查", systemImage: "stethoscope")
+                    }
+                }
+                
+                if !monthlyBudgetAlerts.isEmpty {
+                    Section("本月超支提醒") {
+                        ForEach(monthlyBudgetAlerts) { status in
+                            HStack {
+                                Text(status.budget.category?.name ?? "未分類")
+                                Spacer()
+                                Text("超支 \(abs(status.remaining).formatted(.currency(code: status.budget.currencyCode)))")
+                                    .foregroundStyle(.red)
+                                    .font(.caption)
+                            }
+                        }
+                    }
                 }
                 
                 Section {
@@ -244,6 +273,7 @@ struct SettingsView: View {
             try modelContext.delete(model: Category.self)
             try modelContext.delete(model: Tag.self)
             try modelContext.delete(model: Shortcut.self)
+            try modelContext.delete(model: CategoryMonthlyBudget.self)
             try modelContext.save()
         } catch {
             print("清除失敗: \(error)")

--- a/AI 記帳/Views/Tools/DataHealthCheckView.swift
+++ b/AI 記帳/Views/Tools/DataHealthCheckView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import SwiftData
+
+struct DataHealthCheckView: View {
+    @Environment(\.modelContext) private var modelContext
+    
+    @State private var report: HealthReport?
+    @State private var isRunning = false
+    
+    var body: some View {
+        List {
+            Section("檢查摘要") {
+                if let report {
+                    summaryView(report)
+                } else {
+                    Text("尚未執行檢查")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            if let report {
+                issuesSection("錯誤", severity: .error, report: report)
+                issuesSection("警告", severity: .warning, report: report)
+                issuesSection("資訊", severity: .info, report: report)
+            }
+        }
+        .navigationTitle("資料健康檢查")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(isRunning ? "檢查中..." : "重新檢查") {
+                    runCheck()
+                }
+                .disabled(isRunning)
+            }
+        }
+        .onAppear {
+            if report == nil {
+                runCheck()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private func summaryView(_ report: HealthReport) -> some View {
+        let dateText: String = {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+            return formatter.string(from: report.generatedAt)
+        }()
+        
+        VStack(alignment: .leading, spacing: 8) {
+            Text("最後檢查：\(dateText)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            
+            HStack(spacing: 12) {
+                summaryBadge(title: "錯誤", count: report.errorCount, color: .red)
+                summaryBadge(title: "警告", count: report.warningCount, color: .orange)
+                summaryBadge(title: "資訊", count: report.infoCount, color: .blue)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+    
+    private func summaryBadge(title: String, count: Int, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text("\(count)")
+                .font(.headline)
+                .foregroundStyle(color)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(8)
+        .background(color.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+    
+    @ViewBuilder
+    private func issuesSection(_ title: String, severity: HealthSeverity, report: HealthReport) -> some View {
+        let items = report.issues.filter { $0.severity == severity }
+        if !items.isEmpty {
+            Section(title) {
+                ForEach(items) { item in
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(item.title)
+                            .font(.body)
+                            .fontWeight(.semibold)
+                        Text(item.detail)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Text("建議：\(item.recommendation)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+    
+    private func runCheck() {
+        isRunning = true
+        report = DataHealthCheckService.run(modelContext: modelContext)
+        isRunning = false
+    }
+}


### PR DESCRIPTION
## Summary
- add income/expense switch to charts, with income donut + totals and empty-state support
- add monthly category budget management UI with over-budget reminders
- add data health check tool for transfers, signs, currencies, duplicates, and orphan budget records
- extend backup schema to v1.3 with optional budgets array (keeps old JSON import compatible)

## Technical Notes
- new model: `CategoryMonthlyBudget`
- new services: `BudgetService`, `DataHealthCheckService`
- charts/settings integrated with budget-alert widgets
- backup restore handles missing `budgets` field for legacy backups

## Validation
- xcodebuild Debug build for iOS Simulator succeeds on Xcode 26.2