### PR TITLE
feat: support advance correction and repayment rollback

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -11,6 +11,9 @@ enum AdvanceServiceError: LocalizedError {
     case missingDebtAccount
     case invalidRepaymentAmount
     case repaymentExceedsRemaining
+    case invalidAdjustedOwedAmount
+    case adjustedOwedLowerThanRepaid
+    case missingRepaymentParticipant
     
     var errorDescription: String? {
         switch self {
@@ -32,6 +35,12 @@ enum AdvanceServiceError: LocalizedError {
             return "還款金額需大於 0。"
         case .repaymentExceedsRemaining:
             return "還款金額超過未還餘額。"
+        case .invalidAdjustedOwedAmount:
+            return "更正後欠款金額需大於 0。"
+        case .adjustedOwedLowerThanRepaid:
+            return "更正後欠款不可低於已還金額。"
+        case .missingRepaymentParticipant:
+            return "找不到還款對應的對象資料。"
         }
     }
 }
@@ -271,5 +280,64 @@ enum AdvanceService {
         
         try modelContext.save()
         return repayment
+    }
+    
+    @MainActor
+    static func updateParticipantOwedAmount(
+        advanceCase: AdvanceCase,
+        participant: AdvanceParticipant,
+        newOwedAmount: Decimal,
+        modelContext: ModelContext
+    ) throws {
+        guard participant.advanceCase?.id == advanceCase.id else {
+            throw AdvanceServiceError.participantNotInCase
+        }
+        guard newOwedAmount > 0 else {
+            throw AdvanceServiceError.invalidAdjustedOwedAmount
+        }
+        guard newOwedAmount + roundingTolerance >= participant.repaidAmount else {
+            throw AdvanceServiceError.adjustedOwedLowerThanRepaid
+        }
+        
+        participant.owedAmount = newOwedAmount
+        if participant.repaidAmount > newOwedAmount {
+            participant.repaidAmount = newOwedAmount
+        }
+        participant.updatedAt = Date()
+        advanceCase.updatedAt = Date()
+        
+        try modelContext.save()
+    }
+    
+    @MainActor
+    static func rollbackRepayment(
+        advanceCase: AdvanceCase,
+        repayment: AdvanceRepayment,
+        modelContext: ModelContext
+    ) throws {
+        guard repayment.advanceCase?.id == advanceCase.id else {
+            throw AdvanceServiceError.participantNotInCase
+        }
+        guard let participant = repayment.participant else {
+            throw AdvanceServiceError.missingRepaymentParticipant
+        }
+        
+        if let groupID = repayment.linkedTransferGroupID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.transferGroupID == groupID }
+            )
+            let linkedTransfers = (try? modelContext.fetch(descriptor)) ?? []
+            for tx in linkedTransfers {
+                modelContext.delete(tx)
+            }
+        }
+        
+        let updatedRepaid = participant.repaidAmount - repayment.normalizedAmount
+        participant.repaidAmount = updatedRepaid > 0 ? updatedRepaid : 0
+        participant.updatedAt = Date()
+        advanceCase.updatedAt = Date()
+        
+        modelContext.delete(repayment)
+        try modelContext.save()
     }
 }

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -97,8 +97,15 @@ struct AdvancesView: View {
 }
 
 struct AdvanceCaseDetailView: View {
+    @Environment(\.modelContext) private var modelContext
+    
     let advanceCase: AdvanceCase
-    @State private var selectedParticipant: AdvanceParticipant?
+    @State private var selectedParticipantForRepayment: AdvanceParticipant?
+    @State private var selectedParticipantForEdit: AdvanceParticipant?
+    @State private var repaymentToRollback: AdvanceRepayment?
+    @State private var showingRollbackAlert = false
+    @State private var showingError = false
+    @State private var errorMessage = ""
     
     private var sortedParticipants: [AdvanceParticipant] {
         advanceCase.participants.sorted {
@@ -132,11 +139,23 @@ struct AdvanceCaseDetailView: View {
                     title: "付款帳戶",
                     value: advanceCase.payerAccount?.name ?? "未指定"
                 )
+                summaryRow(
+                    title: "帳務儲存",
+                    value: "借貸帳戶轉帳"
+                )
             }
             
             Section("對象還款狀態") {
                 ForEach(sortedParticipants) { participant in
                     participantRow(participant)
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button {
+                                selectedParticipantForEdit = participant
+                            } label: {
+                                Label("更正欠款", systemImage: "pencil")
+                            }
+                            .tint(.orange)
+                        }
                 }
             }
             
@@ -149,13 +168,37 @@ struct AdvanceCaseDetailView: View {
                 Section("還款紀錄") {
                     ForEach(sortedRepayments) { repayment in
                         repaymentRow(repayment)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    repaymentToRollback = repayment
+                                    showingRollbackAlert = true
+                                } label: {
+                                    Label("沖銷", systemImage: "arrow.uturn.backward.circle")
+                                }
+                            }
                     }
                 }
             }
         }
         .navigationTitle(advanceCase.title)
-        .sheet(item: $selectedParticipant) { participant in
+        .sheet(item: $selectedParticipantForRepayment) { participant in
             AddAdvanceRepaymentView(advanceCase: advanceCase, participant: participant)
+        }
+        .sheet(item: $selectedParticipantForEdit) { participant in
+            EditAdvanceParticipantView(advanceCase: advanceCase, participant: participant)
+        }
+        .alert("確認沖銷還款？", isPresented: $showingRollbackAlert, presenting: repaymentToRollback) { repayment in
+            Button("取消", role: .cancel) {}
+            Button("沖銷", role: .destructive) {
+                rollbackRepayment(repayment)
+            }
+        } message: { repayment in
+            Text("將刪除 \(repayment.amount.formatted(.currency(code: repayment.currencyCode))) 的還款紀錄，並同步刪除對應借貸轉帳。")
+        }
+        .alert("操作失敗", isPresented: $showingError) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(errorMessage)
         }
     }
     
@@ -194,14 +237,34 @@ struct AdvanceCaseDetailView: View {
             }
             
             if remaining > 0 {
+                HStack(spacing: 8) {
+                    Button {
+                        selectedParticipantForRepayment = participant
+                    } label: {
+                        Label("記錄還款", systemImage: "arrow.down.circle")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.blue)
+                    
+                    Button {
+                        selectedParticipantForEdit = participant
+                    } label: {
+                        Label("更正欠款", systemImage: "pencil")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.orange)
+                }
+            } else {
                 Button {
-                    selectedParticipant = participant
+                    selectedParticipantForEdit = participant
                 } label: {
-                    Label("記錄還款", systemImage: "arrow.down.circle")
+                    Label("更正欠款", systemImage: "pencil")
                         .font(.caption)
                 }
                 .buttonStyle(.bordered)
-                .tint(.blue)
+                .tint(.orange)
             }
         }
         .padding(.vertical, 4)
@@ -240,6 +303,19 @@ struct AdvanceCaseDetailView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+    
+    private func rollbackRepayment(_ repayment: AdvanceRepayment) {
+        do {
+            try AdvanceService.rollbackRepayment(
+                advanceCase: advanceCase,
+                repayment: repayment,
+                modelContext: modelContext
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+            showingError = true
+        }
     }
 }
 
@@ -618,6 +694,114 @@ struct AddAdvanceRepaymentView: View {
             Spacer()
             Text(value)
                 .foregroundStyle(.secondary)
+        }
+    }
+    
+    private func sanitizePositiveDecimalInput(_ value: String) -> String {
+        let allowed = value.filter { "0123456789.".contains($0) }
+        var result = ""
+        var hasDot = false
+        
+        for char in allowed {
+            if char == "." {
+                if hasDot { continue }
+                hasDot = true
+            }
+            result.append(char)
+        }
+        
+        return result == "." ? "" : result
+    }
+    
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+    }
+}
+
+struct EditAdvanceParticipantView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    
+    let advanceCase: AdvanceCase
+    let participant: AdvanceParticipant
+    
+    @State private var owedAmountString = ""
+    @State private var showingError = false
+    @State private var errorMessage = ""
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("對象") {
+                    HStack {
+                        Text("姓名")
+                        Spacer()
+                        Text(participant.name)
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("已還")
+                        Spacer()
+                        Text(participant.repaidAmount.formatted(.currency(code: advanceCase.currencyCode)))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                
+                Section("更正欠款") {
+                    TextField("欠款金額", text: Binding(
+                        get: { owedAmountString },
+                        set: { owedAmountString = sanitizePositiveDecimalInput($0) }
+                    ))
+                    .keyboardType(.decimalPad)
+                    
+                    Text("此值用於代墊追蹤；借貸實際帳務仍以轉帳紀錄為準。")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("更正欠款")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("儲存") { save() }
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完成") {
+                        hideKeyboard()
+                    }
+                }
+            }
+            .alert("無法儲存", isPresented: $showingError) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .onAppear {
+                owedAmountString = NSDecimalNumber(decimal: participant.owedAmount).stringValue
+            }
+        }
+    }
+    
+    private func save() {
+        guard let newOwed = Decimal(string: owedAmountString), newOwed > 0 else {
+            showError("請輸入大於 0 的欠款金額。")
+            return
+        }
+        
+        do {
+            try AdvanceService.updateParticipantOwedAmount(
+                advanceCase: advanceCase,
+                participant: participant,
+                newOwedAmount: newOwed,
+                modelContext: modelContext
+            )
+            dismiss()
+        } catch {
+            showError(error.localizedDescription)
         }
     }
     


### PR DESCRIPTION
## Summary
- clarify that advance tracking persists via debt-account transfer bookkeeping
- add ability to edit participant owed amount in an advance case
- add repayment rollback action that removes both repayment record and linked debt transfer entries

## Details
- new service methods in `AdvanceService`:
  - `updateParticipantOwedAmount(...)`
  - `rollbackRepayment(...)`
- advance case detail UI:
  - participant row supports "更正欠款"
  - repayment row supports destructive "沖銷"
  - summary explicitly shows storage mode as "借貸帳戶轉帳"

## Data consistency
- rollback updates participant repaid amount and case updated timestamp
- rollback also deletes linked transfer-group transactions to keep debt ledgers consistent

## Validation
- xcodebuild Debug build for iOS Simulator succeeds on Xcode 26.2