### PR TITLE
feat: support deleting advance cases and participant aggregates

### DIFF
--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -246,6 +246,7 @@ final class AdvanceCase {
     var currencyCode: String
     var myShareAmount: Decimal
     var note: String
+    var selfExpenseTransactionID: UUID?
     var createdAt: Date
     var updatedAt: Date
     
@@ -265,6 +266,7 @@ final class AdvanceCase {
         currencyCode: String = "HKD",
         myShareAmount: Decimal = 0,
         note: String = "",
+        selfExpenseTransactionID: UUID? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         payerAccount: Account? = nil,
@@ -276,6 +278,7 @@ final class AdvanceCase {
         self.currencyCode = currencyCode
         self.myShareAmount = myShareAmount
         self.note = note
+        self.selfExpenseTransactionID = selfExpenseTransactionID
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.payerAccount = payerAccount
@@ -289,6 +292,7 @@ final class AdvanceParticipant {
     var name: String
     var owedAmount: Decimal
     var repaidAmount: Decimal
+    var initialTransferGroupID: UUID?
     var createdAt: Date
     var updatedAt: Date
     
@@ -300,6 +304,7 @@ final class AdvanceParticipant {
         name: String,
         owedAmount: Decimal,
         repaidAmount: Decimal = 0,
+        initialTransferGroupID: UUID? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         advanceCase: AdvanceCase? = nil,
@@ -309,6 +314,7 @@ final class AdvanceParticipant {
         self.name = name
         self.owedAmount = owedAmount
         self.repaidAmount = repaidAmount
+        self.initialTransferGroupID = initialTransferGroupID
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.advanceCase = advanceCase

--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -14,6 +14,7 @@ enum AdvanceServiceError: LocalizedError {
     case invalidAdjustedOwedAmount
     case adjustedOwedLowerThanRepaid
     case missingRepaymentParticipant
+    case cannotDeleteAdvanceCaseWithoutModelContext
     
     var errorDescription: String? {
         switch self {
@@ -41,6 +42,8 @@ enum AdvanceServiceError: LocalizedError {
             return "更正後欠款不可低於已還金額。"
         case .missingRepaymentParticipant:
             return "找不到還款對應的對象資料。"
+        case .cannotDeleteAdvanceCaseWithoutModelContext:
+            return "刪除代墊失敗：缺少可用資料上下文。"
         }
     }
 }
@@ -49,6 +52,11 @@ enum AdvanceService {
     struct ParticipantInput {
         let debtAccount: Account
         let owedAmount: Decimal
+    }
+    
+    struct DeleteAdvanceResult {
+        let deletedTransactionCount: Int
+        let missingLinkedRecordCount: Int
     }
     
     private static let roundingTolerance = Decimal(string: "0.0001") ?? 0.0001
@@ -129,25 +137,27 @@ enum AdvanceService {
                 category: category
             )
             modelContext.insert(expenseTx)
+            advanceCase.selfExpenseTransactionID = expenseTx.id
         }
         
         let transferMemo = finalNote.isEmpty ? finalTitle : finalNote
         
         for input in participants {
+            let transferGroupID = UUID()
+            let outID = UUID()
+            let inID = UUID()
+            
             let participant = AdvanceParticipant(
                 name: input.debtAccount.name,
                 owedAmount: abs(input.owedAmount),
                 repaidAmount: 0,
+                initialTransferGroupID: transferGroupID,
                 createdAt: now,
                 updatedAt: now,
                 advanceCase: advanceCase,
                 debtAccount: input.debtAccount
             )
             modelContext.insert(participant)
-            
-            let outID = UUID()
-            let inID = UUID()
-            let transferGroupID = UUID()
             
             let outTx = FinancialTransaction(
                 id: outID,
@@ -339,5 +349,66 @@ enum AdvanceService {
         
         modelContext.delete(repayment)
         try modelContext.save()
+    }
+    
+    @MainActor
+    static func deleteAdvanceCase(
+        _ advanceCase: AdvanceCase,
+        deleteLinkedTransactions: Bool,
+        modelContext: ModelContext
+    ) throws -> DeleteAdvanceResult {
+        var deletedTransactionCount = 0
+        var missingLinkedRecordCount = 0
+        
+        if deleteLinkedTransactions {
+            var groupIDs = Set<UUID>()
+            
+            for participant in advanceCase.participants {
+                if let groupID = participant.initialTransferGroupID {
+                    groupIDs.insert(groupID)
+                } else {
+                    missingLinkedRecordCount += 1
+                }
+            }
+            
+            for repayment in advanceCase.repayments {
+                if let groupID = repayment.linkedTransferGroupID {
+                    groupIDs.insert(groupID)
+                } else {
+                    missingLinkedRecordCount += 1
+                }
+            }
+            
+            for groupID in groupIDs {
+                let descriptor = FetchDescriptor<FinancialTransaction>(
+                    predicate: #Predicate { $0.transferGroupID == groupID }
+                )
+                let linkedTransfers = (try? modelContext.fetch(descriptor)) ?? []
+                deletedTransactionCount += linkedTransfers.count
+                for tx in linkedTransfers {
+                    modelContext.delete(tx)
+                }
+            }
+            
+            if let expenseID = advanceCase.selfExpenseTransactionID {
+                let descriptor = FetchDescriptor<FinancialTransaction>(
+                    predicate: #Predicate { $0.id == expenseID }
+                )
+                if let expenseTx = try? modelContext.fetch(descriptor).first {
+                    modelContext.delete(expenseTx)
+                    deletedTransactionCount += 1
+                } else {
+                    missingLinkedRecordCount += 1
+                }
+            }
+        }
+        
+        modelContext.delete(advanceCase)
+        try modelContext.save()
+        
+        return DeleteAdvanceResult(
+            deletedTransactionCount: deletedTransactionCount,
+            missingLinkedRecordCount: missingLinkedRecordCount
+        )
     }
 }

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -63,6 +63,7 @@ struct FullBackupData: Codable {
         let currencyCode: String
         let myShareAmount: Decimal?
         let note: String?
+        let selfExpenseTransactionID: UUID?
         let payerAccountID: UUID?
         let expenseCategoryID: UUID?
         let createdAt: Date?
@@ -73,6 +74,7 @@ struct FullBackupData: Codable {
         let name: String
         let owedAmount: Decimal
         let repaidAmount: Decimal?
+        let initialTransferGroupID: UUID?
         let advanceCaseID: UUID?
         let debtAccountID: UUID?
         let createdAt: Date?
@@ -160,7 +162,7 @@ class BackupManager: NSObject, ObservableObject {
         let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
         let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
         
-        return FullBackupData(version: "1.4", timestamp: Date(),
+        return FullBackupData(version: "1.5", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
             categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
@@ -204,6 +206,7 @@ class BackupManager: NSObject, ObservableObject {
                     currencyCode: $0.currencyCode,
                     myShareAmount: $0.myShareAmount,
                     note: $0.note,
+                    selfExpenseTransactionID: $0.selfExpenseTransactionID,
                     payerAccountID: $0.payerAccount?.id,
                     expenseCategoryID: $0.expenseCategory?.id,
                     createdAt: $0.createdAt,
@@ -216,6 +219,7 @@ class BackupManager: NSObject, ObservableObject {
                     name: $0.name,
                     owedAmount: $0.owedAmount,
                     repaidAmount: $0.repaidAmount,
+                    initialTransferGroupID: $0.initialTransferGroupID,
                     advanceCaseID: $0.advanceCase?.id,
                     debtAccountID: $0.debtAccount?.id,
                     createdAt: $0.createdAt,
@@ -357,6 +361,7 @@ class BackupManager: NSObject, ObservableObject {
                     currencyCode: caseDTO.currencyCode,
                     myShareAmount: caseDTO.myShareAmount ?? 0,
                     note: caseDTO.note ?? "",
+                    selfExpenseTransactionID: caseDTO.selfExpenseTransactionID,
                     createdAt: caseDTO.createdAt ?? caseDTO.date,
                     updatedAt: caseDTO.updatedAt ?? (caseDTO.createdAt ?? caseDTO.date),
                     payerAccount: payerAccount,
@@ -384,6 +389,7 @@ class BackupManager: NSObject, ObservableObject {
                     name: participantDTO.name,
                     owedAmount: participantDTO.owedAmount,
                     repaidAmount: participantDTO.repaidAmount ?? 0,
+                    initialTransferGroupID: participantDTO.initialTransferGroupID,
                     createdAt: participantDTO.createdAt ?? Date(),
                     updatedAt: participantDTO.updatedAt ?? (participantDTO.createdAt ?? Date()),
                     advanceCase: advanceCase,

--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -290,5 +290,31 @@ enum DataHealthCheckService {
                 )
             )
         }
+        
+        let casesMissingSelfExpenseLink = cases.filter {
+            $0.myShareAmount > 0 && $0.selfExpenseTransactionID == nil
+        }
+        if !casesMissingSelfExpenseLink.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .info,
+                    title: "代墊主檔缺少自己份額連結",
+                    detail: "共有 \(casesMissingSelfExpenseLink.count) 筆代墊主檔無 selfExpenseTransactionID。",
+                    recommendation: "舊資料可正常使用，但整單連動刪除時可能無法刪到自己份額交易。"
+                )
+            )
+        }
+        
+        let participantsMissingInitialTransferLink = participants.filter { $0.initialTransferGroupID == nil }
+        if !participantsMissingInitialTransferLink.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .info,
+                    title: "代墊對象缺少初始轉帳連結",
+                    detail: "共有 \(participantsMissingInitialTransferLink.count) 位對象無 initialTransferGroupID。",
+                    recommendation: "舊資料可正常使用，但整單連動刪除時可能無法完整刪除初始代墊轉帳。"
+                )
+            )
+        }
     }
 }

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -3,7 +3,23 @@ import SwiftData
 
 struct AdvancesView: View {
     @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
+    @StateObject private var currencyService = CurrencyService.shared
     @State private var showingAddAdvanceCase = false
+    @State private var viewMode: ViewMode = .byCase
+    
+    enum ViewMode: String, CaseIterable {
+        case byCase = "按代墊單"
+        case byParticipant = "按對象"
+    }
+    
+    struct ParticipantAggregate: Identifiable {
+        let id: String
+        let name: String
+        let caseCount: Int
+        let totalOwedMain: Decimal
+        let totalRepaidMain: Decimal
+        let totalRemainingMain: Decimal
+    }
     
     private var activeCases: [AdvanceCase] {
         advanceCases.filter { AdvanceService.outstandingAmount(for: $0) > 0 }
@@ -13,8 +29,60 @@ struct AdvancesView: View {
         advanceCases.filter { AdvanceService.outstandingAmount(for: $0) == 0 }
     }
     
+    private var participantAggregates: [ParticipantAggregate] {
+        var owedTotals: [String: Decimal] = [:]
+        var repaidTotals: [String: Decimal] = [:]
+        var remainingTotals: [String: Decimal] = [:]
+        var names: [String: String] = [:]
+        var caseSets: [String: Set<UUID>] = [:]
+        
+        for advanceCase in advanceCases {
+            for participant in advanceCase.participants {
+                let key = participant.debtAccount?.id.uuidString ?? "name::\(participant.name.lowercased())"
+                let name = participant.debtAccount?.name ?? participant.name
+                
+                names[key] = name
+                caseSets[key, default: []].insert(advanceCase.id)
+                
+                let owed = currencyService.convert(amount: participant.owedAmount, from: advanceCase.currencyCode)
+                let repaid = currencyService.convert(amount: participant.repaidAmount, from: advanceCase.currencyCode)
+                let remaining = currencyService.convert(amount: participant.remainingAmount, from: advanceCase.currencyCode)
+                
+                owedTotals[key, default: 0] += owed
+                repaidTotals[key, default: 0] += repaid
+                remainingTotals[key, default: 0] += remaining
+            }
+        }
+        
+        return names.keys.map { key in
+            ParticipantAggregate(
+                id: key,
+                name: names[key] ?? "未命名",
+                caseCount: caseSets[key]?.count ?? 0,
+                totalOwedMain: owedTotals[key, default: 0],
+                totalRepaidMain: repaidTotals[key, default: 0],
+                totalRemainingMain: remainingTotals[key, default: 0]
+            )
+        }
+        .sorted {
+            if $0.totalRemainingMain == $1.totalRemainingMain {
+                return $0.name < $1.name
+            }
+            return $0.totalRemainingMain > $1.totalRemainingMain
+        }
+    }
+    
     var body: some View {
         List {
+            Section("檢視方式") {
+                Picker("檢視方式", selection: $viewMode) {
+                    ForEach(ViewMode.allCases, id: \.self) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+            
             if advanceCases.isEmpty {
                 Section {
                     ContentUnavailableView(
@@ -24,21 +92,39 @@ struct AdvancesView: View {
                     )
                 }
             } else {
-                if !activeCases.isEmpty {
-                    Section("待收款") {
-                        ForEach(activeCases) { advanceCase in
-                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
-                                advanceCaseRow(advanceCase)
+                if viewMode == .byCase {
+                    if !activeCases.isEmpty {
+                        Section("待收款") {
+                            ForEach(activeCases) { advanceCase in
+                                NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
+                                    advanceCaseRow(advanceCase)
+                                }
                             }
                         }
                     }
-                }
-                
-                if !settledCases.isEmpty {
-                    Section("已結清") {
-                        ForEach(settledCases) { advanceCase in
-                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
-                                advanceCaseRow(advanceCase)
+                    
+                    if !settledCases.isEmpty {
+                        Section("已結清") {
+                            ForEach(settledCases) { advanceCase in
+                                NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
+                                    advanceCaseRow(advanceCase)
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    if participantAggregates.isEmpty {
+                        Section {
+                            ContentUnavailableView(
+                                "尚無對象彙總",
+                                systemImage: "person.2.slash",
+                                description: Text("目前沒有可統計的代墊對象。")
+                            )
+                        }
+                    } else {
+                        Section("對象總覽 (\(currencyService.mainCurrency))") {
+                            ForEach(participantAggregates) { item in
+                                participantAggregateRow(item)
                             }
                         }
                     }
@@ -46,6 +132,9 @@ struct AdvancesView: View {
             }
         }
         .navigationTitle("代墊追蹤")
+        .task {
+            await currencyService.fetchRates()
+        }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
@@ -94,15 +183,55 @@ struct AdvancesView: View {
         }
         .padding(.vertical, 4)
     }
+    
+    private func participantAggregateRow(_ item: ParticipantAggregate) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(item.name)
+                    .font(.headline)
+                Spacer()
+                Text(item.totalRemainingMain.formatted(.currency(code: currencyService.mainCurrency)))
+                    .foregroundStyle(item.totalRemainingMain == 0 ? .green : .red)
+            }
+            
+            HStack {
+                Text("欠款 \(item.totalOwedMain.formatted(.currency(code: currencyService.mainCurrency)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("已還 \(item.totalRepaidMain.formatted(.currency(code: currencyService.mainCurrency)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            Text("關聯代墊單：\(item.caseCount) 筆")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
 }
 
 struct AdvanceCaseDetailView: View {
+    private enum DeleteMode {
+        case trackingOnly
+        case trackingAndLinkedTransactions
+        
+        var deleteLinkedTransactions: Bool {
+            self == .trackingAndLinkedTransactions
+        }
+    }
+    
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
     
     let advanceCase: AdvanceCase
     @State private var selectedParticipantForRepayment: AdvanceParticipant?
     @State private var selectedParticipantForEdit: AdvanceParticipant?
     @State private var repaymentToRollback: AdvanceRepayment?
+    @State private var selectedDeleteMode: DeleteMode?
+    @State private var showingDeleteModeDialog = false
+    @State private var showingDeleteConfirm = false
     @State private var showingRollbackAlert = false
     @State private var showingError = false
     @State private var errorMessage = ""
@@ -143,6 +272,14 @@ struct AdvanceCaseDetailView: View {
                     title: "帳務儲存",
                     value: "借貸帳戶轉帳"
                 )
+            }
+            
+            Section {
+                Button(role: .destructive) {
+                    showingDeleteModeDialog = true
+                } label: {
+                    Label("刪除此代墊單", systemImage: "trash")
+                }
             }
             
             Section("對象還款狀態") {
@@ -186,6 +323,33 @@ struct AdvanceCaseDetailView: View {
         }
         .sheet(item: $selectedParticipantForEdit) { participant in
             EditAdvanceParticipantView(advanceCase: advanceCase, participant: participant)
+        }
+        .confirmationDialog("刪除代墊單", isPresented: $showingDeleteModeDialog, titleVisibility: .visible) {
+            Button("只刪追蹤記錄", role: .destructive) {
+                selectedDeleteMode = .trackingOnly
+                showingDeleteConfirm = true
+            }
+            Button("刪除追蹤與相關交易", role: .destructive) {
+                selectedDeleteMode = .trackingAndLinkedTransactions
+                showingDeleteConfirm = true
+            }
+            Button("取消", role: .cancel) {}
+        } message: {
+            Text("可選擇只刪代墊追蹤，或同時刪除建立此代墊時產生的借貸轉帳與自己份額支出。")
+        }
+        .alert("確認刪除此代墊單？", isPresented: $showingDeleteConfirm) {
+            Button("取消", role: .cancel) {
+                selectedDeleteMode = nil
+            }
+            Button("確認刪除", role: .destructive) {
+                deleteAdvanceCase()
+            }
+        } message: {
+            if case .trackingAndLinkedTransactions = selectedDeleteMode {
+                Text("將刪除代墊追蹤資料，並嘗試刪除關聯借貸轉帳與自己份額支出。此操作無法復原。")
+            } else {
+                Text("將只刪除代墊追蹤資料，原本的實際交易紀錄會保留。此操作無法復原。")
+            }
         }
         .alert("確認沖銷還款？", isPresented: $showingRollbackAlert, presenting: repaymentToRollback) { repayment in
             Button("取消", role: .cancel) {}
@@ -312,6 +476,22 @@ struct AdvanceCaseDetailView: View {
                 repayment: repayment,
                 modelContext: modelContext
             )
+        } catch {
+            errorMessage = error.localizedDescription
+            showingError = true
+        }
+    }
+    
+    private func deleteAdvanceCase() {
+        guard let mode = selectedDeleteMode else { return }
+        
+        do {
+            _ = try AdvanceService.deleteAdvanceCase(
+                advanceCase,
+                deleteLinkedTransactions: mode.deleteLinkedTransactions,
+                modelContext: modelContext
+            )
+            dismiss()
         } catch {
             errorMessage = error.localizedDescription
             showingError = true


### PR DESCRIPTION
## Summary
- add optional linked-record metadata to advance models (`selfExpenseTransactionID`, `initialTransferGroupID`)
- add `AdvanceService.deleteAdvanceCase(...)` to support deleting tracking only or deleting tracking + linked transactions
- add advance detail UI delete flow with explicit mode selection and destructive confirmation
- add participant aggregate mode in Advances list (`按對象`) with totals converted to main currency
- bump backup schema to `1.5` and keep backward-compatible import of old JSON backups
- add health-check info items for legacy advance records that miss new linkage fields

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' build`
