### PR TITLE
feat: add advance-payment tracking and staged repayment flow

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -10,7 +10,10 @@ struct AI___App: App {
             Category.self,
             Tag.self,
             Shortcut.self,
-            CategoryMonthlyBudget.self
+            CategoryMonthlyBudget.self,
+            AdvanceCase.self,
+            AdvanceParticipant.self,
+            AdvanceRepayment.self
         ])
         
         // 1. 獲取 Documents 資料夾

--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @State private var showingAddTransfer = false
     @State private var showingScanReceipt = false
     @State private var showingAddDebt = false
+    @State private var showingAdvanceTracker = false
     
     // 備份相關狀態
     @AppStorage("lastBackupDate") private var lastBackupDate: Double = 0
@@ -52,6 +53,7 @@ struct ContentView: View {
                 Button("掃描單據 (AI)") { showingScanReceipt = true }
                 Button("轉帳") { showingAddTransfer = true }
                 Button("借貸 (借入/還款)") { showingAddDebt = true }
+                Button("代墊追蹤 (多人分帳/還款)") { showingAdvanceTracker = true }
                 Button("取消", role: .cancel) { }
             }
         }
@@ -59,12 +61,16 @@ struct ContentView: View {
         .sheet(isPresented: $showingAddTransfer) { AddTransferView() }
         .sheet(isPresented: $showingScanReceipt) { ScanReceiptView() }
         .sheet(isPresented: $showingAddDebt) { AddDebtView() } // 這裡現在應該正常了
+        .sheet(isPresented: $showingAdvanceTracker) {
+            NavigationStack { AdvancesView() }
+        }
         
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CloseAddFlow"))) { _ in
             showingScanReceipt = false
             showingAddTransaction = false
             showingAddTransfer = false
             showingAddDebt = false
+            showingAdvanceTracker = false
         }
         
         .task {

--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -237,3 +237,128 @@ final class CategoryMonthlyBudget {
         self.category = category
     }
 }
+
+@Model
+final class AdvanceCase {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var date: Date
+    var currencyCode: String
+    var myShareAmount: Decimal
+    var note: String
+    var createdAt: Date
+    var updatedAt: Date
+    
+    var payerAccount: Account?
+    var expenseCategory: Category?
+    
+    @Relationship(deleteRule: .cascade, inverse: \AdvanceParticipant.advanceCase)
+    var participants: [AdvanceParticipant] = []
+    
+    @Relationship(deleteRule: .cascade, inverse: \AdvanceRepayment.advanceCase)
+    var repayments: [AdvanceRepayment] = []
+    
+    init(
+        id: UUID = UUID(),
+        title: String,
+        date: Date = Date(),
+        currencyCode: String = "HKD",
+        myShareAmount: Decimal = 0,
+        note: String = "",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        payerAccount: Account? = nil,
+        expenseCategory: Category? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.date = date
+        self.currencyCode = currencyCode
+        self.myShareAmount = myShareAmount
+        self.note = note
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.payerAccount = payerAccount
+        self.expenseCategory = expenseCategory
+    }
+}
+
+@Model
+final class AdvanceParticipant {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var owedAmount: Decimal
+    var repaidAmount: Decimal
+    var createdAt: Date
+    var updatedAt: Date
+    
+    var advanceCase: AdvanceCase?
+    var debtAccount: Account?
+    
+    init(
+        id: UUID = UUID(),
+        name: String,
+        owedAmount: Decimal,
+        repaidAmount: Decimal = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        advanceCase: AdvanceCase? = nil,
+        debtAccount: Account? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.owedAmount = owedAmount
+        self.repaidAmount = repaidAmount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.advanceCase = advanceCase
+        self.debtAccount = debtAccount
+    }
+    
+    var remainingAmount: Decimal {
+        let remaining = owedAmount - repaidAmount
+        return remaining > 0 ? remaining : 0
+    }
+}
+
+@Model
+final class AdvanceRepayment {
+    @Attribute(.unique) var id: UUID
+    var amount: Decimal
+    var currencyCode: String
+    var normalizedAmount: Decimal // 換算為 AdvanceCase 幣種
+    var date: Date
+    var note: String
+    var linkedTransferGroupID: UUID?
+    var createdAt: Date
+    
+    var advanceCase: AdvanceCase?
+    var participant: AdvanceParticipant?
+    var receivedAccount: Account?
+    
+    init(
+        id: UUID = UUID(),
+        amount: Decimal,
+        currencyCode: String = "HKD",
+        normalizedAmount: Decimal,
+        date: Date = Date(),
+        note: String = "",
+        linkedTransferGroupID: UUID? = nil,
+        createdAt: Date = Date(),
+        advanceCase: AdvanceCase? = nil,
+        participant: AdvanceParticipant? = nil,
+        receivedAccount: Account? = nil
+    ) {
+        self.id = id
+        self.amount = amount
+        self.currencyCode = currencyCode
+        self.normalizedAmount = normalizedAmount
+        self.date = date
+        self.note = note
+        self.linkedTransferGroupID = linkedTransferGroupID
+        self.createdAt = createdAt
+        self.advanceCase = advanceCase
+        self.participant = participant
+        self.receivedAccount = receivedAccount
+    }
+}

--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -1,0 +1,275 @@
+import Foundation
+import SwiftData
+
+enum AdvanceServiceError: LocalizedError {
+    case invalidPayerAccount
+    case noParticipants
+    case duplicateParticipantAccount
+    case invalidMyShare
+    case invalidParticipantAmount
+    case participantNotInCase
+    case missingDebtAccount
+    case invalidRepaymentAmount
+    case repaymentExceedsRemaining
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidPayerAccount:
+            return "請選擇非借貸類型的付款帳戶。"
+        case .noParticipants:
+            return "請至少新增一位代墊對象。"
+        case .duplicateParticipantAccount:
+            return "代墊對象不可重複，請合併同一人的金額。"
+        case .invalidMyShare:
+            return "自己的份額不可小於 0。"
+        case .invalidParticipantAmount:
+            return "每位代墊對象的金額需大於 0。"
+        case .participantNotInCase:
+            return "該還款對象不屬於此代墊單。"
+        case .missingDebtAccount:
+            return "找不到對應的借貸帳戶，請先檢查資料。"
+        case .invalidRepaymentAmount:
+            return "還款金額需大於 0。"
+        case .repaymentExceedsRemaining:
+            return "還款金額超過未還餘額。"
+        }
+    }
+}
+
+enum AdvanceService {
+    struct ParticipantInput {
+        let debtAccount: Account
+        let owedAmount: Decimal
+    }
+    
+    private static let roundingTolerance = Decimal(string: "0.0001") ?? 0.0001
+    
+    static func totalAdvanced(for advanceCase: AdvanceCase) -> Decimal {
+        advanceCase.myShareAmount + advanceCase.participants.reduce(Decimal.zero) { $0 + $1.owedAmount }
+    }
+    
+    static func outstandingAmount(for advanceCase: AdvanceCase) -> Decimal {
+        advanceCase.participants.reduce(Decimal.zero) { partial, participant in
+            partial + participant.remainingAmount
+        }
+    }
+    
+    @MainActor
+    static func createAdvanceCase(
+        title: String,
+        date: Date,
+        currencyCode: String,
+        myShareAmount: Decimal,
+        note: String,
+        payerAccount: Account,
+        category: Category?,
+        participants: [ParticipantInput],
+        modelContext: ModelContext
+    ) throws -> AdvanceCase {
+        guard payerAccount.type != .debt else {
+            throw AdvanceServiceError.invalidPayerAccount
+        }
+        guard !participants.isEmpty else {
+            throw AdvanceServiceError.noParticipants
+        }
+        guard myShareAmount >= 0 else {
+            throw AdvanceServiceError.invalidMyShare
+        }
+        
+        var seenAccounts = Set<UUID>()
+        for participant in participants {
+            guard participant.owedAmount > 0 else {
+                throw AdvanceServiceError.invalidParticipantAmount
+            }
+            if seenAccounts.contains(participant.debtAccount.id) {
+                throw AdvanceServiceError.duplicateParticipantAccount
+            }
+            seenAccounts.insert(participant.debtAccount.id)
+        }
+        
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalTitle = trimmedTitle.isEmpty ? "代墊" : trimmedTitle
+        let finalNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let now = Date()
+        
+        let advanceCase = AdvanceCase(
+            title: finalTitle,
+            date: date,
+            currencyCode: currencyCode,
+            myShareAmount: myShareAmount,
+            note: finalNote,
+            createdAt: now,
+            updatedAt: now,
+            payerAccount: payerAccount,
+            expenseCategory: category
+        )
+        modelContext.insert(advanceCase)
+        
+        if myShareAmount > 0 {
+            let expenseNote = finalNote.isEmpty
+                ? "\(finalTitle) (自己份額)"
+                : "\(finalNote) (自己份額)"
+            
+            let expenseTx = FinancialTransaction(
+                amount: -abs(myShareAmount),
+                currencyCode: currencyCode,
+                date: date,
+                note: expenseNote,
+                type: .expense,
+                account: payerAccount,
+                category: category
+            )
+            modelContext.insert(expenseTx)
+        }
+        
+        let transferMemo = finalNote.isEmpty ? finalTitle : finalNote
+        
+        for input in participants {
+            let participant = AdvanceParticipant(
+                name: input.debtAccount.name,
+                owedAmount: abs(input.owedAmount),
+                repaidAmount: 0,
+                createdAt: now,
+                updatedAt: now,
+                advanceCase: advanceCase,
+                debtAccount: input.debtAccount
+            )
+            modelContext.insert(participant)
+            
+            let outID = UUID()
+            let inID = UUID()
+            let transferGroupID = UUID()
+            
+            let outTx = FinancialTransaction(
+                id: outID,
+                amount: -abs(input.owedAmount),
+                currencyCode: currencyCode,
+                date: date,
+                note: "\(transferMemo) (代墊給 \(input.debtAccount.name))",
+                type: .transfer,
+                linkedTransactionID: inID,
+                transferGroupID: transferGroupID,
+                transferSide: .outgoing,
+                account: payerAccount
+            )
+            
+            let inTx = FinancialTransaction(
+                id: inID,
+                amount: abs(input.owedAmount),
+                currencyCode: currencyCode,
+                date: date,
+                note: "\(transferMemo) (來自 \(payerAccount.name))",
+                type: .transfer,
+                linkedTransactionID: outID,
+                transferGroupID: transferGroupID,
+                transferSide: .incoming,
+                account: input.debtAccount
+            )
+            
+            modelContext.insert(outTx)
+            modelContext.insert(inTx)
+        }
+        
+        try modelContext.save()
+        return advanceCase
+    }
+    
+    @MainActor
+    static func recordRepayment(
+        advanceCase: AdvanceCase,
+        participant: AdvanceParticipant,
+        amount: Decimal,
+        currencyCode: String,
+        date: Date,
+        note: String,
+        receiveAccount: Account,
+        currencyService: CurrencyService,
+        modelContext: ModelContext
+    ) throws -> AdvanceRepayment {
+        guard participant.advanceCase?.id == advanceCase.id else {
+            throw AdvanceServiceError.participantNotInCase
+        }
+        guard let debtAccount = participant.debtAccount else {
+            throw AdvanceServiceError.missingDebtAccount
+        }
+        guard amount > 0 else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        
+        let normalizedAmount = currencyService.convert(
+            amount: abs(amount),
+            from: currencyCode,
+            to: advanceCase.currencyCode
+        )
+        guard normalizedAmount > 0 else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        
+        let remaining = participant.remainingAmount
+        if normalizedAmount - remaining > roundingTolerance {
+            throw AdvanceServiceError.repaymentExceedsRemaining
+        }
+        
+        let finalNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let memo = finalNote.isEmpty ? advanceCase.title : finalNote
+        let outID = UUID()
+        let inID = UUID()
+        let transferGroupID = UUID()
+        
+        let debtOutTx = FinancialTransaction(
+            id: outID,
+            amount: -abs(amount),
+            currencyCode: currencyCode,
+            date: date,
+            note: "\(memo) (還款至 \(receiveAccount.name))",
+            type: .transfer,
+            linkedTransactionID: inID,
+            transferGroupID: transferGroupID,
+            transferSide: .outgoing,
+            account: debtAccount
+        )
+        
+        let myInTx = FinancialTransaction(
+            id: inID,
+            amount: abs(amount),
+            currencyCode: currencyCode,
+            date: date,
+            note: "\(memo) (來自 \(debtAccount.name))",
+            type: .transfer,
+            linkedTransactionID: outID,
+            transferGroupID: transferGroupID,
+            transferSide: .incoming,
+            account: receiveAccount
+        )
+        
+        modelContext.insert(debtOutTx)
+        modelContext.insert(myInTx)
+        
+        let repayment = AdvanceRepayment(
+            amount: abs(amount),
+            currencyCode: currencyCode,
+            normalizedAmount: normalizedAmount,
+            date: date,
+            note: finalNote,
+            linkedTransferGroupID: transferGroupID,
+            createdAt: Date(),
+            advanceCase: advanceCase,
+            participant: participant,
+            receivedAccount: receiveAccount
+        )
+        modelContext.insert(repayment)
+        
+        let updatedRepaid = participant.repaidAmount + normalizedAmount
+        if participant.owedAmount - updatedRepaid < roundingTolerance {
+            participant.repaidAmount = participant.owedAmount
+        } else {
+            participant.repaidAmount = updatedRepaid
+        }
+        
+        participant.updatedAt = Date()
+        advanceCase.updatedAt = Date()
+        
+        try modelContext.save()
+        return repayment
+    }
+}

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -14,6 +14,9 @@ struct FullBackupData: Codable {
     let transactions: [TransactionCodable]
     let shortcuts: [ShortcutCodable]
     let budgets: [BudgetCodable]?
+    let advanceCases: [AdvanceCaseCodable]?
+    let advanceParticipants: [AdvanceParticipantCodable]?
+    let advanceRepayments: [AdvanceRepaymentCodable]?
     
     struct AccountCodable: Codable {
         let id: UUID; let name: String; let currency: String; let type: String; let baseBalance: Decimal; let sortOrder: Int
@@ -52,6 +55,41 @@ struct FullBackupData: Codable {
         let categoryID: UUID?
         let createdAt: Date?
         let updatedAt: Date?
+    }
+    struct AdvanceCaseCodable: Codable {
+        let id: UUID
+        let title: String
+        let date: Date
+        let currencyCode: String
+        let myShareAmount: Decimal?
+        let note: String?
+        let payerAccountID: UUID?
+        let expenseCategoryID: UUID?
+        let createdAt: Date?
+        let updatedAt: Date?
+    }
+    struct AdvanceParticipantCodable: Codable {
+        let id: UUID
+        let name: String
+        let owedAmount: Decimal
+        let repaidAmount: Decimal?
+        let advanceCaseID: UUID?
+        let debtAccountID: UUID?
+        let createdAt: Date?
+        let updatedAt: Date?
+    }
+    struct AdvanceRepaymentCodable: Codable {
+        let id: UUID
+        let amount: Decimal
+        let currencyCode: String
+        let normalizedAmount: Decimal?
+        let date: Date
+        let note: String?
+        let linkedTransferGroupID: UUID?
+        let advanceCaseID: UUID?
+        let participantID: UUID?
+        let receivedAccountID: UUID?
+        let createdAt: Date?
     }
 }
 
@@ -118,8 +156,11 @@ class BackupManager: NSObject, ObservableObject {
         let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
         let shortcuts = (try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []
         let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
+        let advanceCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
+        let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
+        let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
         
-        return FullBackupData(version: "1.3", timestamp: Date(),
+        return FullBackupData(version: "1.4", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
             categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
@@ -153,6 +194,47 @@ class BackupManager: NSObject, ObservableObject {
                     categoryID: $0.category?.id,
                     createdAt: $0.createdAt,
                     updatedAt: $0.updatedAt
+                )
+            },
+            advanceCases: advanceCases.map {
+                FullBackupData.AdvanceCaseCodable(
+                    id: $0.id,
+                    title: $0.title,
+                    date: $0.date,
+                    currencyCode: $0.currencyCode,
+                    myShareAmount: $0.myShareAmount,
+                    note: $0.note,
+                    payerAccountID: $0.payerAccount?.id,
+                    expenseCategoryID: $0.expenseCategory?.id,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            },
+            advanceParticipants: advanceParticipants.map {
+                FullBackupData.AdvanceParticipantCodable(
+                    id: $0.id,
+                    name: $0.name,
+                    owedAmount: $0.owedAmount,
+                    repaidAmount: $0.repaidAmount,
+                    advanceCaseID: $0.advanceCase?.id,
+                    debtAccountID: $0.debtAccount?.id,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            },
+            advanceRepayments: advanceRepayments.map {
+                FullBackupData.AdvanceRepaymentCodable(
+                    id: $0.id,
+                    amount: $0.amount,
+                    currencyCode: $0.currencyCode,
+                    normalizedAmount: $0.normalizedAmount,
+                    date: $0.date,
+                    note: $0.note,
+                    linkedTransferGroupID: $0.linkedTransferGroupID,
+                    advanceCaseID: $0.advanceCase?.id,
+                    participantID: $0.participant?.id,
+                    receivedAccountID: $0.receivedAccount?.id,
+                    createdAt: $0.createdAt
                 )
             }
         )
@@ -256,6 +338,94 @@ class BackupManager: NSObject, ObservableObject {
                 modelContext.insert(budget)
             }
         }
+        
+        // 7. 還原代墊主檔
+        if let advanceCaseDTOs = backup.advanceCases {
+            let existingCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
+            for caseDTO in advanceCaseDTOs {
+                if existingCases.contains(where: { $0.id == caseDTO.id }) {
+                    continue
+                }
+                
+                let payerAccount = updatedAccounts.first(where: { $0.id == caseDTO.payerAccountID })
+                let expenseCategory = updatedCategories.first(where: { $0.id == caseDTO.expenseCategoryID })
+                
+                let advanceCase = AdvanceCase(
+                    id: caseDTO.id,
+                    title: caseDTO.title,
+                    date: caseDTO.date,
+                    currencyCode: caseDTO.currencyCode,
+                    myShareAmount: caseDTO.myShareAmount ?? 0,
+                    note: caseDTO.note ?? "",
+                    createdAt: caseDTO.createdAt ?? caseDTO.date,
+                    updatedAt: caseDTO.updatedAt ?? (caseDTO.createdAt ?? caseDTO.date),
+                    payerAccount: payerAccount,
+                    expenseCategory: expenseCategory
+                )
+                modelContext.insert(advanceCase)
+            }
+        }
+        
+        // 8. 還原代墊對象
+        if let participantDTOs = backup.advanceParticipants {
+            let restoredCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
+            let existingParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
+            
+            for participantDTO in participantDTOs {
+                if existingParticipants.contains(where: { $0.id == participantDTO.id }) {
+                    continue
+                }
+                
+                let advanceCase = restoredCases.first(where: { $0.id == participantDTO.advanceCaseID })
+                let debtAccount = updatedAccounts.first(where: { $0.id == participantDTO.debtAccountID })
+                
+                let participant = AdvanceParticipant(
+                    id: participantDTO.id,
+                    name: participantDTO.name,
+                    owedAmount: participantDTO.owedAmount,
+                    repaidAmount: participantDTO.repaidAmount ?? 0,
+                    createdAt: participantDTO.createdAt ?? Date(),
+                    updatedAt: participantDTO.updatedAt ?? (participantDTO.createdAt ?? Date()),
+                    advanceCase: advanceCase,
+                    debtAccount: debtAccount
+                )
+                modelContext.insert(participant)
+            }
+        }
+        
+        // 9. 還原代墊還款紀錄
+        if let repaymentDTOs = backup.advanceRepayments {
+            let restoredCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
+            let restoredParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
+            let existingRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
+            
+            for repaymentDTO in repaymentDTOs {
+                if existingRepayments.contains(where: { $0.id == repaymentDTO.id }) {
+                    continue
+                }
+                
+                let advanceCase = restoredCases.first(where: { $0.id == repaymentDTO.advanceCaseID })
+                let participant = restoredParticipants.first(where: { $0.id == repaymentDTO.participantID })
+                let receiveAccount = updatedAccounts.first(where: { $0.id == repaymentDTO.receivedAccountID })
+                
+                let normalized = repaymentDTO.normalizedAmount ?? repaymentDTO.amount
+                let repayment = AdvanceRepayment(
+                    id: repaymentDTO.id,
+                    amount: repaymentDTO.amount,
+                    currencyCode: repaymentDTO.currencyCode,
+                    normalizedAmount: normalized,
+                    date: repaymentDTO.date,
+                    note: repaymentDTO.note ?? "",
+                    linkedTransferGroupID: repaymentDTO.linkedTransferGroupID,
+                    createdAt: repaymentDTO.createdAt ?? repaymentDTO.date,
+                    advanceCase: advanceCase,
+                    participant: participant,
+                    receivedAccount: receiveAccount
+                )
+                modelContext.insert(repayment)
+            }
+        }
+        
         try modelContext.save()
     }
     

--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -30,6 +30,9 @@ enum DataHealthCheckService {
         let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
         let categories = (try? modelContext.fetch(FetchDescriptor<Category>())) ?? []
         let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
+        let advanceCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
+        let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
+        let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
         
         var issues: [HealthIssue] = []
         
@@ -38,6 +41,7 @@ enum DataHealthCheckService {
         checkTransferGroups(transactions, into: &issues)
         checkCategories(categories, into: &issues)
         checkBudgets(budgets, into: &issues)
+        checkAdvances(cases: advanceCases, participants: advanceParticipants, repayments: advanceRepayments, into: &issues)
         
         if issues.isEmpty {
             issues.append(
@@ -204,6 +208,85 @@ enum DataHealthCheckService {
                     title: "月預算重複",
                     detail: "共有 \(duplicateCount) 筆重複的「分類 + 月份」預算。",
                     recommendation: "同一分類同月份建議只保留一筆，避免提醒重複。"
+                )
+            )
+        }
+    }
+    
+    private static func checkAdvances(
+        cases: [AdvanceCase],
+        participants: [AdvanceParticipant],
+        repayments: [AdvanceRepayment],
+        into issues: inout [HealthIssue]
+    ) {
+        let orphanParticipants = participants.filter { $0.advanceCase == nil }
+        if !orphanParticipants.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "代墊對象缺少主檔",
+                    detail: "共有 \(orphanParticipants.count) 筆代墊對象未連結到代墊主檔。",
+                    recommendation: "請檢查備份匯入完整性，必要時重建該筆代墊。"
+                )
+            )
+        }
+        
+        let participantsWithoutDebtAccount = participants.filter { $0.debtAccount == nil }
+        if !participantsWithoutDebtAccount.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "代墊對象缺少借貸帳戶",
+                    detail: "共有 \(participantsWithoutDebtAccount.count) 位代墊對象缺少借貸帳戶連結。",
+                    recommendation: "建議補上借貸帳戶，避免還款入帳時無法建立轉帳。"
+                )
+            )
+        }
+        
+        let overRepaidParticipants = participants.filter { $0.repaidAmount > $0.owedAmount }
+        if !overRepaidParticipants.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .error,
+                    title: "代墊對象已還金額異常",
+                    detail: "共有 \(overRepaidParticipants.count) 位對象出現已還金額大於欠款金額。",
+                    recommendation: "請檢查還款紀錄是否重複，並修正對象欠款。"
+                )
+            )
+        }
+        
+        let orphanRepayments = repayments.filter { $0.advanceCase == nil || $0.participant == nil }
+        if !orphanRepayments.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .error,
+                    title: "還款紀錄缺少關聯",
+                    detail: "共有 \(orphanRepayments.count) 筆還款未連結代墊主檔或對象。",
+                    recommendation: "建議回溯該筆還款並重新建立。"
+                )
+            )
+        }
+        
+        let invalidNormalizedRepayments = repayments.filter { $0.normalizedAmount <= 0 }
+        if !invalidNormalizedRepayments.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "還款折算金額異常",
+                    detail: "共有 \(invalidNormalizedRepayments.count) 筆還款折算值小於等於 0。",
+                    recommendation: "請檢查該筆還款幣種與匯率設定。"
+                )
+            )
+        }
+        
+        let emptyCurrencyCases = cases.filter { $0.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        if !emptyCurrencyCases.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "代墊主檔缺少幣種",
+                    detail: "共有 \(emptyCurrencyCases.count) 筆代墊主檔未設定幣種。",
+                    recommendation: "建議補上幣種，確保還款折算與統計正確。"
                 )
             )
         }

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -1,0 +1,644 @@
+import SwiftUI
+import SwiftData
+
+struct AdvancesView: View {
+    @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
+    @State private var showingAddAdvanceCase = false
+    
+    private var activeCases: [AdvanceCase] {
+        advanceCases.filter { AdvanceService.outstandingAmount(for: $0) > 0 }
+    }
+    
+    private var settledCases: [AdvanceCase] {
+        advanceCases.filter { AdvanceService.outstandingAmount(for: $0) == 0 }
+    }
+    
+    var body: some View {
+        List {
+            if advanceCases.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "尚無代墊紀錄",
+                        systemImage: "person.2.fill",
+                        description: Text("可用右上角加號新增代墊，並追蹤每位對象還款進度。")
+                    )
+                }
+            } else {
+                if !activeCases.isEmpty {
+                    Section("待收款") {
+                        ForEach(activeCases) { advanceCase in
+                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
+                                advanceCaseRow(advanceCase)
+                            }
+                        }
+                    }
+                }
+                
+                if !settledCases.isEmpty {
+                    Section("已結清") {
+                        ForEach(settledCases) { advanceCase in
+                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
+                                advanceCaseRow(advanceCase)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("代墊追蹤")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingAddAdvanceCase = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingAddAdvanceCase) {
+            AddAdvanceCaseView()
+        }
+    }
+    
+    @ViewBuilder
+    private func advanceCaseRow(_ advanceCase: AdvanceCase) -> some View {
+        let receivable = advanceCase.participants.reduce(Decimal.zero) { $0 + $1.owedAmount }
+        let repaid = advanceCase.participants.reduce(Decimal.zero) { $0 + $1.repaidAmount }
+        let outstanding = AdvanceService.outstandingAmount(for: advanceCase)
+        let progress: Double = receivable > 0
+            ? min(max((NSDecimalNumber(decimal: repaid).doubleValue / NSDecimalNumber(decimal: receivable).doubleValue), 0), 1)
+            : 1
+        
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(advanceCase.title)
+                    .font(.headline)
+                Spacer()
+                Text(outstanding.formatted(.currency(code: advanceCase.currencyCode)))
+                    .font(.subheadline)
+                    .foregroundStyle(outstanding == 0 ? .green : .red)
+            }
+            
+            ProgressView(value: progress, total: 1.0)
+                .tint(outstanding == 0 ? .green : .orange)
+            
+            HStack {
+                Text("已還 \(repaid.formatted(.currency(code: advanceCase.currencyCode)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(advanceCase.date.formatted(date: .abbreviated, time: .omitted))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct AdvanceCaseDetailView: View {
+    let advanceCase: AdvanceCase
+    @State private var selectedParticipant: AdvanceParticipant?
+    
+    private var sortedParticipants: [AdvanceParticipant] {
+        advanceCase.participants.sorted {
+            if $0.remainingAmount == $1.remainingAmount {
+                return $0.name < $1.name
+            }
+            return $0.remainingAmount > $1.remainingAmount
+        }
+    }
+    
+    private var sortedRepayments: [AdvanceRepayment] {
+        advanceCase.repayments.sorted { $0.date > $1.date }
+    }
+    
+    var body: some View {
+        List {
+            Section("摘要") {
+                summaryRow(
+                    title: "代墊總額",
+                    value: AdvanceService.totalAdvanced(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode))
+                )
+                summaryRow(
+                    title: "自己的支出",
+                    value: advanceCase.myShareAmount.formatted(.currency(code: advanceCase.currencyCode))
+                )
+                summaryRow(
+                    title: "待收總額",
+                    value: AdvanceService.outstandingAmount(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode))
+                )
+                summaryRow(
+                    title: "付款帳戶",
+                    value: advanceCase.payerAccount?.name ?? "未指定"
+                )
+            }
+            
+            Section("對象還款狀態") {
+                ForEach(sortedParticipants) { participant in
+                    participantRow(participant)
+                }
+            }
+            
+            if sortedRepayments.isEmpty {
+                Section("還款紀錄") {
+                    Text("尚未記錄還款")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section("還款紀錄") {
+                    ForEach(sortedRepayments) { repayment in
+                        repaymentRow(repayment)
+                    }
+                }
+            }
+        }
+        .navigationTitle(advanceCase.title)
+        .sheet(item: $selectedParticipant) { participant in
+            AddAdvanceRepaymentView(advanceCase: advanceCase, participant: participant)
+        }
+    }
+    
+    private func summaryRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+    }
+    
+    @ViewBuilder
+    private func participantRow(_ participant: AdvanceParticipant) -> some View {
+        let owed = participant.owedAmount
+        let repaid = participant.repaidAmount
+        let remaining = participant.remainingAmount
+        
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(participant.name)
+                    .font(.headline)
+                Spacer()
+                Text(remaining.formatted(.currency(code: advanceCase.currencyCode)))
+                    .foregroundStyle(remaining == 0 ? .green : .red)
+            }
+            
+            HStack {
+                Text("欠款 \(owed.formatted(.currency(code: advanceCase.currencyCode)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("已還 \(repaid.formatted(.currency(code: advanceCase.currencyCode)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            if remaining > 0 {
+                Button {
+                    selectedParticipant = participant
+                } label: {
+                    Label("記錄還款", systemImage: "arrow.down.circle")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .tint(.blue)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+    
+    private func repaymentRow(_ repayment: AdvanceRepayment) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(repayment.participant?.name ?? "未指定對象")
+                    .font(.body)
+                    .fontWeight(.semibold)
+                Spacer()
+                Text(repayment.amount.formatted(.currency(code: repayment.currencyCode)))
+                    .font(.subheadline)
+                    .foregroundStyle(.green)
+            }
+            
+            HStack(spacing: 6) {
+                Text(repayment.date.formatted(date: .abbreviated, time: .shortened))
+                Text("•")
+                Text("入帳：\(repayment.receivedAccount?.name ?? "未指定")")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            
+            if repayment.currencyCode != advanceCase.currencyCode {
+                Text("折算 \(repayment.normalizedAmount.formatted(.currency(code: advanceCase.currencyCode)))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            
+            if !repayment.note.isEmpty {
+                Text(repayment.note)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct AddAdvanceCaseView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
+    @Query(sort: \Category.name) private var categories: [Category]
+    
+    private struct ParticipantDraft: Identifiable {
+        let id = UUID()
+        var debtAccount: Account?
+        var amountString: String = ""
+    }
+    
+    @State private var title = ""
+    @State private var date = Date()
+    @State private var note = ""
+    @State private var myShareString = ""
+    @State private var selectedCurrency = "HKD"
+    @State private var selectedPayerAccount: Account?
+    @State private var selectedCategory: Category?
+    @State private var participantDrafts: [ParticipantDraft] = [ParticipantDraft()]
+    
+    @State private var showingError = false
+    @State private var errorMessage = ""
+    
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+    
+    private var myAccounts: [Account] {
+        allAccounts.filter { !$0.isArchived && $0.type != .debt }
+    }
+    
+    private var debtAccounts: [Account] {
+        allAccounts.filter { !$0.isArchived && $0.type == .debt }
+    }
+    
+    private var expenseCategories: [Category] {
+        categories.filter { $0.kind.supports(.expense) }
+    }
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("基本資訊") {
+                    TextField("代墊名稱 (例如：聚餐 2026-03-01)", text: $title)
+                    DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                    Picker("付款帳戶", selection: $selectedPayerAccount) {
+                        Text("選擇帳戶").tag(nil as Account?)
+                        ForEach(myAccounts) { account in
+                            Text(account.name).tag(account as Account?)
+                        }
+                    }
+                    .onChange(of: selectedPayerAccount) {
+                        if let account = selectedPayerAccount {
+                            selectedCurrency = account.currency
+                        }
+                    }
+                    
+                    HStack {
+                        Text("幣種")
+                        Spacer()
+                        Picker("幣種", selection: $selectedCurrency) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
+                        }
+                    }
+                }
+                
+                Section("自己的份額") {
+                    TextField("0 (可留空)", text: Binding(
+                        get: { myShareString },
+                        set: { myShareString = sanitizePositiveDecimalInput($0) }
+                    ))
+                    .keyboardType(.decimalPad)
+                    
+                    Picker("支出分類", selection: $selectedCategory) {
+                        Text("不設定").tag(nil as Category?)
+                        ForEach(expenseCategories) { category in
+                            Text(category.name).tag(category as Category?)
+                        }
+                    }
+                }
+                
+                Section("代墊對象") {
+                    if debtAccounts.isEmpty {
+                        Text("請先在「帳戶」新增類型為「借貸/債務」的對象帳戶。")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    } else {
+                        ForEach($participantDrafts) { $draft in
+                            VStack(spacing: 10) {
+                                Picker("對象", selection: $draft.debtAccount) {
+                                    Text("選擇對象").tag(nil as Account?)
+                                    ForEach(debtAccounts) { account in
+                                        Text(account.name).tag(account as Account?)
+                                    }
+                                }
+                                
+                                TextField("代墊金額", text: Binding(
+                                    get: { draft.amountString },
+                                    set: { draft.amountString = sanitizePositiveDecimalInput($0) }
+                                ))
+                                .keyboardType(.decimalPad)
+                                
+                                if participantDrafts.count > 1 {
+                                    Button(role: .destructive) {
+                                        participantDrafts.removeAll { $0.id == draft.id }
+                                    } label: {
+                                        Text("移除此對象")
+                                    }
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        
+                        Button {
+                            participantDrafts.append(ParticipantDraft())
+                        } label: {
+                            Label("新增對象", systemImage: "plus.circle")
+                        }
+                    }
+                }
+                
+                Section("備註") {
+                    TextField("可填入店名、說明等", text: $note)
+                }
+            }
+            .navigationTitle("新增代墊")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("儲存") { save() }
+                        .disabled(selectedPayerAccount == nil || debtAccounts.isEmpty)
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完成") {
+                        hideKeyboard()
+                    }
+                }
+            }
+            .alert("無法儲存", isPresented: $showingError) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .onAppear {
+                if selectedPayerAccount == nil, let first = myAccounts.first {
+                    selectedPayerAccount = first
+                    selectedCurrency = first.currency
+                }
+            }
+        }
+    }
+    
+    private func save() {
+        guard let payer = selectedPayerAccount else {
+            showError("請選擇付款帳戶。")
+            return
+        }
+        
+        let myShare: Decimal
+        if myShareString.isEmpty {
+            myShare = 0
+        } else if let parsed = Decimal(string: myShareString), parsed >= 0 {
+            myShare = parsed
+        } else {
+            showError("自己的份額格式不正確。")
+            return
+        }
+        
+        var participantInputs: [AdvanceService.ParticipantInput] = []
+        for draft in participantDrafts {
+            guard let debtAccount = draft.debtAccount else {
+                showError("請為每位對象選擇借貸帳戶。")
+                return
+            }
+            guard let amount = Decimal(string: draft.amountString), amount > 0 else {
+                showError("請填寫每位對象大於 0 的代墊金額。")
+                return
+            }
+            participantInputs.append(.init(debtAccount: debtAccount, owedAmount: amount))
+        }
+        
+        guard !participantInputs.isEmpty else {
+            showError("請至少新增一位代墊對象。")
+            return
+        }
+        
+        do {
+            _ = try AdvanceService.createAdvanceCase(
+                title: title,
+                date: date,
+                currencyCode: selectedCurrency,
+                myShareAmount: myShare,
+                note: note,
+                payerAccount: payer,
+                category: selectedCategory,
+                participants: participantInputs,
+                modelContext: modelContext
+            )
+            dismiss()
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+    
+    private func sanitizePositiveDecimalInput(_ value: String) -> String {
+        let allowed = value.filter { "0123456789.".contains($0) }
+        var result = ""
+        var hasDot = false
+        
+        for char in allowed {
+            if char == "." {
+                if hasDot { continue }
+                hasDot = true
+            }
+            result.append(char)
+        }
+        
+        return result == "." ? "" : result
+    }
+    
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+    }
+}
+
+struct AddAdvanceRepaymentView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
+    @StateObject private var currencyService = CurrencyService.shared
+    
+    let advanceCase: AdvanceCase
+    let participant: AdvanceParticipant
+    
+    @State private var selectedReceiveAccount: Account?
+    @State private var amountString = ""
+    @State private var selectedCurrency = "HKD"
+    @State private var date = Date()
+    @State private var note = ""
+    @State private var showingError = false
+    @State private var errorMessage = ""
+    
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+    
+    private var receiveAccounts: [Account] {
+        allAccounts.filter { !$0.isArchived && $0.type != .debt }
+    }
+    
+    private var remaining: Decimal {
+        participant.remainingAmount
+    }
+    
+    private var convertedPreview: Decimal? {
+        guard let amount = Decimal(string: amountString), amount > 0 else { return nil }
+        return currencyService.convert(amount: amount, from: selectedCurrency, to: advanceCase.currencyCode)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("對象") {
+                    summaryRow(title: "姓名", value: participant.name)
+                    summaryRow(title: "未還", value: remaining.formatted(.currency(code: advanceCase.currencyCode)))
+                }
+                
+                Section("入帳與金額") {
+                    Picker("入帳帳戶", selection: $selectedReceiveAccount) {
+                        Text("選擇帳戶").tag(nil as Account?)
+                        ForEach(receiveAccounts) { account in
+                            Text(account.name).tag(account as Account?)
+                        }
+                    }
+                    .onChange(of: selectedReceiveAccount) {
+                        if let account = selectedReceiveAccount {
+                            selectedCurrency = account.currency
+                        }
+                    }
+                    
+                    HStack {
+                        Picker("幣種", selection: $selectedCurrency) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
+                        }
+                        .frame(width: 100)
+                        
+                        TextField("還款金額", text: Binding(
+                            get: { amountString },
+                            set: { amountString = sanitizePositiveDecimalInput($0) }
+                        ))
+                        .keyboardType(.decimalPad)
+                    }
+                    
+                    if let convertedPreview {
+                        Text("折算為 \(convertedPreview.formatted(.currency(code: advanceCase.currencyCode)))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                
+                Section("其他") {
+                    DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                    TextField("備註", text: $note)
+                }
+            }
+            .navigationTitle("記錄還款")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("儲存") { save() }
+                        .disabled(selectedReceiveAccount == nil || amountString.isEmpty)
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完成") {
+                        hideKeyboard()
+                    }
+                }
+            }
+            .alert("無法儲存", isPresented: $showingError) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .onAppear {
+                Task { await currencyService.fetchRates() }
+                if selectedReceiveAccount == nil, let first = receiveAccounts.first {
+                    selectedReceiveAccount = first
+                    selectedCurrency = first.currency
+                }
+            }
+        }
+    }
+    
+    private func save() {
+        guard let receiveAccount = selectedReceiveAccount else {
+            showError("請選擇入帳帳戶。")
+            return
+        }
+        guard let amount = Decimal(string: amountString), amount > 0 else {
+            showError("請輸入大於 0 的還款金額。")
+            return
+        }
+        
+        do {
+            _ = try AdvanceService.recordRepayment(
+                advanceCase: advanceCase,
+                participant: participant,
+                amount: amount,
+                currencyCode: selectedCurrency,
+                date: date,
+                note: note,
+                receiveAccount: receiveAccount,
+                currencyService: currencyService,
+                modelContext: modelContext
+            )
+            dismiss()
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+    
+    private func summaryRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+    }
+    
+    private func sanitizePositiveDecimalInput(_ value: String) -> String {
+        let allowed = value.filter { "0123456789.".contains($0) }
+        var result = ""
+        var hasDot = false
+        
+        for char in allowed {
+            if char == "." {
+                if hasDot { continue }
+                hasDot = true
+            }
+            result.append(char)
+        }
+        
+        return result == "." ? "" : result
+    }
+    
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+    }
+}

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -254,22 +254,17 @@ struct ChartsView: View {
     
     var currentData: [ChartData] {
         if chartMode == .category {
-            let grouped = Dictionary(grouping: filteredTransactions) { $0.category }
+            let grouped = Dictionary(grouping: filteredTransactions) { $0.category?.id.uuidString ?? "uncategorized" }
             let sorted = grouped.sorted {
                 let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
                 let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
                 return sum0 > sum1
             }
-            // 🔥 修復：優先使用分類的 colorHex，如果沒有則使用灰色
             return sorted.enumerated().map { (index, item) in
                 let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-                let displayColor: Color
-                if let category = item.key {
-                    displayColor = Color(hex: category.colorHex)
-                } else {
-                    displayColor = .gray
-                }
-                return ChartData(name: item.key?.name ?? "未分類", amount: total, color: displayColor)
+                let category = item.value.compactMap { $0.category }.first
+                let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
+                return ChartData(name: category?.name ?? "未分類", amount: total, color: displayColor)
             }
         } else {
             var tagDict: [String: Decimal] = [:]
@@ -290,22 +285,17 @@ struct ChartsView: View {
             if tagName == "無標籤" { return tx.tags.isEmpty }
             return tx.tags.contains { $0.name == tagName }
         }
-        let grouped = Dictionary(grouping: tagTransactions) { $0.category }
+        let grouped = Dictionary(grouping: tagTransactions) { $0.category?.id.uuidString ?? "uncategorized" }
         let sorted = grouped.sorted {
             let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
             let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
             return sum0 > sum1
         }
-        // 🔥 修復：鑽取詳情時也使用分類顏色
         return sorted.enumerated().map { (index, item) in
             let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-            let displayColor: Color
-            if let category = item.key {
-                displayColor = Color(hex: category.colorHex)
-            } else {
-                displayColor = .gray
-            }
-            return ChartData(name: item.key?.name ?? "未分類", amount: total, color: displayColor)
+            let category = item.value.compactMap { $0.category }.first
+            let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
+            return ChartData(name: category?.name ?? "未分類", amount: total, color: displayColor)
         }
     }
     

--- a/AI 記帳/Views/SettingsView.swift
+++ b/AI 記帳/Views/SettingsView.swift
@@ -174,6 +174,9 @@ struct SettingsView: View {
                 Section("資料管理") {
                     NavigationLink(destination: CategoriesView()) { Label("分類管理", systemImage: "list.bullet") }
                     NavigationLink(destination: TagsView()) { Label("標籤管理", systemImage: "tag") }
+                    NavigationLink(destination: AdvancesView()) {
+                        Label("代墊追蹤", systemImage: "person.2.fill")
+                    }
                     NavigationLink(destination: BudgetsView()) {
                         Label("預算與超支提醒", systemImage: "chart.bar.doc.horizontal")
                     }
@@ -274,6 +277,9 @@ struct SettingsView: View {
             try modelContext.delete(model: Tag.self)
             try modelContext.delete(model: Shortcut.self)
             try modelContext.delete(model: CategoryMonthlyBudget.self)
+            try modelContext.delete(model: AdvanceRepayment.self)
+            try modelContext.delete(model: AdvanceParticipant.self)
+            try modelContext.delete(model: AdvanceCase.self)
             try modelContext.save()
         } catch {
             print("清除失敗: \(error)")


### PR DESCRIPTION
## Summary
- add new advance-payment tracking domain for "代墊後分次還款" use cases
- support one expense split into self share + multiple friends receivable shares
- support staged repayments to different destination accounts with currency conversion

## What was added
- new models: `AdvanceCase`, `AdvanceParticipant`, `AdvanceRepayment`
- new service: `AdvanceService` for business rules and transfer generation
- new UI: `AdvancesView`, case detail, create-advance form, record-repayment form
- entry points:
  - plus menu now includes "代墊追蹤 (多人分帳/還款)"
  - settings data management now includes "代墊追蹤"

## Accounting behavior
- creating an advance:
  - self share -> expense transaction
  - each friend share -> transfer from payer account to that friend debt account
- recording repayment:
  - transfer from friend debt account to selected receive account
  - repayment amount normalized into case currency for progress tracking

## Data safety & compatibility
- backup schema bumped to `1.4`
- backup export/import now includes advance cases/participants/repayments
- keeps backward compatibility (old JSON without new fields still imports)
- delete-all now includes advance models
- data health check now validates advance integrity issues

## Validation
- xcodebuild Debug build for iOS Simulator succeeds on Xcode 26.2