### PR TITLE
feat: add legacy advance-link repair tool

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -59,6 +59,21 @@ enum AdvanceService {
         let missingLinkedRecordCount: Int
     }
     
+    struct LegacyLinkRepairResult {
+        let updatedCaseLinkCount: Int
+        let unresolvedCaseLinkCount: Int
+        let updatedParticipantLinkCount: Int
+        let unresolvedParticipantLinkCount: Int
+        
+        var totalUpdated: Int {
+            updatedCaseLinkCount + updatedParticipantLinkCount
+        }
+        
+        var totalUnresolved: Int {
+            unresolvedCaseLinkCount + unresolvedParticipantLinkCount
+        }
+    }
+    
     private static let roundingTolerance = Decimal(string: "0.0001") ?? 0.0001
     
     static func totalAdvanced(for advanceCase: AdvanceCase) -> Decimal {
@@ -410,5 +425,213 @@ enum AdvanceService {
             deletedTransactionCount: deletedTransactionCount,
             missingLinkedRecordCount: missingLinkedRecordCount
         )
+    }
+    
+    @MainActor
+    static func repairLegacyLinks(modelContext: ModelContext) throws -> LegacyLinkRepairResult {
+        let advanceCases = try modelContext.fetch(FetchDescriptor<AdvanceCase>())
+        let participants = try modelContext.fetch(FetchDescriptor<AdvanceParticipant>())
+        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        
+        var updatedCaseLinkCount = 0
+        var unresolvedCaseLinkCount = 0
+        var updatedParticipantLinkCount = 0
+        var unresolvedParticipantLinkCount = 0
+        
+        let groupedTransfers = Dictionary(
+            grouping: transactions.filter { $0.type == .transfer && $0.transferGroupID != nil }
+        ) { $0.transferGroupID! }
+        
+        var usedExpenseIDs = Set<UUID>(advanceCases.compactMap(\.selfExpenseTransactionID))
+        var usedGroupIDs = Set<UUID>(participants.compactMap(\.initialTransferGroupID))
+        usedGroupIDs.formUnion(repayments.compactMap(\.linkedTransferGroupID))
+        
+        let now = Date()
+        let calendar = Calendar.current
+        
+        for advanceCase in advanceCases where advanceCase.myShareAmount > 0 && advanceCase.selfExpenseTransactionID == nil {
+            guard let payerAccount = advanceCase.payerAccount else {
+                unresolvedCaseLinkCount += 1
+                continue
+            }
+            
+            let targetAmount = -abs(advanceCase.myShareAmount)
+            let candidates = transactions.filter { tx in
+                tx.type == .expense
+                    && tx.account?.id == payerAccount.id
+                    && tx.currencyCode == advanceCase.currencyCode
+                    && decimalEquals(tx.amount, targetAmount)
+                    && calendar.isDate(tx.date, inSameDayAs: advanceCase.date)
+                    && !usedExpenseIDs.contains(tx.id)
+            }
+            
+            if let best = bestSelfExpenseCandidate(candidates, advanceCase: advanceCase) {
+                advanceCase.selfExpenseTransactionID = best.id
+                advanceCase.updatedAt = now
+                usedExpenseIDs.insert(best.id)
+                updatedCaseLinkCount += 1
+            } else {
+                unresolvedCaseLinkCount += 1
+            }
+        }
+        
+        for participant in participants where participant.initialTransferGroupID == nil {
+            guard
+                let advanceCase = participant.advanceCase,
+                let payerAccount = advanceCase.payerAccount,
+                let debtAccount = participant.debtAccount
+            else {
+                unresolvedParticipantLinkCount += 1
+                continue
+            }
+            
+            let targetOutgoing = -abs(participant.owedAmount)
+            let targetIncoming = abs(participant.owedAmount)
+            let participantName = participant.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let payerName = payerAccount.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            
+            var bestGroupID: UUID?
+            var bestScore = Int.min
+            var bestDateDiff = TimeInterval.greatestFiniteMagnitude
+            
+            for (groupID, group) in groupedTransfers {
+                if usedGroupIDs.contains(groupID) {
+                    continue
+                }
+                
+                let outgoingCandidates = group.filter { tx in
+                    tx.account?.id == payerAccount.id
+                        && tx.currencyCode == advanceCase.currencyCode
+                        && decimalEquals(tx.amount, targetOutgoing)
+                }
+                if outgoingCandidates.isEmpty {
+                    continue
+                }
+                
+                let incomingCandidates = group.filter { tx in
+                    tx.account?.id == debtAccount.id
+                        && tx.currencyCode == advanceCase.currencyCode
+                        && decimalEquals(tx.amount, targetIncoming)
+                }
+                if incomingCandidates.isEmpty {
+                    continue
+                }
+                
+                let outgoingByDate = outgoingCandidates.sorted {
+                    abs($0.date.timeIntervalSince(advanceCase.date)) < abs($1.date.timeIntervalSince(advanceCase.date))
+                }
+                let incomingByDate = incomingCandidates.sorted {
+                    abs($0.date.timeIntervalSince(advanceCase.date)) < abs($1.date.timeIntervalSince(advanceCase.date))
+                }
+                
+                guard let outgoing = outgoingByDate.first, let incoming = incomingByDate.first else {
+                    continue
+                }
+                
+                var score = 0
+                if outgoing.note.contains("代墊") {
+                    score += 2
+                }
+                if !participantName.isEmpty && outgoing.note.localizedCaseInsensitiveContains(participantName) {
+                    score += 3
+                }
+                if !payerName.isEmpty && incoming.note.localizedCaseInsensitiveContains(payerName) {
+                    score += 1
+                }
+                
+                let outgoingDateDiff = abs(outgoing.date.timeIntervalSince(advanceCase.date))
+                let incomingDateDiff = abs(incoming.date.timeIntervalSince(advanceCase.date))
+                let dateDiff = min(outgoingDateDiff, incomingDateDiff)
+                
+                if outgoingDateDiff <= 5 * 60 {
+                    score += 2
+                } else if calendar.isDate(outgoing.date, inSameDayAs: advanceCase.date) {
+                    score += 1
+                }
+                
+                if incomingDateDiff <= 5 * 60 {
+                    score += 1
+                }
+                
+                if score > bestScore || (score == bestScore && dateDiff < bestDateDiff) {
+                    bestScore = score
+                    bestDateDiff = dateDiff
+                    bestGroupID = groupID
+                }
+            }
+            
+            if let groupID = bestGroupID {
+                participant.initialTransferGroupID = groupID
+                participant.updatedAt = now
+                advanceCase.updatedAt = now
+                usedGroupIDs.insert(groupID)
+                updatedParticipantLinkCount += 1
+            } else {
+                unresolvedParticipantLinkCount += 1
+            }
+        }
+        
+        if updatedCaseLinkCount > 0 || updatedParticipantLinkCount > 0 {
+            try modelContext.save()
+        }
+        
+        return LegacyLinkRepairResult(
+            updatedCaseLinkCount: updatedCaseLinkCount,
+            unresolvedCaseLinkCount: unresolvedCaseLinkCount,
+            updatedParticipantLinkCount: updatedParticipantLinkCount,
+            unresolvedParticipantLinkCount: unresolvedParticipantLinkCount
+        )
+    }
+    
+    private static func bestSelfExpenseCandidate(
+        _ candidates: [FinancialTransaction],
+        advanceCase: AdvanceCase
+    ) -> FinancialTransaction? {
+        guard !candidates.isEmpty else { return nil }
+        
+        let trimmedTitle = advanceCase.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNote = advanceCase.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        var bestCandidate: FinancialTransaction?
+        var bestScore = Int.min
+        var bestDateDiff = TimeInterval.greatestFiniteMagnitude
+        
+        for candidate in candidates {
+            var score = 0
+            
+            if candidate.note.contains("自己份額") {
+                score += 4
+            }
+            if !trimmedTitle.isEmpty && candidate.note.localizedCaseInsensitiveContains(trimmedTitle) {
+                score += 2
+            }
+            if !trimmedNote.isEmpty && candidate.note.localizedCaseInsensitiveContains(trimmedNote) {
+                score += 3
+            }
+            if let expenseCategoryID = advanceCase.expenseCategory?.id,
+               candidate.category?.id == expenseCategoryID {
+                score += 2
+            }
+            
+            let dateDiff = abs(candidate.date.timeIntervalSince(advanceCase.date))
+            if dateDiff <= 5 * 60 {
+                score += 2
+            } else if dateDiff <= 60 * 60 {
+                score += 1
+            }
+            
+            if score > bestScore || (score == bestScore && dateDiff < bestDateDiff) {
+                bestScore = score
+                bestDateDiff = dateDiff
+                bestCandidate = candidate
+            }
+        }
+        
+        return bestCandidate
+    }
+    
+    private static func decimalEquals(_ lhs: Decimal, _ rhs: Decimal) -> Bool {
+        abs(lhs - rhs) <= roundingTolerance
     }
 }

--- a/AI 記帳/Views/Tools/DataHealthCheckView.swift
+++ b/AI 記帳/Views/Tools/DataHealthCheckView.swift
@@ -6,6 +6,8 @@ struct DataHealthCheckView: View {
     
     @State private var report: HealthReport?
     @State private var isRunning = false
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
     
     var body: some View {
         List {
@@ -16,6 +18,17 @@ struct DataHealthCheckView: View {
                     Text("尚未執行檢查")
                         .foregroundStyle(.secondary)
                 }
+            }
+            
+            Section("修復工具") {
+                Button(isRunning ? "處理中..." : "修復代墊舊資料連結") {
+                    repairAdvanceLegacyLinks()
+                }
+                .disabled(isRunning)
+                
+                Text("補齊舊資料缺少的連結欄位，讓整單連動刪除可更完整刪除相關交易。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
             
             if let report {
@@ -37,6 +50,11 @@ struct DataHealthCheckView: View {
             if report == nil {
                 runCheck()
             }
+        }
+        .alert("處理結果", isPresented: $showingAlert) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(alertMessage)
         }
     }
     
@@ -104,5 +122,25 @@ struct DataHealthCheckView: View {
         isRunning = true
         report = DataHealthCheckService.run(modelContext: modelContext)
         isRunning = false
+    }
+    
+    private func repairAdvanceLegacyLinks() {
+        isRunning = true
+        
+        do {
+            let result = try AdvanceService.repairLegacyLinks(modelContext: modelContext)
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            
+            alertMessage = """
+            已更新 \(result.totalUpdated) 筆連結。
+            - 代墊主檔：修復 \(result.updatedCaseLinkCount) / 未修復 \(result.unresolvedCaseLinkCount)
+            - 代墊對象：修復 \(result.updatedParticipantLinkCount) / 未修復 \(result.unresolvedParticipantLinkCount)
+            """
+        } catch {
+            alertMessage = "修復失敗：\(error.localizedDescription)"
+        }
+        
+        isRunning = false
+        showingAlert = true
     }
 }


### PR DESCRIPTION
## Summary
- add `AdvanceService.repairLegacyLinks(modelContext:)` to backfill old advance linkage fields
- attempt to repair two legacy links:
  - `AdvanceCase.selfExpenseTransactionID`
  - `AdvanceParticipant.initialTransferGroupID`
- use amount/currency/account/date/note heuristics and avoid reusing already-linked records
- add a new repair action in Data Health Check page: `修復代墊舊資料連結`
- re-run health checks after repair and show detailed repaired/unresolved counts

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' build`
