### PR TITLE
fix: drill down chart categories and exclude asset adjustments from income

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -49,6 +49,78 @@ struct AI___App: App {
         }
     }
     
+    private static func repairLegacyAssetAdjustmentTransactionsIfNeeded(storeURL: URL) {
+        guard FileManager.default.fileExists(atPath: storeURL.path) else {
+            return
+        }
+        
+        var db: OpaquePointer?
+        let openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        let openResult = sqlite3_open_v2(storeURL.path, &db, openFlags, nil)
+        guard openResult == SQLITE_OK, let db else {
+            if let errorMessage = sqlite3_errmsg(db) {
+                print("⚠️ 無法開啟資料庫修復資產調整資料: \(String(cString: errorMessage))")
+            }
+            if db != nil {
+                sqlite3_close(db)
+            }
+            return
+        }
+        defer { sqlite3_close(db) }
+        
+        guard tableExists("ZFINANCIALTRANSACTION", db: db),
+              columnExists("ZTYPE", in: "ZFINANCIALTRANSACTION", db: db),
+              columnExists("ZNOTE", in: "ZFINANCIALTRANSACTION", db: db),
+              columnExists("ZCATEGORY", in: "ZFINANCIALTRANSACTION", db: db) else {
+            return
+        }
+        
+        let beforeChanges = sqlite3_total_changes(db)
+        
+        let normalizeTypeSQL = """
+        UPDATE ZFINANCIALTRANSACTION
+        SET ZTYPE = 'Transfer'
+        WHERE ZTYPE IN ('Income', 'Expense')
+          AND ZCATEGORY IS NULL
+          AND (
+                ZNOTE LIKE '初始餘額 (%'
+             OR ZNOTE = '餘額修正'
+             OR ZNOTE LIKE '餘額修正 %'
+             OR ZNOTE LIKE '[資產調整]%'
+          );
+        """
+        
+        let updateTypeResult = sqlite3_exec(db, normalizeTypeSQL, nil, nil, nil)
+        guard updateTypeResult == SQLITE_OK else {
+            if let errorMessage = sqlite3_errmsg(db) {
+                print("⚠️ 舊資產調整交易修復失敗: \(String(cString: errorMessage))")
+            }
+            return
+        }
+        
+        if columnExists("ZTRANSFERSIDE", in: "ZFINANCIALTRANSACTION", db: db),
+           columnExists("ZAMOUNT", in: "ZFINANCIALTRANSACTION", db: db) {
+            let repairSideSQL = """
+            UPDATE ZFINANCIALTRANSACTION
+            SET ZTRANSFERSIDE = CASE WHEN ZAMOUNT >= 0 THEN 'Incoming' ELSE 'Outgoing' END
+            WHERE ZTYPE = 'Transfer'
+              AND ZTRANSFERSIDE IS NULL
+              AND (
+                    ZNOTE LIKE '初始餘額 (%'
+                 OR ZNOTE = '餘額修正'
+                 OR ZNOTE LIKE '餘額修正 %'
+                 OR ZNOTE LIKE '[資產調整]%'
+              );
+            """
+            _ = sqlite3_exec(db, repairSideSQL, nil, nil, nil)
+        }
+        
+        let repairedCount = sqlite3_total_changes(db) - beforeChanges
+        if repairedCount > 0 {
+            print("✅ 已修復舊版資產調整交易 \(repairedCount) 筆（不再計入收支）")
+        }
+    }
+    
     private static func tableExists(_ name: String, db: OpaquePointer) -> Bool {
         let sql = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1;"
         var statement: OpaquePointer?
@@ -65,6 +137,28 @@ struct AI___App: App {
         let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_text(statement, 1, name, -1, transient)
         return sqlite3_step(statement) == SQLITE_ROW
+    }
+    
+    private static func columnExists(_ columnName: String, in tableName: String, db: OpaquePointer) -> Bool {
+        let sql = "PRAGMA table_info(\(tableName));"
+        var statement: OpaquePointer?
+        defer {
+            if statement != nil {
+                sqlite3_finalize(statement)
+            }
+        }
+        
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return false
+        }
+        
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let cString = sqlite3_column_text(statement, 1) else { continue }
+            if String(cString: cString) == columnName {
+                return true
+            }
+        }
+        return false
     }
     
     var sharedModelContainer: ModelContainer = {
@@ -100,6 +194,8 @@ struct AI___App: App {
         
         // 4. 啟動前先修復舊資料的 Category.kind，避免 enum 強制轉型崩潰
         repairLegacyCategoryKindsIfNeeded(storeURL: storeURL)
+        // 5. 啟動前修復舊版「其他幣種餘額/餘額修正」被誤記為收支的資料
+        repairLegacyAssetAdjustmentTransactionsIfNeeded(storeURL: storeURL)
         
         let modelConfiguration = ModelConfiguration(
             schema: schema,

--- a/AI 記帳/Views/Accounts/AddAccountView.swift
+++ b/AI 記帳/Views/Accounts/AddAccountView.swift
@@ -88,7 +88,7 @@ struct AddAccountView: View {
                     }) {
                         Label("新增其他幣種餘額", systemImage: "plus.circle")
                     }
-                } header: { Text("其他幣種餘額 (選填)") } footer: { Text("這些餘額將以「初始餘額」交易的形式記錄。") }
+                } header: { Text("其他幣種餘額 (選填)") } footer: { Text("這些餘額會記為「資產調整」交易，不計入收入/支出報表。") }
                 
                 if type == .debt && !balanceString.isEmpty && balanceString != "0" && balanceString != "-" {
                     Section("主幣種資金流向 (選填)") {
@@ -162,7 +162,15 @@ struct AddAccountView: View {
         
         for item in additionalBalances {
             if let amount = Decimal(string: item.amountString), amount != 0 {
-                let tx = FinancialTransaction(amount: amount, currencyCode: item.currency, date: now, note: "\(note) (\(item.currency))", type: amount >= 0 ? .income : .expense, account: newAccount)
+                let tx = FinancialTransaction(
+                    amount: amount,
+                    currencyCode: item.currency,
+                    date: now,
+                    note: "[資產調整] \(note) (\(item.currency))",
+                    type: .transfer,
+                    transferSide: amount >= 0 ? .incoming : .outgoing,
+                    account: newAccount
+                )
                 modelContext.insert(tx)
             }
         }

--- a/AI 記帳/Views/Accounts/EditAccountView.swift
+++ b/AI 記帳/Views/Accounts/EditAccountView.swift
@@ -10,7 +10,7 @@ struct EditAccountView: View {
     
     @State private var adjustmentAmountString: String = ""
     @State private var adjustmentCurrency: String = "HKD"
-    @State private var adjustmentNote: String = "餘額修正"
+    @State private var adjustmentNote: String = "資產餘額修正"
     
     @FocusState private var isAmountFocused: Bool
     
@@ -79,7 +79,7 @@ struct EditAccountView: View {
                 
                 Section(
                     header: Text("新增餘額調整 (其他幣種)"),
-                    footer: Text("這會新增一筆「餘額修正」交易來調整該幣種的總額。")
+                    footer: Text("這會新增一筆「資產調整」交易來調整該幣種總額，不計入收入/支出報表。")
                 ) {
                     HStack {
                         Picker("", selection: $adjustmentCurrency) {
@@ -122,14 +122,21 @@ struct EditAccountView: View {
     
     private func addAdjustment() {
         guard let amount = Decimal(string: adjustmentAmountString), amount != 0 else { return }
+        let trimmedNote = adjustmentNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalNote = trimmedNote.isEmpty ? "[資產調整] 餘額修正" : "[資產調整] \(trimmedNote)"
         
         let tx = FinancialTransaction(
-            amount: amount, currencyCode: adjustmentCurrency, date: Date(), note: adjustmentNote,
-            type: amount >= 0 ? .income : .expense, account: account
+            amount: amount,
+            currencyCode: adjustmentCurrency,
+            date: Date(),
+            note: finalNote,
+            type: .transfer,
+            transferSide: amount >= 0 ? .incoming : .outgoing,
+            account: account
         )
         modelContext.insert(tx)
         
         adjustmentAmountString = ""
-        adjustmentNote = "餘額修正"
+        adjustmentNote = "資產餘額修正"
     }
 }

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -14,8 +14,8 @@ struct ChartsView: View {
     @State private var flowMode: FlowMode = .expense
     
     // 互動狀態
-    @State private var selectedSegmentName: String?
     @State private var selectedTagForDetail: String?
+    @State private var selectedReportDetail: ReportDetail?
     
     enum ChartMode: String, CaseIterable {
         case category = "依分類"
@@ -48,6 +48,12 @@ struct ChartsView: View {
         }
     }
     
+    struct ReportDetail: Identifiable {
+        let id = UUID()
+        let title: String
+        let transactions: [FinancialTransaction]
+    }
+    
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -73,13 +79,13 @@ struct ChartsView: View {
                             ForEach(FlowMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
                         }
                         .pickerStyle(.segmented)
-                        .onChange(of: flowMode) { selectedTagForDetail = nil; selectedSegmentName = nil }
+                        .onChange(of: flowMode) { selectedTagForDetail = nil }
                         
                         Picker("模式", selection: $chartMode) {
                             ForEach(ChartMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
                         }
                         .pickerStyle(.segmented)
-                        .onChange(of: chartMode) { selectedTagForDetail = nil; selectedSegmentName = nil }
+                        .onChange(of: chartMode) { selectedTagForDetail = nil }
                     }
                 }
                 .padding()
@@ -124,6 +130,9 @@ struct ChartsView: View {
             .sheet(isPresented: $showingFilterSheet) {
                 DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
             }
+            .sheet(item: $selectedReportDetail) { detail in
+                ReportTransactionListView(title: detail.title, transactions: detail.transactions)
+            }
         }
     }
     
@@ -135,15 +144,19 @@ struct ChartsView: View {
                 .padding(.horizontal)
             
             LazyVStack(spacing: 16) {
-                ForEach(currentData, id: \.name) { item in
+                ForEach(currentData, id: \.key) { item in
                     Button(action: {
                         if chartMode == .tag {
-                            withAnimation { selectedTagForDetail = item.name; selectedSegmentName = nil }
+                            withAnimation { selectedTagForDetail = item.name }
                         } else {
-                            withAnimation { selectedSegmentName = (selectedSegmentName == item.name) ? nil : item.name }
+                            presentTransactions(for: item)
                         }
                     }) {
-                        rowView(item: item, total: totalAmount(data: currentData), isDrillDown: chartMode == .tag)
+                        rowView(
+                            item: item,
+                            total: totalAmount(data: currentData),
+                            trailingIcon: chartMode == .tag ? "chevron.right" : "list.bullet"
+                        )
                     }
                     .buttonStyle(.plain)
                 }
@@ -156,7 +169,7 @@ struct ChartsView: View {
     var tagDetailView: some View {
         VStack(spacing: 24) {
             HStack {
-                Button(action: { withAnimation { selectedTagForDetail = nil; selectedSegmentName = nil } }) {
+                Button(action: { withAnimation { selectedTagForDetail = nil } }) {
                     HStack {
                         Image(systemName: "arrow.left.circle.fill").font(.title2)
                         Text(selectedTagForDetail ?? "").font(.title3).bold()
@@ -176,11 +189,11 @@ struct ChartsView: View {
                     .padding(.horizontal)
                 
                 LazyVStack(spacing: 16) {
-                    ForEach(detailData, id: \.name) { item in
+                    ForEach(detailData, id: \.key) { item in
                         Button(action: {
-                            withAnimation { selectedSegmentName = (selectedSegmentName == item.name) ? nil : item.name }
+                            presentTransactions(for: item, tagName: selectedTagForDetail)
                         }) {
-                            rowView(item: item, total: totalAmount(data: detailData), isDrillDown: false)
+                            rowView(item: item, total: totalAmount(data: detailData), trailingIcon: "list.bullet")
                         }
                         .buttonStyle(.plain)
                     }
@@ -194,31 +207,27 @@ struct ChartsView: View {
     // MARK: - 通用組件
     func chartView(data: [ChartData]) -> some View {
         let total = totalAmount(data: data)
-        let displayTotal = selectedSegmentName != nil ? (data.first(where: { $0.name == selectedSegmentName })?.amount ?? 0) : total
         return ZStack {
-            Chart(data, id: \.name) { item in
+            Chart(data, id: \.key) { item in
                 SectorMark(
                     angle: .value("金額", item.amount),
                     innerRadius: .ratio(0.65),
-                    outerRadius: selectedSegmentName == item.name ? .ratio(1.0) : .ratio(0.9),
+                    outerRadius: .ratio(0.9),
                     angularInset: 2.0
                 )
                 .cornerRadius(6)
                 .foregroundStyle(item.color)
-                .opacity(selectedSegmentName == nil ? 1.0 : (selectedSegmentName == item.name ? 1.0 : 0.3))
             }
-            .chartAngleSelection(value: $selectedSegmentName)
             VStack {
-                Text(selectedSegmentName ?? flowMode.totalTitle).font(.callout).foregroundStyle(.secondary)
-                Text(displayTotal.formatted(.currency(code: currencyService.mainCurrency)))
+                Text(flowMode.totalTitle).font(.callout).foregroundStyle(.secondary)
+                Text(total.formatted(.currency(code: currencyService.mainCurrency)))
                     .font(.title2).bold().foregroundStyle(.primary)
             }
         }
     }
     
-    func rowView(item: ChartData, total: Decimal, isDrillDown: Bool) -> some View {
+    func rowView(item: ChartData, total: Decimal, trailingIcon: String) -> some View {
         let percent = total > 0 ? (item.amount / total * 100) : 0
-        let isSelected = (selectedSegmentName == item.name)
         return HStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 4).fill(item.color).frame(width: 4, height: 40)
             VStack(alignment: .leading, spacing: 2) {
@@ -235,21 +244,22 @@ struct ChartsView: View {
                 Text(item.amount.formatted(.currency(code: currencyService.mainCurrency))).font(.body).bold()
                 HStack(spacing: 4) {
                     Text("\(percent.formatted(.number.precision(.fractionLength(1))))%")
-                    if isDrillDown { Image(systemName: "chevron.right") }
+                    Image(systemName: trailingIcon)
                 }.font(.caption).foregroundStyle(.secondary)
             }
         }
         .padding(12)
-        .background(isSelected ? Color.blue.opacity(0.1) : Color(uiColor: .secondarySystemBackground))
+        .background(Color(uiColor: .secondarySystemBackground))
         .cornerRadius(12)
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(isSelected ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1))
     }
     
     // MARK: - Data Logic
     struct ChartData {
+        let key: String
         let name: String
         let amount: Decimal
         let color: Color
+        let transactions: [FinancialTransaction]
     }
     
     var currentData: [ChartData] {
@@ -260,22 +270,42 @@ struct ChartsView: View {
                 let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
                 return sum0 > sum1
             }
-            return sorted.enumerated().map { (index, item) in
+            return sorted.map { item in
                 let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
                 let category = item.value.compactMap { $0.category }.first
                 let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
-                return ChartData(name: category?.name ?? "未分類", amount: total, color: displayColor)
+                return ChartData(
+                    key: item.key,
+                    name: category?.name ?? "未分類",
+                    amount: total,
+                    color: displayColor,
+                    transactions: item.value
+                )
             }
         } else {
             var tagDict: [String: Decimal] = [:]
+            var tagTransactions: [String: [FinancialTransaction]] = [:]
             for tx in filteredTransactions {
                 let amount = currencyService.convert(amount: abs(tx.amount), from: tx.currencyCode)
-                if tx.tags.isEmpty { tagDict["無標籤", default: 0] += amount }
-                else { for tag in tx.tags { tagDict[tag.name, default: 0] += amount } }
+                if tx.tags.isEmpty {
+                    tagDict["無標籤", default: 0] += amount
+                    tagTransactions["無標籤", default: []].append(tx)
+                } else {
+                    for tag in tx.tags {
+                        tagDict[tag.name, default: 0] += amount
+                        tagTransactions[tag.name, default: []].append(tx)
+                    }
+                }
             }
             let sorted = tagDict.sorted { $0.value > $1.value }
             return sorted.enumerated().map { (index, item) in
-                ChartData(name: item.key, amount: item.value, color: Color.generateDistinctColor(index: index, total: sorted.count))
+                ChartData(
+                    key: item.key,
+                    name: item.key,
+                    amount: item.value,
+                    color: Color.generateDistinctColor(index: index, total: sorted.count),
+                    transactions: tagTransactions[item.key] ?? []
+                )
             }
         }
     }
@@ -291,12 +321,31 @@ struct ChartsView: View {
             let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
             return sum0 > sum1
         }
-        return sorted.enumerated().map { (index, item) in
+        return sorted.map { item in
             let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
             let category = item.value.compactMap { $0.category }.first
             let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
-            return ChartData(name: category?.name ?? "未分類", amount: total, color: displayColor)
+            return ChartData(
+                key: item.key,
+                name: category?.name ?? "未分類",
+                amount: total,
+                color: displayColor,
+                transactions: item.value
+            )
         }
+    }
+    
+    func presentTransactions(for item: ChartData, tagName: String? = nil) {
+        let flowLabel = flowMode == .income ? "收入" : "支出"
+        let title: String
+        if let tagName {
+            title = "\(flowLabel)・\(tagName)・\(item.name)"
+        } else {
+            title = "\(flowLabel)・\(item.name)"
+        }
+        
+        let sortedTransactions = item.transactions.sorted { $0.date > $1.date }
+        selectedReportDetail = ReportDetail(title: title, transactions: sortedTransactions)
     }
     
     func totalAmount(data: [ChartData]) -> Decimal { data.reduce(0) { $0 + $1.amount } }
@@ -331,6 +380,50 @@ struct ChartsView: View {
         let key = BudgetService.monthKey(from: Date())
         return BudgetService.statuses(for: key, budgets: budgets, transactions: transactions, currencyService: currencyService)
             .filter { $0.ratio >= 1 }
+    }
+}
+
+private struct ReportTransactionListView: View {
+    let title: String
+    let transactions: [FinancialTransaction]
+    
+    private var groupedTransactions: [(title: String, items: [FinancialTransaction])] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy/MM/dd (E)"
+        let grouped = Dictionary(grouping: transactions) { tx in
+            formatter.string(from: tx.date)
+        }
+        return grouped
+            .sorted { lhs, rhs in
+                guard let leftDate = lhs.value.first?.date, let rightDate = rhs.value.first?.date else {
+                    return lhs.key > rhs.key
+                }
+                return leftDate > rightDate
+            }
+            .map { ($0.key, $0.value.sorted { $0.date > $1.date }) }
+    }
+    
+    var body: some View {
+        NavigationStack {
+            Group {
+                if transactions.isEmpty {
+                    ContentUnavailableView("找不到交易", systemImage: "tray")
+                } else {
+                    List {
+                        ForEach(groupedTransactions, id: \.title) { group in
+                            Section(group.title) {
+                                ForEach(group.items) { tx in
+                                    TransactionRow(transaction: tx)
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -211,6 +211,12 @@ struct TransactionsListView: View {
         let calendar = Calendar.current
         let timeFiltered = transactions.filter { tx in
             if tx.type == .transfer && tx.amount > 0 { return false }
+            if tx.type == .transfer,
+               tx.transferGroupID == nil,
+               tx.linkedTransactionID == nil,
+               isAssetAdjustment(note: tx.note) {
+                return false
+            }
             switch filterType {
             case .all: return true
             case .year: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .year)
@@ -325,5 +331,9 @@ struct TransactionsListView: View {
         }
         
         return output
+    }
+    
+    private func isAssetAdjustment(note: String) -> Bool {
+        note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("[資產調整]")
     }
 }


### PR DESCRIPTION
## Summary
- change chart interaction: tapping category/tag breakdown row opens transaction list instead of pie zoom
- add report detail sheet to inspect transactions behind each chart segment
- treat add/edit account multi-currency balance adjustments as transfer (asset adjustment) rather than income/expense
- hide standalone asset-adjustment transfers from transactions list
- add startup SQLite repair to migrate legacy uncategorized income/expense balance-adjustment rows to transfer

## Why
- user could see uncategorized income in report but could not locate the entry
- cross-currency account holdings should affect asset estimate, not income reporting

## Validation
- xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' build
- simulator DB query confirms legacy row converted from Income to Transfer