### PR TITLE
Refactor Android shell toward iOS parity

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/ai/ReceiptScanService.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/ai/ReceiptScanService.kt
@@ -1,0 +1,147 @@
+package org.duckdns.lhfser.aiaccounting.core.ai
+
+import android.util.Base64
+import com.google.gson.Gson
+import java.io.IOException
+import java.math.BigDecimal
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+data class ReceiptInfo(
+    val amount: BigDecimal,
+    val currency: String,
+    val date: String,
+    val time: String?,
+    val merchant: String,
+    val categoryName: String,
+    val note: String
+)
+
+class ReceiptScanService(
+    private val settingsStore: GeminiSettingsStore
+) {
+    private val gson = Gson()
+    private val modelName = "gemini-flash-latest"
+
+    suspend fun analyzeReceipt(
+        imageBytes: ByteArray,
+        userNote: String,
+        categoryCandidates: List<String>
+    ): ReceiptInfo = withContext(Dispatchers.IO) {
+        val apiKey = settingsStore.apiKey
+        require(apiKey.isNotBlank()) { "未設定 Gemini API Key。" }
+
+        val categoryList = if (categoryCandidates.isEmpty()) "無可用分類，請回傳「未分類」" else categoryCandidates.joinToString(", ")
+        val prompt = """
+            You are an AI assistant for a personal finance app.
+            Analyze the attached receipt image and the user's specific instruction: \"$userNote\".
+            Available user categories (must prioritize from this list): $categoryList
+
+            Task:
+            1. Identify the Merchant Name. Translate to Traditional Chinese when possible.
+            2. Identify the Date (format YYYY-MM-DD). If year is missing, assume the current year.
+            3. Identify the Time (format HH:mm, 24-hour). If missing, return null.
+            4. Calculate the Total Amount relevant to the user.
+               - If the user note mentions splitting, only sum the user-relevant part.
+               - Otherwise use the receipt grand total.
+            5. Suggest a Category.
+               - Prefer a close match from the provided category list.
+               - If none fits, return \"未分類\".
+            6. Detect the currency code (HKD, USD, TWD, JPY, CNY, EUR, GBP). Default to HKD if unknown.
+            7. Summarize the purchase in Traditional Chinese.
+
+            Output strict JSON only, without markdown fences, with this structure:
+            {
+              "amount": 100.5,
+              "currency": "HKD",
+              "date": "2026-04-01",
+              "time": "13:45",
+              "merchant": "麥當勞",
+              "categoryName": "餐飲",
+              "note": "午餐"
+            }
+        """.trimIndent()
+
+        val requestBody = gson.toJson(
+            mapOf(
+                "contents" to listOf(
+                    mapOf(
+                        "parts" to listOf(
+                            mapOf("text" to prompt),
+                            mapOf(
+                                "inlineData" to mapOf(
+                                    "mimeType" to "image/jpeg",
+                                    "data" to Base64.encodeToString(imageBytes, Base64.NO_WRAP)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val responseText = postGenerateContent(apiKey, requestBody)
+        val response = gson.fromJson(responseText, GenerateContentResponse::class.java)
+        val rawText = response.candidates
+            ?.firstOrNull()
+            ?.content
+            ?.parts
+            ?.joinToString(separator = "") { it.text.orEmpty() }
+            ?.trim()
+            .orEmpty()
+            .removePrefix("```json")
+            .removePrefix("```")
+            .removeSuffix("```")
+            .trim()
+
+        if (rawText.isBlank()) {
+            throw IllegalStateException("AI 未回傳可讀取的單據資料。")
+        }
+
+        return@withContext gson.fromJson(rawText, ReceiptInfo::class.java)
+    }
+
+    private fun postGenerateContent(apiKey: String, body: String): String {
+        val endpoint = URL("https://generativelanguage.googleapis.com/v1beta/models/$modelName:generateContent?key=$apiKey")
+        val connection = endpoint.openConnection() as HttpURLConnection
+        return try {
+            connection.requestMethod = "POST"
+            connection.setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            connection.connectTimeout = 20_000
+            connection.readTimeout = 60_000
+            connection.doOutput = true
+            connection.outputStream.use { output ->
+                output.write(body.toByteArray(StandardCharsets.UTF_8))
+            }
+
+            val code = connection.responseCode
+            val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+            val text = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+            if (code !in 200..299) {
+                throw IOException("AI 服務失敗（$code）：$text")
+            }
+            text
+        } finally {
+            connection.disconnect()
+        }
+    }
+}
+
+private data class GenerateContentResponse(
+    val candidates: List<GenerateContentCandidate>?
+)
+
+private data class GenerateContentCandidate(
+    val content: GenerateContentContent?
+)
+
+private data class GenerateContentContent(
+    val parts: List<GenerateContentPart>?
+)
+
+private data class GenerateContentPart(
+    val text: String?
+)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -1,5 +1,6 @@
 package org.duckdns.lhfser.aiaccounting.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -12,8 +13,12 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.Assessment
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,6 +44,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityActionSheetRow
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityBottomBar
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityBottomBarItem
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFloatingAddButton
@@ -391,23 +397,40 @@ private fun AddActionSheet(
     onAction: (String) -> Unit
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)) {
-            Text("新增內容", style = MaterialTheme.typography.titleMedium)
-            Spacer(modifier = Modifier.height(16.dp))
-            AddActionRow(label = "記一筆（收入/支出）") { onAction(AppDestination.TransactionAdd.route) }
-            AddActionRow(label = "掃描收據（AI）") { onAction(AppDestination.ReceiptScan.route) }
-            AddActionRow(label = "轉帳") { onAction(AppDestination.TransferAdd.route) }
-            AddActionRow(label = "借貸（借入/還款）") { onAction(AppDestination.DebtAdd.route) }
-            AddActionRow(label = "新增代墊單（多人分帳）") { onAction(AppDestination.AdvanceAdd.route) }
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text("新增內容", style = MaterialTheme.typography.titleMedium, fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold)
+            Text("選擇現在想建立的記錄類型。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(modifier = Modifier.height(4.dp))
+            ParityActionSheetRow(
+                title = "記一筆（收入/支出）",
+                subtitle = "快速新增收入或支出交易",
+                icon = Icons.Default.Description
+            ) { onAction(AppDestination.TransactionAdd.route) }
+            ParityActionSheetRow(
+                title = "掃描收據（AI）",
+                subtitle = "上傳照片後由 AI 分析帳單內容",
+                icon = Icons.Default.QrCodeScanner
+            ) { onAction(AppDestination.ReceiptScan.route) }
+            ParityActionSheetRow(
+                title = "轉帳",
+                subtitle = "處理帳戶之間的資金移動",
+                icon = Icons.Default.SwapHoriz
+            ) { onAction(AppDestination.TransferAdd.route) }
+            ParityActionSheetRow(
+                title = "借貸（借入/還款）",
+                subtitle = "建立借貸或記錄還款流向",
+                icon = Icons.Default.AccountBalanceWallet
+            ) { onAction(AppDestination.DebtAdd.route) }
+            ParityActionSheetRow(
+                title = "新增代墊單（多人分帳）",
+                subtitle = "建立多人代墊並追蹤後續還款",
+                icon = Icons.Default.Group
+            ) { onAction(AppDestination.AdvanceAdd.route) }
             Spacer(modifier = Modifier.height(12.dp))
         }
-    }
-}
-
-@Composable
-private fun AddActionRow(label: String, onClick: () -> Unit) {
-    TextButton(onClick = onClick, modifier = Modifier.padding(vertical = 4.dp)) {
-        Text(label)
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -191,7 +191,10 @@ fun AIAccountingRoot(
         },
         floatingActionButton = {
             if (showTopLevelChrome) {
-                ParityFloatingAddButton(onClick = { showAddSheet = true })
+                ParityFloatingAddButton(
+                    modifier = Modifier.padding(bottom = 6.dp),
+                    onClick = { showAddSheet = true }
+                )
             }
         },
         contentWindowInsets = WindowInsets.safeDrawing

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -358,7 +358,10 @@ fun AIAccountingRoot(
             }
             composable(AppDestination.Guide.route) {
                 Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
-                    UserGuideScreen(onDone = { navController.popBackStack() })
+                    UserGuideScreen(
+                        onDone = { navController.popBackStack() },
+                        isFirstLaunch = false
+                    )
                     Spacer(modifier = Modifier.height(20.dp))
                 }
             }
@@ -388,6 +391,7 @@ fun AIAccountingRoot(
         ) {
             Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)) {
                 UserGuideScreen(
+                    isFirstLaunch = true,
                     onDone = {
                         showGuide = false
                         onGuideSeen()

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -9,22 +9,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.AccountBalanceWallet
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Assessment
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -42,6 +39,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityBottomBar
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityBottomBarItem
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityFloatingAddButton
+import org.duckdns.lhfser.aiaccounting.ui.screens.AccountDetailScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.AccountEditorScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.AccountsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.AddAdvanceCaseScreen
@@ -52,7 +53,9 @@ import org.duckdns.lhfser.aiaccounting.ui.screens.BudgetsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.CategoriesScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.CategoryEditorScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.DataHealthScreen
+import org.duckdns.lhfser.aiaccounting.ui.screens.DebtEntryScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.OverviewScreen
+import org.duckdns.lhfser.aiaccounting.ui.screens.ReceiptScanScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReportsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.SettingsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ShortcutEditorScreen
@@ -81,6 +84,10 @@ private sealed class AppDestination(
     data object TransferEdit : AppDestination("transfer/edit/{groupId}", "編輯轉帳")
     data object AdvanceAdd : AppDestination("advance/add", "新增代墊")
     data object AdvanceDetail : AppDestination("advance/{caseId}", "代墊明細")
+    data object ReceiptScan : AppDestination("receipt/scan", "掃描單據")
+    data object DebtAdd : AppDestination("debt/add", "借貸管理")
+    data object AccountDetail : AppDestination("accounts/{accountId}", "帳戶明細")
+    data object Guide : AppDestination("guide", "使用教學")
 
     data object Categories : AppDestination("categories", "分類管理")
     data object CategoryEdit : AppDestination("categories/edit/{categoryId}", "編輯分類")
@@ -114,14 +121,8 @@ fun AIAccountingRoot(
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
     val topLevelRoutes = remember { topLevelDestinations.map { it.route }.toSet() }
-    val showBars = currentRoute in topLevelRoutes
-
-    LaunchedEffect(startOnOverview) {
-        val startDestination = if (startOnOverview) AppDestination.Overview.route else AppDestination.Transactions.route
-        navController.navigate(startDestination) {
-            popUpTo(0)
-        }
-    }
+    val showTopLevelChrome = currentRoute in topLevelRoutes
+    val startDestination = if (startOnOverview) AppDestination.Overview.route else AppDestination.Transactions.route
 
     LaunchedEffect(currencyService.mainCurrency) {
         currencyService.fetchRates()
@@ -130,76 +131,66 @@ fun AIAccountingRoot(
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
-            val title = if (showBars) {
-                topLevelDestinations.firstOrNull { it.route == currentRoute }?.label ?: "AI 記帳"
-            } else {
-                resolveTitle(backStackEntry)
-            }
-            TopAppBar(
-                title = { Text(text = title, style = MaterialTheme.typography.titleLarge) },
-                navigationIcon = {
-                    if (!showBars && navController.previousBackStackEntry != null) {
-                        IconButton(onClick = { navController.popBackStack() }) {
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
-                        }
-                    }
-                },
-                actions = {
-                    when (currentRoute) {
-                        AppDestination.Categories.route -> {
-                            IconButton(onClick = {
-                                navController.navigate("categories/edit/${UUID.randomUUID()}")
-                            }) {
-                                Icon(Icons.Default.Add, contentDescription = "新增分類")
+            if (!showTopLevelChrome && currentRoute != null) {
+                TopAppBar(
+                    title = { Text(text = resolveTitle(backStackEntry), style = MaterialTheme.typography.titleLarge) },
+                    navigationIcon = {
+                        if (navController.previousBackStackEntry != null) {
+                            IconButton(onClick = { navController.popBackStack() }) {
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
                             }
                         }
-                        AppDestination.Tags.route -> {
-                            IconButton(onClick = {
-                                navController.navigate("tags/edit/${UUID.randomUUID()}")
-                            }) {
-                                Icon(Icons.Default.Add, contentDescription = "新增標籤")
+                    },
+                    actions = {
+                        when {
+                            currentRoute == AppDestination.Categories.route -> {
+                                TextButton(onClick = { navController.navigate("categories/edit/${UUID.randomUUID()}") }) {
+                                    Text("新增")
+                                }
+                            }
+                            currentRoute == AppDestination.Tags.route -> {
+                                TextButton(onClick = { navController.navigate("tags/edit/${UUID.randomUUID()}") }) {
+                                    Text("新增")
+                                }
                             }
                         }
-                    }
-                },
-                windowInsets = TopAppBarDefaults.windowInsets,
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background
+                    },
+                    windowInsets = TopAppBarDefaults.windowInsets,
+                    colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
                 )
-            )
+            }
         },
         bottomBar = {
-            if (showBars) {
-                NavigationBar {
+            if (showTopLevelChrome) {
+                ParityBottomBar {
                     topLevelDestinations.forEach { destination ->
-                        NavigationBarItem(
+                        ParityBottomBarItem(
+                            modifier = Modifier.weight(1f),
                             selected = currentRoute == destination.route,
+                            label = destination.label,
+                            icon = destination.icon ?: return@forEach,
                             onClick = {
                                 navController.navigate(destination.route) {
                                     launchSingleTop = true
                                     popUpTo(navController.graph.startDestinationId) { saveState = true }
                                     restoreState = true
                                 }
-                            },
-                            icon = { destination.icon?.let { Icon(it, contentDescription = null) } },
-                            label = { Text(destination.label) }
+                            }
                         )
                     }
                 }
             }
         },
         floatingActionButton = {
-            if (showBars) {
-                FloatingActionButton(onClick = { showAddSheet = true }) {
-                    Icon(Icons.Default.Add, contentDescription = "新增")
-                }
+            if (showTopLevelChrome) {
+                ParityFloatingAddButton(onClick = { showAddSheet = true })
             }
         },
         contentWindowInsets = WindowInsets.safeDrawing
     ) { padding ->
         NavHost(
             navController = navController,
-            startDestination = AppDestination.Transactions.route,
+            startDestination = startDestination,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
@@ -240,11 +231,15 @@ fun AIAccountingRoot(
                 )
             }
             composable(AppDestination.Reports.route) { ReportsScreen() }
-            composable(AppDestination.Accounts.route) { AccountsScreen(onEdit = { id ->
-                navController.navigate("accounts/edit/$id")
-            }) }
+            composable(AppDestination.Accounts.route) {
+                AccountsScreen(
+                    onOpenDetail = { id -> navController.navigate("accounts/$id") },
+                    onAddAccount = { navController.navigate("accounts/edit/${UUID.randomUUID()}") }
+                )
+            }
             composable(AppDestination.Settings.route) {
                 SettingsScreen(
+                    onOpenGuide = { navController.navigate(AppDestination.Guide.route) },
                     onOpenCategories = { navController.navigate(AppDestination.Categories.route) },
                     onOpenTags = { navController.navigate(AppDestination.Tags.route) },
                     onOpenBudgets = { navController.navigate(AppDestination.Budgets.route) },
@@ -280,10 +275,14 @@ fun AIAccountingRoot(
             composable(AppDestination.AdvanceAdd.route) {
                 AddAdvanceCaseScreen(onDone = { navController.popBackStack() })
             }
+            composable(AppDestination.ReceiptScan.route) {
+                ReceiptScanScreen(onDone = { navController.popBackStack() })
+            }
+            composable(AppDestination.DebtAdd.route) {
+                DebtEntryScreen(onDone = { navController.popBackStack() })
+            }
             composable("advances") {
-                AdvancesScreen(onOpenCase = { caseId ->
-                    navController.navigate("advance/$caseId")
-                })
+                AdvancesScreen(onOpenCase = { caseId -> navController.navigate("advance/$caseId") })
             }
             composable(
                 AppDestination.AdvanceDetail.route,
@@ -292,9 +291,7 @@ fun AIAccountingRoot(
                 AdvanceDetailScreen(caseId = entry.arguments?.getString("caseId"))
             }
             composable(AppDestination.Categories.route) {
-                CategoriesScreen(onEdit = { id ->
-                    navController.navigate("categories/edit/$id")
-                })
+                CategoriesScreen(onEdit = { id -> navController.navigate("categories/edit/$id") })
             }
             composable(
                 AppDestination.CategoryEdit.route,
@@ -329,6 +326,17 @@ fun AIAccountingRoot(
                 )
             }
             composable(
+                AppDestination.AccountDetail.route,
+                arguments = listOf(navArgument("accountId") { type = NavType.StringType })
+            ) { entry ->
+                AccountDetailScreen(
+                    accountId = entry.arguments?.getString("accountId"),
+                    onEditAccount = { id -> navController.navigate("accounts/edit/$id") },
+                    onEditTransaction = { id -> navController.navigate("transaction/edit/$id") },
+                    onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") }
+                )
+            }
+            composable(
                 AppDestination.ShortcutEdit.route,
                 arguments = listOf(navArgument("shortcutId") { type = NavType.StringType })
             ) { entry ->
@@ -336,6 +344,12 @@ fun AIAccountingRoot(
                     shortcutId = entry.arguments?.getString("shortcutId"),
                     onDone = { navController.popBackStack() }
                 )
+            }
+            composable(AppDestination.Guide.route) {
+                Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+                    UserGuideScreen(onDone = { navController.popBackStack() })
+                    Spacer(modifier = Modifier.height(20.dp))
+                }
             }
         }
     }
@@ -381,9 +395,10 @@ private fun AddActionSheet(
             Text("新增內容", style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(16.dp))
             AddActionRow(label = "記一筆（收入/支出）") { onAction(AppDestination.TransactionAdd.route) }
+            AddActionRow(label = "掃描收據（AI）") { onAction(AppDestination.ReceiptScan.route) }
             AddActionRow(label = "轉帳") { onAction(AppDestination.TransferAdd.route) }
-            AddActionRow(label = "新增代墊單") { onAction(AppDestination.AdvanceAdd.route) }
-            AddActionRow(label = "新增帳戶") { onAction("accounts/edit/${UUID.randomUUID()}") }
+            AddActionRow(label = "借貸（借入/還款）") { onAction(AppDestination.DebtAdd.route) }
+            AddActionRow(label = "新增代墊單（多人分帳）") { onAction(AppDestination.AdvanceAdd.route) }
             Spacer(modifier = Modifier.height(12.dp))
         }
     }
@@ -391,7 +406,7 @@ private fun AddActionSheet(
 
 @Composable
 private fun AddActionRow(label: String, onClick: () -> Unit) {
-    androidx.compose.material3.TextButton(onClick = onClick, modifier = Modifier.padding(vertical = 4.dp)) {
+    TextButton(onClick = onClick, modifier = Modifier.padding(vertical = 4.dp)) {
         Text(label)
     }
 }
@@ -402,6 +417,8 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
         route.startsWith("transaction/edit") -> "編輯記帳"
         route == AppDestination.TransactionAdd.route -> "記一筆"
         route == AppDestination.TransferAdd.route -> "轉帳"
+        route == AppDestination.ReceiptScan.route -> "掃描單據"
+        route == AppDestination.DebtAdd.route -> "借貸管理"
         route == AppDestination.AdvanceAdd.route -> "新增代墊"
         route.startsWith("advance/") -> "代墊明細"
         route == AppDestination.Categories.route -> "分類"
@@ -411,7 +428,9 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
         route == AppDestination.Budgets.route -> "預算與提醒"
         route == AppDestination.DataHealth.route -> "資料健康檢查"
         route.startsWith("accounts/edit") -> "編輯帳戶"
+        route.startsWith("accounts/") -> "帳戶明細"
         route.startsWith("shortcuts/edit") -> "捷徑"
+        route == AppDestination.Guide.route -> "使用教學"
         else -> "AI 記帳"
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -48,6 +49,7 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParityActionSheetRow
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityBottomBar
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityBottomBarItem
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFloatingAddButton
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySheetHandle
 import org.duckdns.lhfser.aiaccounting.ui.screens.AccountDetailScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.AccountEditorScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.AccountsScreen
@@ -371,13 +373,17 @@ fun AIAccountingRoot(
     }
 
     if (showGuide) {
+        val guideSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
         ModalBottomSheet(
             onDismissRequest = {
                 showGuide = false
                 onGuideSeen()
-            }
+            },
+            sheetState = guideSheetState,
+            containerColor = MaterialTheme.colorScheme.background,
+            dragHandle = { ParitySheetHandle() }
         ) {
-            Column(modifier = Modifier.padding(24.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)) {
                 UserGuideScreen(
                     onDone = {
                         showGuide = false
@@ -396,7 +402,13 @@ private fun AddActionSheet(
     onDismiss: () -> Unit,
     onAction: (String) -> Unit
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        dragHandle = { ParitySheetHandle() }
+    ) {
         Column(
             modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
@@ -52,6 +54,7 @@ object ParityTokens {
     val ShortcutIconSize = 46.dp
     val BottomBarHeight = 72.dp
     val FloatingButtonSize = 60.dp
+    val FloatingContentBottomPadding = 112.dp
 }
 
 @Composable
@@ -342,6 +345,82 @@ fun ParityActionSheetRow(
 }
 
 @Composable
+fun ParitySelectionSheetRow(
+    title: String,
+    subtitle: String? = null,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    PressableCard(
+        modifier = modifier.fillMaxWidth(),
+        onClick = onClick,
+        containerColor = if (selected) {
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant
+        },
+        pressedContainerColor = MaterialTheme.colorScheme.surface,
+        borderColor = if (selected) {
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+        } else {
+            MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
+        },
+        pressedBorderColor = if (selected) {
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.28f)
+        } else {
+            MaterialTheme.colorScheme.outline.copy(alpha = 0.32f)
+        },
+        shape = RoundedCornerShape(20.dp),
+        scaleOnPress = 0.992f,
+        pressedElevation = 1.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            if (selected) {
+                Surface(
+                    modifier = Modifier.size(28.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
 fun ParitySheetHandle(modifier: Modifier = Modifier) {
     Surface(
         modifier = modifier
@@ -383,6 +462,7 @@ fun ParityBottomBarItem(
 ) {
     Column(
         modifier = modifier
+            .defaultMinSize(minHeight = 48.dp)
             .clip(RoundedCornerShape(16.dp))
             .clickable(onClick = onClick)
             .padding(horizontal = 10.dp, vertical = 8.dp),
@@ -426,6 +506,7 @@ fun ParityBottomBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .navigationBarsPadding()
                 .height(ParityTokens.BottomBarHeight)
                 .padding(contentPadding),
             horizontalArrangement = Arrangement.SpaceAround,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
@@ -1,0 +1,309 @@
+package org.duckdns.lhfser.aiaccounting.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+
+object ParityTokens {
+    val TopSectionTopPadding = 6.dp
+    val TopSectionBottomPadding = 10.dp
+    val FilterCapsuleHeight = 40.dp
+    val SegmentedControlHeight = 42.dp
+    val ShortcutTileWidth = 76.dp
+    val ShortcutTileHeight = 88.dp
+    val ShortcutIconSize = 46.dp
+    val BottomBarHeight = 72.dp
+    val FloatingButtonSize = 60.dp
+}
+
+@Composable
+fun ParityTopSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    accessory: (@Composable RowScope.() -> Unit)? = null
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = ParityTokens.TopSectionTopPadding, bottom = ParityTokens.TopSectionBottomPadding),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 31.sp,
+                        lineHeight = 36.sp
+                    ),
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            if (accessory != null) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = accessory
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ParityFilterCapsule(
+    label: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = modifier.clickable(onClick = onClick),
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
+        border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+    ) {
+        Row(
+            modifier = Modifier
+                .defaultMinSize(minHeight = ParityTokens.FilterCapsuleHeight)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            if (icon != null) {
+                Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            }
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
+@Composable
+fun <T> ParitySegmentedControl(
+    options: List<T>,
+    selected: T,
+    label: (T) -> String,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(15.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            options.forEach { option ->
+                val isSelected = option == selected
+                Surface(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(ParityTokens.SegmentedControlHeight),
+                    onClick = { onSelect(option) },
+                    shape = RoundedCornerShape(11.dp),
+                    color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = label(option),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                            color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            maxLines = 1
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ParitySummaryCard(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    supporting: String? = null,
+    accent: Color = MaterialTheme.colorScheme.primary,
+    onClick: (() -> Unit)? = null
+) {
+    val cardModifier = if (onClick != null) modifier.clickable(onClick = onClick) else modifier
+    Surface(
+        modifier = cardModifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = accent.copy(alpha = 0.08f),
+        border = BorderStroke(0.8.dp, accent.copy(alpha = 0.16f))
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(5.dp)
+        ) {
+            Text(title, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+            if (!supporting.isNullOrBlank()) {
+                Text(supporting, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+fun ParitySettingRow(
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    trailing: @Composable (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null
+) {
+    val rowModifier = if (onClick != null) modifier.clickable(onClick = onClick) else modifier
+    Row(
+        modifier = rowModifier
+            .fillMaxWidth()
+            .padding(horizontal = AppSpacing.card, vertical = 14.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        trailing?.invoke()
+    }
+}
+
+@Composable
+fun ParityFloatingAddButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.size(ParityTokens.FloatingButtonSize),
+        onClick = onClick,
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 8.dp
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "新增",
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(28.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun ParityBottomBarItem(
+    selected: Boolean,
+    label: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(34.dp)
+                .clip(RoundedCornerShape(17.dp))
+                .background(if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+fun ParityBottomBar(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 18.dp, vertical = 10.dp),
+    content: @Composable RowScope.() -> Unit
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.background,
+        border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.10f))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ParityTokens.BottomBarHeight)
+                .padding(contentPadding),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically,
+            content = content
+        )
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
@@ -421,6 +421,63 @@ fun ParitySelectionSheetRow(
 }
 
 @Composable
+fun ParityMenuField(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    placeholder: String = "請選擇",
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        PressableCard(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onClick,
+            containerColor = MaterialTheme.colorScheme.surface,
+            pressedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.28f),
+            pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.40f),
+            shape = RoundedCornerShape(16.dp),
+            scaleOnPress = 0.994f,
+            pressedElevation = 1.dp
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Text(
+                    text = value.ifBlank { placeholder },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (value.isBlank()) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier.weight(1f)
+                )
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
 fun ParitySheetHandle(modifier: Modifier = Modifier) {
     Surface(
         modifier = modifier

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
@@ -303,19 +304,22 @@ fun ParityActionSheetRow(
         containerColor = MaterialTheme.colorScheme.surfaceVariant,
         pressedContainerColor = MaterialTheme.colorScheme.surface,
         borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.24f),
-        pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.38f)
+        pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.38f),
+        pressedElevation = 2.dp,
+        scaleOnPress = 0.988f,
+        shape = RoundedCornerShape(22.dp)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
+                .padding(horizontal = 18.dp, vertical = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             if (icon != null) {
                 Surface(
-                    modifier = Modifier.size(42.dp),
-                    shape = RoundedCornerShape(14.dp),
+                    modifier = Modifier.size(44.dp),
+                    shape = RoundedCornerShape(15.dp),
                     color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
                 ) {
                     Box(contentAlignment = Alignment.Center) {
@@ -327,8 +331,25 @@ fun ParityActionSheetRow(
                 Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                 Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp)
+            )
         }
     }
+}
+
+@Composable
+fun ParitySheetHandle(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier
+            .padding(top = 8.dp, bottom = 4.dp)
+            .size(width = 38.dp, height = 5.dp),
+        shape = RoundedCornerShape(999.dp),
+        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)
+    ) {}
 }
 
 @Composable
@@ -338,7 +359,8 @@ fun ParityFloatingAddButton(onClick: () -> Unit, modifier: Modifier = Modifier) 
         onClick = onClick,
         shape = CircleShape,
         color = MaterialTheme.colorScheme.primary,
-        shadowElevation = 8.dp
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.08f)),
+        shadowElevation = 10.dp
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
@@ -19,10 +19,15 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,6 +45,7 @@ object ParityTokens {
     val TopSectionBottomPadding = 10.dp
     val FilterCapsuleHeight = 40.dp
     val SegmentedControlHeight = 42.dp
+    val SearchFieldMinHeight = 52.dp
     val ShortcutTileWidth = 76.dp
     val ShortcutTileHeight = 88.dp
     val ShortcutIconSize = 46.dp
@@ -174,6 +180,63 @@ fun <T> ParitySegmentedControl(
 }
 
 @Composable
+fun ParitySearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = ParityTokens.SearchFieldMinHeight),
+        singleLine = true,
+        shape = RoundedCornerShape(18.dp),
+        placeholder = {
+            Text(
+                text = placeholder,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        trailingIcon = {
+            if (value.isNotBlank()) {
+                IconButton(onClick = { onValueChange("") }) {
+                    Icon(
+                        imageVector = Icons.Default.Clear,
+                        contentDescription = "清除",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        },
+        textStyle = MaterialTheme.typography.bodyLarge,
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            errorContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            errorIndicatorColor = Color.Transparent,
+            focusedTextColor = MaterialTheme.colorScheme.onSurface,
+            unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+            cursorColor = MaterialTheme.colorScheme.primary
+        )
+    )
+}
+
+@Composable
 fun ParitySummaryCard(
     title: String,
     value: String,
@@ -223,6 +286,48 @@ fun ParitySettingRow(
             Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
         trailing?.invoke()
+    }
+}
+
+@Composable
+fun ParityActionSheetRow(
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    onClick: () -> Unit
+) {
+    PressableCard(
+        modifier = modifier.fillMaxWidth(),
+        onClick = onClick,
+        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        pressedContainerColor = MaterialTheme.colorScheme.surface,
+        borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.24f),
+        pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.38f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (icon != null) {
+                Surface(
+                    modifier = Modifier.size(42.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    }
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp), modifier = Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityStateComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityStateComponents.kt
@@ -1,0 +1,150 @@
+package org.duckdns.lhfser.aiaccounting.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+
+@Composable
+fun ParitySectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    detail: String? = null,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = AppSpacing.tight),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (!detail.isNullOrBlank()) {
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        if (actionLabel != null && onAction != null) {
+            TextButton(onClick = onAction) {
+                Text(actionLabel)
+            }
+        }
+    }
+}
+
+@Composable
+fun ParityStatusPill(
+    text: String,
+    modifier: Modifier = Modifier,
+    tint: Color = MaterialTheme.colorScheme.secondary
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(999.dp),
+        color = tint.copy(alpha = 0.12f),
+        border = BorderStroke(0.8.dp, tint.copy(alpha = 0.18f))
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = tint
+        )
+    }
+}
+
+@Composable
+fun ParityEmptyState(
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.22f))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            if (icon != null) {
+                Surface(
+                    modifier = Modifier.size(44.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (actionLabel != null && onAction != null) {
+                TextButton(onClick = onAction) {
+                    Text(actionLabel)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/SectionComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/SectionComponents.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 
 @Composable
@@ -102,18 +104,22 @@ fun PressableCard(
     var isPressed by remember { mutableStateOf(false) }
     val animatedScale by animateFloatAsState(
         targetValue = if (isPressed) scaleOnPress else 1f,
+        animationSpec = spring(dampingRatio = 0.88f, stiffness = 720f),
         label = "pressScale"
     )
     val animatedElevation by animateDpAsState(
         targetValue = if (isPressed) pressedElevation else elevation,
+        animationSpec = spring(dampingRatio = 0.92f, stiffness = 560f),
         label = "pressElevation"
     )
     val animatedContainer by animateColorAsState(
         targetValue = if (isPressed) pressedContainerColor else containerColor,
+        animationSpec = tween(durationMillis = 140),
         label = "pressContainer"
     )
     val animatedBorder by animateColorAsState(
         targetValue = if (isPressed) pressedBorderColor else borderColor,
+        animationSpec = tween(durationMillis = 140),
         label = "pressBorder"
     )
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -30,6 +30,7 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
@@ -78,8 +79,10 @@ fun AccountDetailScreen(
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(
-            horizontal = AppSpacing.screenHorizontal,
-            vertical = AppSpacing.screenVertical
+            start = AppSpacing.screenHorizontal,
+            end = AppSpacing.screenHorizontal,
+            top = AppSpacing.screenVertical,
+            bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
         ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
@@ -128,7 +131,7 @@ fun AccountDetailScreen(
         item {
             ParitySectionHeader(
                 title = "交易紀錄",
-                detail = "${accountTransactions.size} 筆"
+                detail = "${accountTransactions.size} 筆 · 點擊即可查看或編輯"
             )
         }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -1,0 +1,242 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateTimeText
+import java.math.BigDecimal
+import java.util.UUID
+
+@Composable
+fun AccountDetailScreen(
+    accountId: String?,
+    onEditAccount: (String) -> Unit,
+    onEditTransaction: (String) -> Unit,
+    onEditTransfer: (String) -> Unit
+) {
+    val repository = LocalRepository.current
+    val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val transactions by repository.transactions.collectAsState(initial = emptyList())
+
+    val resolvedId = remember(accountId) { accountId?.let(UUID::fromString) }
+    val account = remember(accounts, resolvedId) { accounts.firstOrNull { it.id == resolvedId } }
+
+    if (account == null) {
+        Column(modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)) {
+            ParityTopSection(title = "帳戶明細", subtitle = "找不到這個帳戶")
+        }
+        return
+    }
+
+    val accountTransactions = remember(transactions, account.id) {
+        transactions
+            .filter { it.transaction.accountId == account.id }
+            .sortedByDescending { it.transaction.date }
+    }
+    val balances = remember(account, accountTransactions) { calculateBalances(account, accountTransactions) }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.section)) {
+                ParityTopSection(
+                    title = account.name,
+                    subtitle = buildString {
+                        append(account.type.rawValue)
+                        append(" · ")
+                        append(account.currency)
+                        if (account.isArchived) {
+                            append(" · 已歸檔")
+                        }
+                    },
+                    accessory = {
+                        TextButton(onClick = { onEditAccount(account.id.toString()) }) {
+                            Text("編輯")
+                        }
+                    }
+                )
+                if (balances.isEmpty()) {
+                    ParitySummaryCard(
+                        title = "目前餘額",
+                        value = BigDecimal.ZERO.asCurrencyText(account.currency),
+                        supporting = "尚未有任何交易"
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+                        balances.forEach { balance ->
+                            ParitySummaryCard(
+                                title = if (balances.size == 1) "目前餘額" else "${balance.currency} 餘額",
+                                value = balance.amount.asCurrencyText(balance.currency),
+                                supporting = "含初始餘額與所有已記錄交易",
+                                accent = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "帳戶明細",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = "${accountTransactions.size} 筆",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        if (accountTransactions.isEmpty()) {
+            item {
+                Text(
+                    text = "這個帳戶還沒有任何交易。",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            items(accountTransactions, key = { it.transaction.id }) { item ->
+                AccountTransactionRow(
+                    item = item,
+                    onClick = {
+                        val groupId = item.transaction.transferGroupId?.toString()
+                        if (item.transaction.type == TransactionType.Transfer && groupId != null) {
+                            onEditTransfer(groupId)
+                        } else {
+                            onEditTransaction(item.transaction.id.toString())
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountTransactionRow(
+    item: TransactionWithDetails,
+    onClick: () -> Unit
+) {
+    val transaction = item.transaction
+    val amountColor = when {
+        transaction.amount.signum() > 0 -> MaterialTheme.colorScheme.primary
+        transaction.amount.signum() < 0 -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    PressableCard(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.tight)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = item.category?.name ?: defaultTransactionTitle(transaction.type),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = transaction.note.ifBlank { "無備註" },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    text = transaction.amount.asCurrencyText(transaction.currencyCode),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = amountColor,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = transaction.date.toDateTimeText(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = if (transaction.type == TransactionType.Transfer) "編輯轉帳" else "查看 / 編輯",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+private data class AccountCurrencyBalance(
+    val currency: String,
+    val amount: BigDecimal
+)
+
+private fun calculateBalances(
+    account: AccountEntity,
+    transactions: List<TransactionWithDetails>
+): List<AccountCurrencyBalance> {
+    val totals = linkedMapOf<String, BigDecimal>()
+    if (account.baseBalance != BigDecimal.ZERO) {
+        totals[account.currency] = account.baseBalance
+    }
+    transactions.forEach { tx ->
+        val currency = tx.transaction.currencyCode
+        totals[currency] = totals.getOrDefault(currency, BigDecimal.ZERO) + tx.transaction.amount
+    }
+    return totals.entries
+        .filter { it.value != BigDecimal.ZERO }
+        .sortedBy { it.key }
+        .map { AccountCurrencyBalance(it.key, it.value) }
+}
+
+private fun defaultTransactionTitle(type: TransactionType): String = when (type) {
+    TransactionType.Income -> "收入"
+    TransactionType.Expense -> "支出"
+    TransactionType.Transfer -> "轉帳"
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -23,6 +25,9 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
@@ -47,8 +52,18 @@ fun AccountDetailScreen(
     val account = remember(accounts, resolvedId) { accounts.firstOrNull { it.id == resolvedId } }
 
     if (account == null) {
-        Column(modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)) {
+        Column(
+            modifier = Modifier.padding(
+                horizontal = AppSpacing.screenHorizontal,
+                vertical = AppSpacing.screenVertical
+            )
+        ) {
             ParityTopSection(title = "帳戶明細", subtitle = "找不到這個帳戶")
+            ParityEmptyState(
+                title = "找不到帳戶",
+                message = "這個帳戶可能已刪除、尚未同步，或目前沒有可顯示的資料。",
+                icon = Icons.Default.AccountBalanceWallet
+            )
         }
         return
     }
@@ -62,22 +77,24 @@ fun AccountDetailScreen(
 
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        contentPadding = PaddingValues(
+            horizontal = AppSpacing.screenHorizontal,
+            vertical = AppSpacing.screenVertical
+        ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         item {
             Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.section)) {
                 ParityTopSection(
                     title = account.name,
-                    subtitle = buildString {
-                        append(account.type.rawValue)
-                        append(" · ")
-                        append(account.currency)
-                        if (account.isArchived) {
-                            append(" · 已歸檔")
-                        }
-                    },
+                    subtitle = "${account.type.rawValue} · ${account.currency}",
                     accessory = {
+                        if (account.isArchived) {
+                            ParityStatusPill(
+                                text = "已歸檔",
+                                tint = MaterialTheme.colorScheme.tertiary
+                            )
+                        }
                         TextButton(onClick = { onEditAccount(account.id.toString()) }) {
                             Text("編輯")
                         }
@@ -96,7 +113,11 @@ fun AccountDetailScreen(
                                 title = if (balances.size == 1) "目前餘額" else "${balance.currency} 餘額",
                                 value = balance.amount.asCurrencyText(balance.currency),
                                 supporting = "含初始餘額與所有已記錄交易",
-                                accent = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                                accent = if (balance.amount.signum() >= 0) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.error
+                                }
                             )
                         }
                     }
@@ -105,30 +126,18 @@ fun AccountDetailScreen(
         }
 
         item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "帳戶明細",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.weight(1f)
-                )
-                Text(
-                    text = "${accountTransactions.size} 筆",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+            ParitySectionHeader(
+                title = "交易紀錄",
+                detail = "${accountTransactions.size} 筆"
+            )
         }
 
         if (accountTransactions.isEmpty()) {
             item {
-                Text(
-                    text = "這個帳戶還沒有任何交易。",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                ParityEmptyState(
+                    title = "還沒有交易",
+                    message = "這個帳戶目前只有初始資料，還沒有新增任何收入、支出或轉帳。",
+                    icon = Icons.Default.AccountBalanceWallet
                 )
             }
         } else {
@@ -160,9 +169,19 @@ private fun AccountTransactionRow(
         transaction.amount.signum() < 0 -> MaterialTheme.colorScheme.error
         else -> MaterialTheme.colorScheme.onSurface
     }
+    val categoryText = item.category?.name ?: defaultTransactionTitle(transaction.type)
+    val metaText = listOfNotNull(categoryText, item.account?.name)
+        .distinct()
+        .joinToString(" · ")
+        .ifBlank { "未分類" }
+
     PressableCard(
         modifier = Modifier.fillMaxWidth(),
-        onClick = onClick
+        onClick = onClick,
+        containerColor = MaterialTheme.colorScheme.surface,
+        pressedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+        borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
+        pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.48f)
     ) {
         Column(
             modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
@@ -173,40 +192,42 @@ private fun AccountTransactionRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
                     Text(
-                        text = item.category?.name ?: defaultTransactionTitle(transaction.type),
+                        text = transaction.note.ifBlank { categoryText },
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.SemiBold
                     )
                     Text(
-                        text = transaction.note.ifBlank { "無備註" },
-                        style = MaterialTheme.typography.bodySmall,
+                        text = metaText,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = transaction.date.toDateTimeText(),
+                        style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                Text(
-                    text = transaction.amount.asCurrencyText(transaction.currencyCode),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = amountColor,
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = transaction.date.toDateTimeText(),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = if (transaction.type == TransactionType.Transfer) "編輯轉帳" else "查看 / 編輯",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary
-                )
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
+                    Text(
+                        text = transaction.amount.asCurrencyText(transaction.currencyCode),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = amountColor,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = if (transaction.type == TransactionType.Transfer) "編輯轉帳" else "查看 / 編輯",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
@@ -37,6 +37,7 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
@@ -78,8 +79,10 @@ fun AccountsScreen(
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = androidx.compose.foundation.layout.PaddingValues(
-            horizontal = AppSpacing.screenHorizontal,
-            vertical = AppSpacing.screenVertical
+            start = AppSpacing.screenHorizontal,
+            end = AppSpacing.screenHorizontal,
+            top = AppSpacing.screenVertical,
+            bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
         ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
@@ -180,6 +183,16 @@ fun AccountsScreen(
                 )
             }
         } else {
+            item {
+                ParitySectionHeader(
+                    title = if (showArchived) "所有帳戶" else "活動帳戶",
+                    detail = if (showArchived) {
+                        "包含可還原的已歸檔帳戶"
+                    } else {
+                        "點擊後可查看該帳戶的完整明細"
+                    }
+                )
+            }
             items(visibleSummaries, key = { it.account.id }) { row ->
                 PressableCard(
                     modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -18,10 +20,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -30,6 +32,9 @@ import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
@@ -72,14 +77,21 @@ fun AccountsScreen(
 
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+            horizontal = AppSpacing.screenHorizontal,
+            vertical = AppSpacing.screenVertical
+        ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         item {
             Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.section)) {
                 ParityTopSection(
                     title = "帳戶",
-                    subtitle = if (showArchived) "目前顯示所有帳戶，包含已歸檔項目。" else "總資產與幣別持有只計入未歸檔帳戶。",
+                    subtitle = if (showArchived) {
+                        "目前顯示所有帳戶，包含已歸檔項目。"
+                    } else {
+                        "總資產與幣別持有只計入未歸檔帳戶。"
+                    },
                     accessory = {
                         TextButton(onClick = { showArchived = !showArchived }) {
                             Text(if (showArchived) "隱藏歸檔" else "顯示歸檔")
@@ -98,16 +110,15 @@ fun AccountsScreen(
                     )
 
                     Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-                        Text(
-                            "各幣種持有總額",
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold
+                        ParitySectionHeader(
+                            title = "各幣種持有總額",
+                            detail = if (currencyHoldings.isEmpty()) null else "${currencyHoldings.size} 種幣別"
                         )
                         if (currencyHoldings.isEmpty()) {
-                            Text(
-                                "目前沒有活動帳戶餘額",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            ParityEmptyState(
+                                title = "暫時沒有持有總額",
+                                message = "活動帳戶目前沒有可計算的餘額。",
+                                icon = Icons.Default.AccountBalanceWallet
                             )
                         } else {
                             Row(
@@ -118,13 +129,16 @@ fun AccountsScreen(
                             ) {
                                 currencyHoldings.forEach { holding ->
                                     Surface(
-                                        modifier = Modifier.width(156.dp),
+                                        modifier = Modifier.width(168.dp),
                                         shape = MaterialTheme.shapes.large,
                                         color = MaterialTheme.colorScheme.surfaceVariant,
-                                        border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
+                                        border = BorderStroke(
+                                            0.6.dp,
+                                            MaterialTheme.colorScheme.outline.copy(alpha = 0.35f)
+                                        )
                                     ) {
                                         Column(
-                                            modifier = Modifier.padding(AppSpacing.card),
+                                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
                                             verticalArrangement = Arrangement.spacedBy(6.dp)
                                         ) {
                                             Text(
@@ -137,7 +151,11 @@ fun AccountsScreen(
                                                 holding.amount.asCurrencyText(holding.currency),
                                                 style = MaterialTheme.typography.titleSmall,
                                                 fontWeight = FontWeight.SemiBold,
-                                                color = if (holding.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
+                                                color = if (holding.amount.signum() >= 0) {
+                                                    MaterialTheme.colorScheme.onSurface
+                                                } else {
+                                                    MaterialTheme.colorScheme.error
+                                                }
                                             )
                                         }
                                     }
@@ -151,36 +169,48 @@ fun AccountsScreen(
 
         if (visibleSummaries.isEmpty()) {
             item {
-                Text(
-                    if (showArchived) "目前沒有任何帳戶。" else "目前沒有活動帳戶。",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                ParityEmptyState(
+                    title = if (showArchived) "沒有已歸檔帳戶" else "尚未建立帳戶",
+                    message = if (showArchived) {
+                        "切回活動帳戶，或先把現有帳戶歸檔後再回來查看。"
+                    } else {
+                        "先新增一個帳戶，之後就能記錄資產、轉帳與日常交易。"
+                    },
+                    icon = Icons.Default.AccountBalanceWallet
                 )
             }
         } else {
             items(visibleSummaries, key = { it.account.id }) { row ->
                 PressableCard(
                     modifier = Modifier.fillMaxWidth(),
-                    onClick = { onOpenDetail(row.account.id.toString()) }
+                    onClick = { onOpenDetail(row.account.id.toString()) },
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    pressedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
+                    pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.48f)
                 ) {
                     Row(
-                        modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 15.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         Column(
                             modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                            verticalArrangement = Arrangement.spacedBy(5.dp)
                         ) {
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Text(row.account.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(
+                                    row.account.name,
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold
+                                )
                                 if (row.account.isArchived) {
-                                    Text(
-                                        "已歸檔",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    ParityStatusPill(
+                                        text = "已歸檔",
+                                        tint = MaterialTheme.colorScheme.tertiary
                                     )
                                 }
                             }
@@ -190,33 +220,64 @@ fun AccountsScreen(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
-                        Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                            if (row.balances.isEmpty()) {
-                                Text("0.00", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            } else if (row.balances.size == 1) {
-                                val balance = row.balances.first()
-                                Text(
-                                    balance.amount.asCurrencyText(balance.currency),
-                                    style = MaterialTheme.typography.titleSmall,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
-                                )
-                            } else {
-                                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                                    row.balances.take(2).forEach { balance ->
-                                        Text(
-                                            balance.amount.asCurrencyText(balance.currency),
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            fontWeight = FontWeight.SemiBold,
-                                            color = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
-                                        )
-                                    }
-                                    if (row.balances.size > 2) {
-                                        Text("...", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Column(
+                            horizontalAlignment = Alignment.End,
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            when {
+                                row.balances.isEmpty() -> {
+                                    Text(
+                                        BigDecimal.ZERO.asCurrencyText(row.account.currency),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                row.balances.size == 1 -> {
+                                    val balance = row.balances.first()
+                                    Text(
+                                        balance.amount.asCurrencyText(balance.currency),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = if (balance.amount.signum() >= 0) {
+                                            MaterialTheme.colorScheme.onSurface
+                                        } else {
+                                            MaterialTheme.colorScheme.error
+                                        }
+                                    )
+                                }
+                                else -> {
+                                    Column(
+                                        horizontalAlignment = Alignment.End,
+                                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                                    ) {
+                                        row.balances.take(2).forEach { balance ->
+                                            Text(
+                                                balance.amount.asCurrencyText(balance.currency),
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                fontWeight = FontWeight.SemiBold,
+                                                color = if (balance.amount.signum() >= 0) {
+                                                    MaterialTheme.colorScheme.onSurface
+                                                } else {
+                                                    MaterialTheme.colorScheme.error
+                                                }
+                                            )
+                                        }
+                                        if (row.balances.size > 2) {
+                                            Text(
+                                                "共 ${row.balances.size} 種幣別",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
                                     }
                                 }
                             }
-                            Text("查看明細", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                            Text(
+                                "查看明細",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Medium
+                            )
                         }
                     }
                 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
@@ -1,5 +1,6 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -13,40 +14,50 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.shape.RoundedCornerShape
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
-import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
-import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import java.math.BigDecimal
 
 @Composable
-fun AccountsScreen(onEdit: (String) -> Unit) {
+fun AccountsScreen(
+    onOpenDetail: (String) -> Unit,
+    onAddAccount: () -> Unit
+) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val transactions by repository.transactions.collectAsState(initial = emptyList())
     val rateSnapshot = currencyService.rates
     val mainCurrency = currencyService.mainCurrency
+    var showArchived by rememberSaveable { mutableStateOf(false) }
 
     val accountSummaries = remember(accounts, transactions) {
         calculateBalances(accounts, transactions)
     }
     val activeSummaries = remember(accountSummaries) {
         accountSummaries.filter { !it.account.isArchived }
+    }
+    val visibleSummaries = remember(accountSummaries, showArchived) {
+        if (showArchived) accountSummaries else activeSummaries
     }
     val totalEstimatedAssets = remember(activeSummaries, mainCurrency, rateSnapshot) {
         activeSummaries.fold(BigDecimal.ZERO) { accountTotal, summary ->
@@ -60,78 +71,75 @@ fun AccountsScreen(onEdit: (String) -> Unit) {
     }
 
     LazyColumn(
-        modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         item {
             Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.section)) {
-                SectionCard {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text(
-                            "總資產估算 ($mainCurrency)",
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Text(
-                            totalEstimatedAssets.asCurrencyText(mainCurrency),
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold
-                        )
-                        Text(
-                            "根據目前主幣別與匯率換算",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                ParityTopSection(
+                    title = "帳戶",
+                    subtitle = if (showArchived) "目前顯示所有帳戶，包含已歸檔項目。" else "總資產與幣別持有只計入未歸檔帳戶。",
+                    accessory = {
+                        TextButton(onClick = { showArchived = !showArchived }) {
+                            Text(if (showArchived) "隱藏歸檔" else "顯示歸檔")
+                        }
+                        TextButton(onClick = onAddAccount) {
+                            Text("新增")
+                        }
                     }
-                }
+                )
 
-                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-                    Text(
-                        "各幣種持有總額",
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold
+                if (!showArchived) {
+                    ParitySummaryCard(
+                        title = "總資產估算 ($mainCurrency)",
+                        value = totalEstimatedAssets.asCurrencyText(mainCurrency),
+                        supporting = "根據目前主幣別與匯率換算"
                     )
-                    if (currencyHoldings.isEmpty()) {
+
+                    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
                         Text(
-                            "目前沒有活動帳戶餘額",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            "各幣種持有總額",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold
                         )
-                    } else {
-                        Row(
-                            modifier = Modifier
-                                .horizontalScroll(rememberScrollState())
-                                .padding(horizontal = 2.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp)
-                        ) {
-                            currencyHoldings.forEach { holding ->
-                                Surface(
-                                    modifier = Modifier.width(152.dp),
-                                    shape = RoundedCornerShape(16.dp),
-                                    color = MaterialTheme.colorScheme.surfaceVariant,
-                                    border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
-                                ) {
-                                    Column(
-                                        modifier = Modifier.padding(AppSpacing.card),
-                                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                        if (currencyHoldings.isEmpty()) {
+                            Text(
+                                "目前沒有活動帳戶餘額",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        } else {
+                            Row(
+                                modifier = Modifier
+                                    .horizontalScroll(rememberScrollState())
+                                    .padding(horizontal = 2.dp),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                currencyHoldings.forEach { holding ->
+                                    Surface(
+                                        modifier = Modifier.width(156.dp),
+                                        shape = MaterialTheme.shapes.large,
+                                        color = MaterialTheme.colorScheme.surfaceVariant,
+                                        border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
                                     ) {
-                                        Text(
-                                            holding.currency,
-                                            style = MaterialTheme.typography.labelMedium,
-                                            fontWeight = FontWeight.Bold,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                        Text(
-                                            holding.amount.asCurrencyText(holding.currency),
-                                            style = MaterialTheme.typography.titleSmall,
-                                            fontWeight = FontWeight.SemiBold,
-                                            color = if (holding.amount.signum() >= 0) {
-                                                MaterialTheme.colorScheme.onSurface
-                                            } else {
-                                                MaterialTheme.colorScheme.error
-                                            }
-                                        )
+                                        Column(
+                                            modifier = Modifier.padding(AppSpacing.card),
+                                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                                        ) {
+                                            Text(
+                                                holding.currency,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                fontWeight = FontWeight.Bold,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                            Text(
+                                                holding.amount.asCurrencyText(holding.currency),
+                                                style = MaterialTheme.typography.titleSmall,
+                                                fontWeight = FontWeight.SemiBold,
+                                                color = if (holding.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -141,67 +149,74 @@ fun AccountsScreen(onEdit: (String) -> Unit) {
             }
         }
 
-        items(accountSummaries) { row ->
-            PressableCard(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onEdit(row.account.id.toString()) }
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically
+        if (visibleSummaries.isEmpty()) {
+            item {
+                Text(
+                    if (showArchived) "目前沒有任何帳戶。" else "目前沒有活動帳戶。",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            items(visibleSummaries, key = { it.account.id }) { row ->
+                PressableCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { onOpenDetail(row.account.id.toString()) }
                 ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    Row(
+                        modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
                         ) {
-                            Text(row.account.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                            if (row.account.isArchived) {
-                                Text(
-                                    "已歸檔",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                        }
-                        Text(
-                            "${row.account.type.rawValue} · ${row.account.currency}",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Column(horizontalAlignment = Alignment.End) {
-                        if (row.balances.isEmpty()) {
-                            Text("0.00", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        } else if (row.balances.size == 1) {
-                            val balance = row.balances.first()
-                            Text(
-                                balance.amount.asCurrencyText(balance.currency),
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
-                            )
-                        } else {
-                            Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                                row.balances.take(2).forEach { balance ->
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(row.account.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                if (row.account.isArchived) {
                                     Text(
-                                        balance.amount.asCurrencyText(balance.currency),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        fontWeight = FontWeight.SemiBold,
-                                        color = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
-                                    )
-                                }
-                                if (row.balances.size > 2) {
-                                    Text(
-                                        "...",
+                                        "已歸檔",
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
                                 }
                             }
+                            Text(
+                                "${row.account.type.rawValue} · ${row.account.currency}",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            if (row.balances.isEmpty()) {
+                                Text("0.00", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            } else if (row.balances.size == 1) {
+                                val balance = row.balances.first()
+                                Text(
+                                    balance.amount.asCurrencyText(balance.currency),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
+                                )
+                            } else {
+                                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    row.balances.take(2).forEach { balance ->
+                                        Text(
+                                            balance.amount.asCurrencyText(balance.currency),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = FontWeight.SemiBold,
+                                            color = if (balance.amount.signum() >= 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error
+                                        )
+                                    }
+                                    if (row.balances.size > 2) {
+                                        Text("...", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    }
+                                }
+                            }
+                            Text("查看明細", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                         }
                     }
                 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
@@ -35,6 +35,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
@@ -88,27 +92,32 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                end = AppSpacing.screenHorizontal,
+                bottom = ParityTokens.FloatingContentBottomPadding
+            )
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Text("基本資料", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "基本資料",
+            detail = "先決定方向、標題與主要付款帳戶。"
+        )
         SectionCard {
             Text("方向", style = MaterialTheme.typography.titleSmall)
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                AdvanceDirection.values().forEach { mode ->
-                    FilterChip(
-                        selected = direction == mode,
-                        onClick = {
-                            direction = mode
-                            if (expenseCategory != null && flowCategories.none { it.id == expenseCategory?.id }) {
-                                expenseCategory = null
-                            }
-                        },
-                        label = { Text(mode.label) }
-                    )
+            ParitySegmentedControl(
+                options = AdvanceDirection.values().toList(),
+                selected = direction,
+                label = { it.label },
+                onSelect = { mode ->
+                    direction = mode
+                    if (expenseCategory != null && flowCategories.none { it.id == expenseCategory?.id }) {
+                        expenseCategory = null
+                    }
                 }
-            }
+            )
             OutlinedTextField(
                 value = title,
                 onValueChange = { title = it },
@@ -119,15 +128,18 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                 payerAccount = acc
                 if (acc != null) currency = acc.currency
             }
-        AmountRow(
-            label = "自己的份額",
-            amount = myShare,
-            onAmountChange = { myShare = sanitizeAmount(it) },
-            currency = currency
-        )
+            AmountRow(
+                label = "自己的份額",
+                amount = myShare,
+                onAmountChange = { myShare = sanitizeAmount(it) },
+                currency = currency
+            )
         }
 
-        Text("分類與標籤", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "分類與標籤",
+            detail = "這會決定帳目歸類、報表與之後的預算分析。"
+        )
         SectionCard {
             CategoryPicker(
                 categories = flowCategories,
@@ -139,7 +151,12 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
             TagPicker(tags = tags, selected = selectedTags, onChange = { selectedTags = it })
         }
 
-        Text(if (direction == AdvanceDirection.IAdvanceOthers) "代墊對象" else "借款對象", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = if (direction == AdvanceDirection.IAdvanceOthers) "代墊對象" else "借款對象",
+            detail = "每位對象都會保留獨立的金額與後續還款追蹤。",
+            actionLabel = "新增對象",
+            onAction = { participants = participants + ParticipantDraft() }
+        )
         SectionCard {
             participants.forEachIndexed { index, participant ->
                 key(participant.id) {
@@ -161,15 +178,15 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                     )
                 }
             }
-            TextButton(onClick = { participants = participants + ParticipantDraft() }) {
-                Text("新增對象")
-            }
             TextButton(onClick = { showCreateDebtDialog = true }) {
                 Text("新增債務人物")
             }
         }
 
-        Text("備註", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "備註",
+            detail = "可補充這次代墊的場景、用途或之後追蹤要注意的事情。"
+        )
         SectionCard {
             OutlinedTextField(
                 value = note,
@@ -204,7 +221,8 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                     )
                     onDone()
                 }
-            }
+            },
+            modifier = Modifier.fillMaxWidth()
         ) {
             Text("儲存")
         }
@@ -274,7 +292,10 @@ private fun ParticipantEditor(
     onRemove: (() -> Unit)?
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text("對象 ${index + 1}", style = MaterialTheme.typography.titleSmall)
+        ParitySectionHeader(
+            title = "對象 ${index + 1}",
+            detail = "可先選債務人物，再填這位對應的金額。"
+        )
         AccountPicker(label = "欠款帳戶", accounts = debtAccounts, selected = participant.debtAccount) { acc ->
             onUpdate(participant.copy(debtAccount = acc))
         }
@@ -299,10 +320,12 @@ private fun AccountPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.titleSmall)
-        TextButton(onClick = { expanded = true }) {
-            Text(selected?.name ?: "選擇帳戶")
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.name.orEmpty(),
+            placeholder = "選擇帳戶",
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             accounts.forEach { account ->
                 DropdownMenuItem(text = { Text(account.name) }, onClick = {
@@ -348,10 +371,12 @@ private fun CategoryPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.titleSmall)
-        TextButton(onClick = { expanded = true }) {
-            Text(selected?.name ?: "無分類")
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.name.orEmpty(),
+            placeholder = "無分類",
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(
                 text = { Text("無分類") },

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -31,6 +30,10 @@ import org.duckdns.lhfser.aiaccounting.data.repository.TransferLeg
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import java.math.BigDecimal
@@ -81,24 +84,32 @@ fun AddTransferScreen(onDone: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                end = AppSpacing.screenHorizontal,
+                bottom = ParityTokens.FloatingContentBottomPadding
+            )
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Text("轉帳模式", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "轉帳模式",
+            detail = "一般、分拆與合併都會對齊 iOS 的轉帳建立方式。"
+        )
         SectionCard {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                AddTransferMode.values().forEach { item ->
-                    FilterChip(
-                        selected = mode == item,
-                        onClick = { mode = item },
-                        label = { Text(item.label) }
-                    )
-                }
-            }
+            ParitySegmentedControl(
+                options = AddTransferMode.values().toList(),
+                selected = mode,
+                label = { it.label },
+                onSelect = { mode = it }
+            )
         }
 
-        Text("轉帳內容", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "轉帳內容",
+            detail = "先決定來源與目的，再補每個分錄的實際金額。"
+        )
         SectionCard {
             when (mode) {
                 AddTransferMode.OneToOne -> {
@@ -189,7 +200,10 @@ fun AddTransferScreen(onDone: () -> Unit) {
             }
         }
 
-        Text("備註", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "備註",
+            detail = "可補充用途、匯率或這次轉帳的背景。"
+        )
         SectionCard {
             OutlinedTextField(
                 value = note,
@@ -259,7 +273,8 @@ fun AddTransferScreen(onDone: () -> Unit) {
                     }
                     onDone()
                 }
-            }
+            },
+            modifier = Modifier.fillMaxWidth()
         ) {
             Text("儲存")
         }
@@ -276,10 +291,12 @@ private fun AccountPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.titleSmall)
-        TextButton(onClick = { expanded = true }) {
-            Text(selected?.name ?: "選擇帳戶")
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.name.orEmpty(),
+            placeholder = "選擇帳戶",
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             accounts.forEach { account ->
                 DropdownMenuItem(
@@ -334,7 +351,10 @@ private fun TransferLegEditor(
     onRemove: (() -> Unit)?
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(title, style = MaterialTheme.typography.titleSmall)
+        ParitySectionHeader(
+            title = title,
+            detail = "可用不同帳戶與幣別拆分這次轉帳。"
+        )
         AccountPicker(label = "帳戶", accounts = accounts, selected = leg.account) { acc ->
             onUpdate(leg.copy(account = acc, currency = acc?.currency ?: leg.currency))
         }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
@@ -1,0 +1,534 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import android.app.DatePickerDialog
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+
+private enum class DebtMode(val label: String) {
+    Borrow("借入 (我欠人)"),
+    Repay("還款 (還給人)")
+}
+
+private enum class DebtEntryMode(val label: String) {
+    Normal("一般"),
+    Split("分拆 (1 -> 多)"),
+    Merge("合併 (多 -> 1)")
+}
+
+private data class DebtSplitLeg(
+    val id: UUID = UUID.randomUUID(),
+    val account: AccountEntity? = null,
+    val currency: String = "HKD",
+    val amount: String = ""
+)
+
+private data class DebtMergeLeg(
+    val id: UUID = UUID.randomUUID(),
+    val currency: String = "HKD",
+    val amount: String = ""
+)
+
+@Composable
+fun DebtEntryScreen(onDone: () -> Unit) {
+    val repository = LocalRepository.current
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val scrollState = rememberScrollState()
+
+    val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val debtAccounts = remember(accounts) { accounts.filter { it.type == AccountType.Debt && !it.isArchived }.sortedBy { it.name } }
+    val myAccounts = remember(accounts) { accounts.filter { it.type != AccountType.Debt && !it.isArchived }.sortedBy { it.sortOrder } }
+
+    var mode by remember { mutableStateOf(DebtMode.Borrow) }
+    var entryMode by remember { mutableStateOf(DebtEntryMode.Normal) }
+    var selectedDebtAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var selectedMyAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var selectedCurrency by remember { mutableStateOf("HKD") }
+    var amountInput by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+    var date by remember { mutableStateOf(Instant.now()) }
+    var splitLegs by remember { mutableStateOf(listOf(DebtSplitLeg())) }
+    var mergeLegs by remember { mutableStateOf(listOf(DebtMergeLeg())) }
+    var validationMessage by remember { mutableStateOf<String?>(null) }
+
+    if (selectedDebtAccount == null && debtAccounts.isNotEmpty()) {
+        selectedDebtAccount = debtAccounts.first()
+    }
+    if (selectedMyAccount == null && myAccounts.isNotEmpty()) {
+        selectedMyAccount = myAccounts.first()
+        selectedCurrency = selectedMyAccount?.currency ?: selectedCurrency
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        ParityTopSection(
+            title = "借貸管理",
+            subtitle = "和 iOS 一樣，借貸會落成一組或多組轉帳分錄，方便之後繼續編輯與對帳。"
+        )
+
+        SectionCard {
+            ParitySegmentedControl(
+                options = DebtMode.values().toList(),
+                selected = mode,
+                label = { it.label },
+                onSelect = { mode = it }
+            )
+            ParitySegmentedControl(
+                options = DebtEntryMode.values().toList(),
+                selected = entryMode,
+                label = { it.label },
+                onSelect = { entryMode = it }
+            )
+        }
+
+        SectionCard {
+            AccountMenuPicker(
+                label = if (mode == DebtMode.Borrow) "跟誰借" else "還給誰",
+                options = debtAccounts,
+                selected = selectedDebtAccount,
+                onSelect = { selectedDebtAccount = it }
+            )
+            if (entryMode != DebtEntryMode.Split) {
+                AccountMenuPicker(
+                    label = if (mode == DebtMode.Borrow) "存入帳戶" else "付款帳戶",
+                    options = myAccounts,
+                    selected = selectedMyAccount,
+                    onSelect = {
+                        selectedMyAccount = it
+                        if (it != null) {
+                            selectedCurrency = it.currency
+                        }
+                    }
+                )
+            }
+        }
+
+        SectionCard {
+            when (entryMode) {
+                DebtEntryMode.Normal -> {
+                    AmountCurrencyRow(
+                        amount = amountInput,
+                        onAmountChange = { amountInput = sanitizeAmount(it) },
+                        currency = selectedCurrency,
+                        onCurrencyChange = { selectedCurrency = it }
+                    )
+                }
+                DebtEntryMode.Split -> {
+                    splitLegs.forEachIndexed { index, leg ->
+                        DebtSplitLegEditor(
+                            index = index,
+                            leg = leg,
+                            accounts = myAccounts,
+                            onUpdate = { updated ->
+                                splitLegs = splitLegs.toMutableList().also { it[index] = updated }
+                            },
+                            onRemove = if (splitLegs.size > 1) {
+                                { splitLegs = splitLegs.toMutableList().also { it.removeAt(index) } }
+                            } else null
+                        )
+                    }
+                    TextButton(onClick = { splitLegs = splitLegs + DebtSplitLeg(currency = selectedCurrency) }) {
+                        Text("新增分拆帳戶")
+                    }
+                }
+                DebtEntryMode.Merge -> {
+                    mergeLegs.forEachIndexed { index, leg ->
+                        DebtMergeLegEditor(
+                            index = index,
+                            leg = leg,
+                            onUpdate = { updated ->
+                                mergeLegs = mergeLegs.toMutableList().also { it[index] = updated }
+                            },
+                            onRemove = if (mergeLegs.size > 1) {
+                                { mergeLegs = mergeLegs.toMutableList().also { it.removeAt(index) } }
+                            } else null
+                        )
+                    }
+                    TextButton(onClick = { mergeLegs = mergeLegs + DebtMergeLeg(currency = selectedCurrency) }) {
+                        Text("新增合併金額項")
+                    }
+                }
+            }
+
+            TextButton(onClick = {
+                val localDate = date.atZone(ZoneId.systemDefault()).toLocalDate()
+                DatePickerDialog(
+                    context,
+                    { _, year, month, day ->
+                        date = LocalDate.of(year, month + 1, day)
+                            .atStartOfDay(ZoneId.systemDefault())
+                            .toInstant()
+                    },
+                    localDate.year,
+                    localDate.monthValue - 1,
+                    localDate.dayOfMonth
+                ).show()
+            }) {
+                Text("日期：${date.toDateText()}")
+            }
+
+            OutlinedTextField(
+                value = note,
+                onValueChange = { note = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("備註") }
+            )
+        }
+
+        ParitySummaryCard(
+            title = "交易預覽",
+            value = totalAmountPreview(entryMode, amountInput, splitLegs, mergeLegs),
+            supporting = when (mode) {
+                DebtMode.Borrow -> "借入會讓借貸帳戶出帳、你的帳戶入帳"
+                DebtMode.Repay -> "還款會讓你的帳戶出帳、借貸帳戶入帳"
+            }
+        )
+
+        if (validationMessage != null) {
+            Text(validationMessage.orEmpty(), color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+
+        Button(
+            onClick = {
+                val debtAccount = selectedDebtAccount
+                if (debtAccount == null) {
+                    validationMessage = "請先選擇借貸對象。"
+                    return@Button
+                }
+                val transactions = buildDebtTransactions(
+                    mode = mode,
+                    entryMode = entryMode,
+                    debtAccount = debtAccount,
+                    myAccount = selectedMyAccount,
+                    date = date,
+                    note = note,
+                    currency = selectedCurrency,
+                    amountInput = amountInput,
+                    splitLegs = splitLegs,
+                    mergeLegs = mergeLegs
+                )
+                if (transactions == null) {
+                    validationMessage = "請輸入完整金額並選擇需要的帳戶。"
+                    return@Button
+                }
+                scope.launch {
+                    repository.upsertTransactions(transactions)
+                    onDone()
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = debtAccounts.isNotEmpty() && myAccounts.isNotEmpty()
+        ) {
+            Text("確認")
+        }
+    }
+}
+
+@Composable
+private fun AccountMenuPicker(
+    label: String,
+    options: List<AccountEntity>,
+    selected: AccountEntity?,
+    onSelect: (AccountEntity?) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(label, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+        TextButton(onClick = { expanded = true }, modifier = Modifier.fillMaxWidth()) {
+            Text(selected?.name ?: "請選擇")
+        }
+        androidx.compose.material3.DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { account ->
+                androidx.compose.material3.DropdownMenuItem(
+                    text = { Text(account.name) },
+                    onClick = {
+                        expanded = false
+                        onSelect(account)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AmountCurrencyRow(
+    amount: String,
+    onAmountChange: (String) -> Unit,
+    currency: String,
+    onCurrencyChange: (String) -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.weight(1f)) {
+            OutlinedTextField(
+                value = amount,
+                onValueChange = onAmountChange,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("金額") }
+            )
+        }
+        CurrencyPicker(selected = currency, onSelect = onCurrencyChange, buttonStyle = CurrencyButtonStyle.Text)
+    }
+}
+
+@Composable
+private fun DebtSplitLegEditor(
+    index: Int,
+    leg: DebtSplitLeg,
+    accounts: List<AccountEntity>,
+    onUpdate: (DebtSplitLeg) -> Unit,
+    onRemove: (() -> Unit)?
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        AccountMenuPicker(
+            label = "分拆帳戶 ${index + 1}",
+            options = accounts,
+            selected = leg.account,
+            onSelect = {
+                onUpdate(leg.copy(account = it, currency = it?.currency ?: leg.currency))
+            }
+        )
+        AmountCurrencyRow(
+            amount = leg.amount,
+            onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
+            currency = leg.currency,
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+        )
+        if (onRemove != null) {
+            TextButton(onClick = onRemove) { Text("移除此帳戶") }
+        }
+    }
+}
+
+@Composable
+private fun DebtMergeLegEditor(
+    index: Int,
+    leg: DebtMergeLeg,
+    onUpdate: (DebtMergeLeg) -> Unit,
+    onRemove: (() -> Unit)?
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("合併金額項 ${index + 1}", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+        AmountCurrencyRow(
+            amount = leg.amount,
+            onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
+            currency = leg.currency,
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+        )
+        if (onRemove != null) {
+            TextButton(onClick = onRemove) { Text("移除此金額項") }
+        }
+    }
+}
+
+private fun buildDebtTransactions(
+    mode: DebtMode,
+    entryMode: DebtEntryMode,
+    debtAccount: AccountEntity,
+    myAccount: AccountEntity?,
+    date: Instant,
+    note: String,
+    currency: String,
+    amountInput: String,
+    splitLegs: List<DebtSplitLeg>,
+    mergeLegs: List<DebtMergeLeg>
+): List<TransactionEntity>? {
+    return when (entryMode) {
+        DebtEntryMode.Normal -> {
+            val account = myAccount ?: return null
+            val amount = amountInput.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO } ?: return null
+            createDebtPair(mode, debtAccount, account, amount, currency, date, note)
+        }
+        DebtEntryMode.Split -> {
+            val legs = splitLegs.map { leg ->
+                val account = leg.account ?: return null
+                val amount = leg.amount.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO } ?: return null
+                Triple(account, amount, leg.currency)
+            }
+            legs.flatMapIndexed { index, (account, amount, legCurrency) ->
+                createDebtPair(mode, debtAccount, account, amount, legCurrency, date, indexedMemo(note, entryMode, index, legs.size))
+            }
+        }
+        DebtEntryMode.Merge -> {
+            val account = myAccount ?: return null
+            val items = mergeLegs.map { leg ->
+                val amount = leg.amount.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO } ?: return null
+                amount to leg.currency
+            }
+            items.flatMapIndexed { index, (amount, legCurrency) ->
+                createDebtPair(mode, debtAccount, account, amount, legCurrency, date, indexedMemo(note, entryMode, index, items.size))
+            }
+        }
+    }
+}
+
+private fun createDebtPair(
+    mode: DebtMode,
+    debtAccount: AccountEntity,
+    myAccount: AccountEntity,
+    amount: BigDecimal,
+    currencyCode: String,
+    date: Instant,
+    memo: String
+): List<TransactionEntity> {
+    val finalMemo = memo.trim().ifBlank { mode.label }
+    val groupId = UUID.randomUUID()
+    val firstId = UUID.randomUUID()
+    val secondId = UUID.randomUUID()
+    return if (mode == DebtMode.Borrow) {
+        listOf(
+            TransactionEntity(
+                id = firstId,
+                amount = amount.abs().negate(),
+                currencyCode = currencyCode,
+                date = date,
+                note = "$finalMemo (借入至 ${myAccount.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = secondId,
+                transferGroupId = groupId,
+                transferSide = TransferSide.Outgoing,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                accountId = debtAccount.id,
+                categoryId = null
+            ),
+            TransactionEntity(
+                id = secondId,
+                amount = amount.abs(),
+                currencyCode = currencyCode,
+                date = date,
+                note = "$finalMemo (來自 ${debtAccount.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = firstId,
+                transferGroupId = groupId,
+                transferSide = TransferSide.Incoming,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                accountId = myAccount.id,
+                categoryId = null
+            )
+        )
+    } else {
+        listOf(
+            TransactionEntity(
+                id = firstId,
+                amount = amount.abs().negate(),
+                currencyCode = currencyCode,
+                date = date,
+                note = "$finalMemo (還款給 ${debtAccount.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = secondId,
+                transferGroupId = groupId,
+                transferSide = TransferSide.Outgoing,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                accountId = myAccount.id,
+                categoryId = null
+            ),
+            TransactionEntity(
+                id = secondId,
+                amount = amount.abs(),
+                currencyCode = currencyCode,
+                date = date,
+                note = "$finalMemo (來自 ${myAccount.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = firstId,
+                transferGroupId = groupId,
+                transferSide = TransferSide.Incoming,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                accountId = debtAccount.id,
+                categoryId = null
+            )
+        )
+    }
+}
+
+private fun totalAmountPreview(
+    entryMode: DebtEntryMode,
+    amountInput: String,
+    splitLegs: List<DebtSplitLeg>,
+    mergeLegs: List<DebtMergeLeg>
+): String {
+    val total = when (entryMode) {
+        DebtEntryMode.Normal -> amountInput.toBigDecimalOrNull()
+        DebtEntryMode.Split -> splitLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == splitLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
+        DebtEntryMode.Merge -> mergeLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == mergeLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
+    }
+    return total?.toPlainString() ?: "尚未完成輸入"
+}
+
+private fun sanitizeAmount(input: String): String {
+    var hasDot = false
+    return buildString {
+        input.forEach { char ->
+            when {
+                char.isDigit() -> append(char)
+                char == '.' && !hasDot -> {
+                    append(char)
+                    hasDot = true
+                }
+            }
+        }
+    }.removePrefix(".")
+}
+
+private fun indexedMemo(base: String, mode: DebtEntryMode, index: Int, count: Int): String {
+    val suffix = when (mode) {
+        DebtEntryMode.Split -> "[分拆 ${index + 1}/$count]"
+        DebtEntryMode.Merge -> "[合併 ${index + 1}/$count]"
+        DebtEntryMode.Normal -> ""
+    }
+    val trimmed = base.trim()
+    return listOf(trimmed, suffix).filter { it.isNotBlank() }.joinToString(" ")
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -33,9 +35,13 @@ import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
@@ -104,7 +110,12 @@ fun DebtEntryScreen(onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         ParityTopSection(
@@ -113,6 +124,10 @@ fun DebtEntryScreen(onDone: () -> Unit) {
         )
 
         SectionCard {
+            ParitySectionHeader(
+                title = "借貸方式",
+                detail = "先選操作，再決定一般 / 分拆 / 合併模式"
+            )
             ParitySegmentedControl(
                 options = DebtMode.values().toList(),
                 selected = mode,
@@ -127,29 +142,44 @@ fun DebtEntryScreen(onDone: () -> Unit) {
             )
         }
 
-        SectionCard {
-            AccountMenuPicker(
-                label = if (mode == DebtMode.Borrow) "跟誰借" else "還給誰",
-                options = debtAccounts,
-                selected = selectedDebtAccount,
-                onSelect = { selectedDebtAccount = it }
+        if (debtAccounts.isEmpty()) {
+            ParityEmptyState(
+                title = "還沒有借貸對象",
+                message = "先到帳戶頁建立類型為借貸的帳戶，之後才能記錄借入與還款流程。"
             )
-            if (entryMode != DebtEntryMode.Split) {
-                AccountMenuPicker(
-                    label = if (mode == DebtMode.Borrow) "存入帳戶" else "付款帳戶",
-                    options = myAccounts,
-                    selected = selectedMyAccount,
-                    onSelect = {
-                        selectedMyAccount = it
-                        if (it != null) {
-                            selectedCurrency = it.currency
-                        }
-                    }
+        } else {
+            SectionCard {
+                ParitySectionHeader(
+                    title = "帳戶與對象",
+                    detail = "選擇借貸對象與你的實際資金帳戶"
                 )
+                AccountMenuPicker(
+                    label = if (mode == DebtMode.Borrow) "跟誰借" else "還給誰",
+                    options = debtAccounts,
+                    selected = selectedDebtAccount,
+                    onSelect = { selectedDebtAccount = it }
+                )
+                if (entryMode != DebtEntryMode.Split) {
+                    AccountMenuPicker(
+                        label = if (mode == DebtMode.Borrow) "存入帳戶" else "付款帳戶",
+                        options = myAccounts,
+                        selected = selectedMyAccount,
+                        onSelect = {
+                            selectedMyAccount = it
+                            if (it != null) {
+                                selectedCurrency = it.currency
+                            }
+                        }
+                    )
+                }
             }
         }
 
         SectionCard {
+            ParitySectionHeader(
+                title = "金額與時間",
+                detail = "這裡的資料會直接影響之後產生的轉帳分錄"
+            )
             when (entryMode) {
                 DebtEntryMode.Normal -> {
                     AmountCurrencyRow(
@@ -262,7 +292,11 @@ fun DebtEntryScreen(onDone: () -> Unit) {
                     onDone()
                 }
             },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
             enabled = debtAccounts.isNotEmpty() && myAccounts.isNotEmpty()
         ) {
             Text("確認")
@@ -279,10 +313,11 @@ private fun AccountMenuPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
-        TextButton(onClick = { expanded = true }, modifier = Modifier.fillMaxWidth()) {
-            Text(selected?.name ?: "請選擇")
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.name.orEmpty(),
+            onClick = { expanded = true }
+        )
         androidx.compose.material3.DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEach { account ->
                 androidx.compose.material3.DropdownMenuItem(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -52,6 +52,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
@@ -114,19 +115,10 @@ fun OverviewScreen(
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.tight)) {
-            Text("歡迎使用 AI 記帳", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-            Text(
-                "今天是 ${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                "${filterDisplayString(filterType, selectedDate)}已記錄 $recordCount 筆收入/支出",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+        ParityTopSection(
+            title = "總覽",
+            subtitle = "今天是 ${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))} · ${filterDisplayString(filterType, selectedDate)}已記錄 $recordCount 筆收入/支出"
+        )
 
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Surface(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -253,17 +253,41 @@ private fun EntryButton(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Icon(
-                icon,
-                contentDescription = null,
-                modifier = Modifier.size(22.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
+            androidx.compose.material3.Surface(
+                modifier = Modifier.size(40.dp),
+                shape = MaterialTheme.shapes.medium,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
             Column(modifier = Modifier.weight(1f)) {
                 androidx.compose.material3.Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                 androidx.compose.material3.Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Icon(Icons.Default.ChevronRight, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            androidx.compose.material3.Surface(
+                modifier = Modifier.size(28.dp),
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.surface
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.ChevronRight, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -1,8 +1,6 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
 import android.app.DatePickerDialog
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,22 +11,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Book
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.ReceiptLong
-import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -43,7 +37,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -52,10 +45,13 @@ import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
-import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 
 private enum class OverviewFilterType(val label: String) {
     All("全部"),
@@ -63,8 +59,6 @@ private enum class OverviewFilterType(val label: String) {
     Month("本月"),
     Day("今日")
 }
-
-private val OverviewFilterShape = RoundedCornerShape(18.dp)
 
 @Composable
 fun OverviewScreen(
@@ -120,35 +114,17 @@ fun OverviewScreen(
             subtitle = "今天是 ${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))} · ${filterDisplayString(filterType, selectedDate)}已記錄 $recordCount 筆收入/支出"
         )
 
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Surface(
-                modifier = Modifier.clickable { showFilterDialog = true },
-                shape = OverviewFilterShape,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
-                border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        filterDisplayString(filterType, selectedDate),
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OverviewFilterType.values().forEach { type ->
-                    FilterChip(
-                        selected = filterType == type,
-                        onClick = { filterType = type },
-                        label = { Text(type.label) }
-                    )
-                }
-            }
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            ParityFilterCapsule(
+                label = filterDisplayString(filterType, selectedDate),
+                onClick = { showFilterDialog = true }
+            )
+            ParitySegmentedControl(
+                options = OverviewFilterType.values().toList(),
+                selected = filterType,
+                label = { it.label },
+                onSelect = { filterType = it }
+            )
         }
 
         PressableCard(
@@ -157,8 +133,18 @@ fun OverviewScreen(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
             pressedContainerColor = MaterialTheme.colorScheme.surface
         ) {
-            Column(modifier = Modifier.padding(AppSpacing.card), verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-                Text("快速開始", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Column(
+                modifier = Modifier.padding(AppSpacing.card),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    androidx.compose.material3.Text("快速開始", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    androidx.compose.material3.Text(
+                        "先記一筆，或直接打開教學頁快速熟悉主要流程。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                     Button(
                         onClick = onQuickAdd,
@@ -169,7 +155,7 @@ fun OverviewScreen(
                     ) {
                         Icon(Icons.AutoMirrored.Filled.ReceiptLong, contentDescription = null)
                         Spacer(modifier = Modifier.width(6.dp))
-                        Text("新增記錄")
+                        androidx.compose.material3.Text("新增記錄")
                     }
                     Button(
                         onClick = onOpenGuide,
@@ -180,14 +166,14 @@ fun OverviewScreen(
                     ) {
                         Icon(Icons.Default.Book, contentDescription = null)
                         Spacer(modifier = Modifier.width(6.dp))
-                        Text("使用教學")
+                        androidx.compose.material3.Text("使用教學")
                     }
                 }
             }
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text(
+            androidx.compose.material3.Text(
                 "${filterDisplayString(filterType, selectedDate)}重點（$baseCurrency）",
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.SemiBold
@@ -203,7 +189,7 @@ fun OverviewScreen(
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text("功能入口", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            androidx.compose.material3.Text("功能入口", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
             EntryButton(
                 icon = Icons.AutoMirrored.Filled.List,
                 title = "查看帳目明細",
@@ -241,24 +227,12 @@ fun OverviewScreen(
 
 @Composable
 private fun SummaryTile(label: String, value: String, tint: Color, modifier: Modifier = Modifier) {
-    PressableCard(
+    ParitySummaryCard(
+        title = label,
+        value = value,
         modifier = modifier,
-        onClick = {},
-        containerColor = tint.copy(alpha = 0.08f),
-        pressedContainerColor = tint.copy(alpha = 0.12f),
-        borderColor = tint.copy(alpha = 0.12f),
-        pressedBorderColor = tint.copy(alpha = 0.2f)
-    ) {
-        Column(modifier = Modifier.padding(AppSpacing.card), verticalArrangement = Arrangement.spacedBy(AppSpacing.tight)) {
-            Text(
-                label,
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = tint)
-        }
-    }
+        accent = tint
+    )
 }
 
 @Composable
@@ -286,8 +260,8 @@ private fun EntryButton(
                 tint = MaterialTheme.colorScheme.primary
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                androidx.compose.material3.Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                androidx.compose.material3.Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             Icon(Icons.Default.ChevronRight, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
         }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -49,6 +49,7 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
@@ -106,7 +107,12 @@ fun OverviewScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         ParityTopSection(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
@@ -51,8 +52,11 @@ import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import java.math.BigDecimal
@@ -110,7 +114,12 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         ParityTopSection(
@@ -119,6 +128,10 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
         )
 
         SectionCard {
+            ParitySectionHeader(
+                title = "上傳單據",
+                detail = "你可以先挑圖片，再決定是否補充備註給 AI"
+            )
             if (imageBytes == null) {
                 Surface(
                     modifier = Modifier
@@ -157,7 +170,13 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                             .height(240.dp)
                     )
                 }
-                Button(onClick = { imagePicker.launch("image/*") }, modifier = Modifier.fillMaxWidth()) {
+                Button(
+                    onClick = { imagePicker.launch("image/*") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(50.dp),
+                    shape = RoundedCornerShape(18.dp)
+                ) {
                     Text("更換單據圖片")
                 }
             }
@@ -194,7 +213,10 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                         isAnalyzing = false
                     }
                 },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp),
+                shape = RoundedCornerShape(18.dp),
                 enabled = imageBytes != null && !isAnalyzing
             ) {
                 Text(if (isAnalyzing) "AI 分析中..." else "開始智能識別")
@@ -217,30 +239,38 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
             )
 
             SectionCard {
+                ParitySectionHeader(
+                    title = "確認與調整",
+                    detail = "金額、帳戶、分類、日期時間都可以在儲存前修改"
+                )
                 OutlinedTextField(
                     value = amountInput,
                     onValueChange = { amountInput = sanitizeDecimal(it) },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("金額") }
+                    label = { Text("金額") },
+                    shape = RoundedCornerShape(18.dp)
                 )
                 CurrencyPicker(selected = currencyCode, onSelect = { currencyCode = it }, buttonStyle = CurrencyButtonStyle.Text)
                 OutlinedTextField(
                     value = dateInput,
                     onValueChange = { dateInput = it },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("日期（YYYY-MM-DD）") }
+                    label = { Text("日期（YYYY-MM-DD）") },
+                    shape = RoundedCornerShape(18.dp)
                 )
                 OutlinedTextField(
                     value = timeInput,
                     onValueChange = { timeInput = it },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("時間（HH:mm，可選）") }
+                    label = { Text("時間（HH:mm，可選）") },
+                    shape = RoundedCornerShape(18.dp)
                 )
                 OutlinedTextField(
                     value = noteInput,
                     onValueChange = { noteInput = it },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("商戶 / 備註") }
+                    label = { Text("商戶 / 備註") },
+                    shape = RoundedCornerShape(18.dp)
                 )
                 EntityPicker(
                     label = "帳戶",
@@ -281,7 +311,11 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                             onDone()
                         }
                     },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(50.dp),
+                    shape = RoundedCornerShape(18.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                     enabled = selectedAccount != null && amountInput.toBigDecimalOrNull() != null
                 ) {
                     Text("儲存為支出")
@@ -301,21 +335,11 @@ private fun <T> EntityPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { expanded = true },
-            shape = RoundedCornerShape(14.dp),
-            color = MaterialTheme.colorScheme.surface,
-            border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
-        ) {
-            Text(
-                text = selected?.let(optionLabel) ?: "請選擇",
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp),
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.let(optionLabel).orEmpty(),
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             options.forEach { option ->
                 DropdownMenuItem(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
@@ -1,0 +1,377 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import android.graphics.BitmapFactory
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.duckdns.lhfser.aiaccounting.core.ai.GeminiSettingsStore
+import org.duckdns.lhfser.aiaccounting.core.ai.ReceiptInfo
+import org.duckdns.lhfser.aiaccounting.core.ai.ReceiptScanService
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Composable
+fun ReceiptScanScreen(onDone: () -> Unit) {
+    val context = LocalContext.current
+    val repository = LocalRepository.current
+    val scope = rememberCoroutineScope()
+    val service = remember(context) { ReceiptScanService(GeminiSettingsStore(context)) }
+    val scrollState = rememberScrollState()
+
+    val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val categories by repository.categories.collectAsState(initial = emptyList())
+    val activeAccounts = remember(accounts) { accounts.filter { !it.isArchived } }
+    val expenseCategories = remember(categories) { categories.filter { it.kind.supports(TransactionType.Expense) } }
+
+    var imageBytes by remember { mutableStateOf<ByteArray?>(null) }
+    var userNote by remember { mutableStateOf("") }
+    var isAnalyzing by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var scanResult by remember { mutableStateOf<ReceiptInfo?>(null) }
+
+    var amountInput by remember { mutableStateOf("") }
+    var currencyCode by remember { mutableStateOf("HKD") }
+    var dateInput by remember { mutableStateOf(LocalDate.now().toString()) }
+    var timeInput by remember { mutableStateOf("") }
+    var noteInput by remember { mutableStateOf("") }
+    var selectedAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
+
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            imageBytes = withContext(Dispatchers.IO) {
+                context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            }
+        }
+    }
+
+    LaunchedEffect(activeAccounts) {
+        if (selectedAccount == null) {
+            selectedAccount = activeAccounts.firstOrNull()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        ParityTopSection(
+            title = "掃描單據",
+            subtitle = "上傳單據圖片，先由 AI 識別，再由你確認後才寫入帳目。"
+        )
+
+        SectionCard {
+            if (imageBytes == null) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(240.dp)
+                        .clickable { imagePicker.launch("image/*") },
+                    shape = RoundedCornerShape(18.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        androidx.compose.material3.Icon(
+                            imageVector = Icons.Default.CameraAlt,
+                            contentDescription = null,
+                            modifier = Modifier.size(42.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Text("上傳或拍攝單據", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                        Text("支援從相簿或檔案挑選圖片", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            } else {
+                val bitmap = remember(imageBytes) {
+                    imageBytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+                }
+                if (bitmap != null) {
+                    Image(
+                        bitmap = bitmap.asImageBitmap(),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(240.dp)
+                    )
+                }
+                Button(onClick = { imagePicker.launch("image/*") }, modifier = Modifier.fillMaxWidth()) {
+                    Text("更換單據圖片")
+                }
+            }
+
+            OutlinedTextField(
+                value = userNote,
+                onValueChange = { userNote = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("備註（可選）") },
+                placeholder = { Text("例如：我和朋友 AA 制，只計我自己的餐費") }
+            )
+
+            Button(
+                onClick = {
+                    val bytes = imageBytes ?: return@Button
+                    isAnalyzing = true
+                    errorMessage = null
+                    scope.launch {
+                        runCatching {
+                            service.analyzeReceipt(bytes, userNote, expenseCategories.map { it.name })
+                        }.onSuccess { result ->
+                            scanResult = result
+                            amountInput = result.amount.toPlainString()
+                            currencyCode = normalizedCurrencyCode(result.currency, selectedAccount?.currency ?: "HKD")
+                            dateInput = result.date
+                            timeInput = result.time.orEmpty()
+                            noteInput = listOf(result.merchant, result.note)
+                                .filter { it.isNotBlank() }
+                                .joinToString(" - ")
+                            selectedCategory = matchCategory(expenseCategories, result.categoryName)
+                        }.onFailure {
+                            errorMessage = it.localizedMessage ?: "AI 識別失敗"
+                        }
+                        isAnalyzing = false
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = imageBytes != null && !isAnalyzing
+            ) {
+                Text(if (isAnalyzing) "AI 分析中..." else "開始智能識別")
+            }
+
+            if (errorMessage != null) {
+                Text(
+                    text = errorMessage.orEmpty(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        if (scanResult != null) {
+            ParitySummaryCard(
+                title = "AI 識別結果",
+                value = "請確認後再入帳",
+                supporting = "AI 只提供建議，你可以在儲存前修改所有欄位。"
+            )
+
+            SectionCard {
+                OutlinedTextField(
+                    value = amountInput,
+                    onValueChange = { amountInput = sanitizeDecimal(it) },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("金額") }
+                )
+                CurrencyPicker(selected = currencyCode, onSelect = { currencyCode = it }, buttonStyle = CurrencyButtonStyle.Text)
+                OutlinedTextField(
+                    value = dateInput,
+                    onValueChange = { dateInput = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("日期（YYYY-MM-DD）") }
+                )
+                OutlinedTextField(
+                    value = timeInput,
+                    onValueChange = { timeInput = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("時間（HH:mm，可選）") }
+                )
+                OutlinedTextField(
+                    value = noteInput,
+                    onValueChange = { noteInput = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("商戶 / 備註") }
+                )
+                EntityPicker(
+                    label = "帳戶",
+                    options = activeAccounts,
+                    selected = selectedAccount,
+                    optionLabel = { it.name },
+                    onSelect = { selectedAccount = it }
+                )
+                EntityPicker(
+                    label = "分類",
+                    options = expenseCategories,
+                    selected = selectedCategory,
+                    optionLabel = { it.name },
+                    onSelect = { selectedCategory = it }
+                )
+                Button(
+                    onClick = {
+                        val account = selectedAccount ?: return@Button
+                        val amount = amountInput.toBigDecimalOrNull() ?: return@Button
+                        val transaction = TransactionEntity(
+                            id = UUID.randomUUID(),
+                            amount = amount.abs().negate(),
+                            currencyCode = currencyCode,
+                            date = parseDateTime(dateInput, timeInput),
+                            note = noteInput,
+                            photoPath = null,
+                            type = TransactionType.Expense,
+                            linkedTransactionId = null,
+                            transferGroupId = null,
+                            transferSide = null,
+                            createdAt = Instant.now(),
+                            updatedAt = Instant.now(),
+                            accountId = account.id,
+                            categoryId = selectedCategory?.id
+                        )
+                        scope.launch {
+                            repository.upsertTransaction(transaction, emptyList())
+                            onDone()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = selectedAccount != null && amountInput.toBigDecimalOrNull() != null
+                ) {
+                    Text("儲存為支出")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun <T> EntityPicker(
+    label: String,
+    options: List<T>,
+    selected: T?,
+    optionLabel: (T) -> String,
+    onSelect: (T) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(label, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = true },
+            shape = RoundedCornerShape(14.dp),
+            color = MaterialTheme.colorScheme.surface,
+            border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
+        ) {
+            Text(
+                text = selected?.let(optionLabel) ?: "請選擇",
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(optionLabel(option)) },
+                    onClick = {
+                        expanded = false
+                        onSelect(option)
+                    }
+                )
+            }
+        }
+    }
+}
+
+private fun parseDateTime(dateRaw: String, timeRaw: String): Instant {
+    val date = runCatching { LocalDate.parse(dateRaw, DateTimeFormatter.ISO_LOCAL_DATE) }.getOrNull() ?: LocalDate.now()
+    val time = if (timeRaw.isBlank()) {
+        LocalTime.now().withSecond(0).withNano(0)
+    } else {
+        runCatching { LocalTime.parse(timeRaw, DateTimeFormatter.ofPattern("HH:mm")) }.getOrNull()
+            ?: LocalTime.now().withSecond(0).withNano(0)
+    }
+    return LocalDateTime.of(date, time).atZone(ZoneId.systemDefault()).toInstant()
+}
+
+private fun matchCategory(categories: List<CategoryEntity>, name: String): CategoryEntity? {
+    val normalized = name.trim()
+    if (normalized.isBlank()) return null
+    return categories.firstOrNull { it.name.equals(normalized, ignoreCase = true) }
+        ?: categories.firstOrNull { it.name.contains(normalized, ignoreCase = true) || normalized.contains(it.name, ignoreCase = true) }
+}
+
+private fun normalizedCurrencyCode(raw: String, fallback: String): String {
+    return when (raw.trim().uppercase()) {
+        "HKD", "HK$", "H$" -> "HKD"
+        "USD", "US$", "$" -> "USD"
+        "TWD", "NT$", "NTD" -> "TWD"
+        "JPY", "¥" -> "JPY"
+        "CNY", "RMB", "CN¥" -> "CNY"
+        "EUR", "€" -> "EUR"
+        "GBP", "£" -> "GBP"
+        else -> fallback.trim().uppercase()
+    }
+}
+
+private fun sanitizeDecimal(input: String): String {
+    var hasDot = false
+    return buildString {
+        input.forEach { char ->
+            when {
+                char.isDigit() -> append(char)
+                char == '.' && !hasDot -> {
+                    append(char)
+                    hasDot = true
+                }
+            }
+        }
+    }.removePrefix(".")
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -3,8 +3,6 @@ package org.duckdns.lhfser.aiaccounting.ui.screens
 import android.app.DatePickerDialog
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,15 +11,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -34,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,28 +44,29 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.shape.RoundedCornerShape
-import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
-import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
-import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
-import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
-import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
-import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
-import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
-import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
-import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
-import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
-import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 
 private enum class ReportFilterType(val label: String) {
     All("全部時間"),
@@ -107,8 +103,6 @@ private data class BudgetAlert(
     val remaining: BigDecimal,
     val categoryName: String
 )
-
-private val ReportFilterShape = RoundedCornerShape(18.dp)
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -162,52 +156,28 @@ fun ReportsScreen() {
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
-            verticalArrangement = Arrangement.spacedBy(0.dp)
-        ) {
-            ParityTopSection(
-                title = "報表",
-                subtitle = "切換收支、分類與標籤，查看和 iOS 對齊的統計視圖。"
-            )
-        }
+        ParityTopSection(
+            title = "報表",
+            modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
+            subtitle = "切換收支、分類與標籤，查看和 iOS 對齊的統計視圖。"
+        )
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(
-                    modifier = Modifier.clickable { showFilterDialog = true },
-                    shape = ReportFilterShape,
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
-                    border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        Icon(Icons.Default.DateRange, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                        Text(
-                            filterLabel(filterType, selectedDate),
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.weight(1f))
-            }
+            ParityFilterCapsule(
+                label = filterLabel(filterType, selectedDate),
+                icon = Icons.Default.DateRange,
+                onClick = { showFilterDialog = true }
+            )
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline)
             ) {
-                SegmentedOptionGroup(
+                ParitySegmentedControl(
                     modifier = Modifier.weight(1f),
                     options = ReportFlowMode.values().toList(),
                     selected = flowMode,
@@ -217,7 +187,7 @@ fun ReportsScreen() {
                         selectedTag = null
                     }
                 )
-                SegmentedOptionGroup(
+                ParitySegmentedControl(
                     modifier = Modifier.weight(1f),
                     options = ReportChartMode.values().toList(),
                     selected = chartMode,
@@ -242,11 +212,12 @@ fun ReportsScreen() {
                 item {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         IconButton(onClick = { selectedTag = null }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                         }
                         Text(
                             selectedTag ?: "",
                             style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -316,7 +287,7 @@ fun ReportsScreen() {
                             Text(type.label)
                         }
                     }
-                    Spacer(modifier = Modifier.height(6.dp))
+                    Spacer(modifier = Modifier.size(6.dp))
                     TextButton(onClick = {
                         showDatePicker(context, selectedDate) { selectedDate = it }
                     }) {
@@ -342,57 +313,6 @@ fun ReportsScreen() {
 }
 
 @Composable
-private fun <T> SegmentedOptionGroup(
-    modifier: Modifier = Modifier,
-    options: List<T>,
-    selected: T,
-    label: (T) -> String,
-    onSelect: (T) -> Unit
-) {
-    Surface(
-        modifier = modifier,
-        shape = RoundedCornerShape(14.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(4.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            options.forEach { option ->
-                val isSelected = option == selected
-                Surface(
-                    modifier = Modifier.weight(1f),
-                    onClick = { onSelect(option) },
-                    shape = RoundedCornerShape(10.dp),
-                    color = if (isSelected) {
-                        MaterialTheme.colorScheme.primaryContainer
-                    } else {
-                        Color.Transparent
-                    }
-                ) {
-                    Text(
-                        text = label(option),
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 10.dp),
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
-                        color = if (isSelected) {
-                            MaterialTheme.colorScheme.onPrimaryContainer
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                        textAlign = TextAlign.Center,
-                        maxLines = 1
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
 private fun ReportRow(
     item: ReportSlice,
     total: BigDecimal,
@@ -403,6 +323,9 @@ private fun ReportRow(
     val progress = if (total > BigDecimal.ZERO) {
         item.amount.divide(total, 4, RoundingMode.HALF_UP).toFloat().coerceIn(0f, 1f)
     } else 0f
+    val percent = if (total > BigDecimal.ZERO) {
+        item.amount.multiply(BigDecimal(100)).divide(total, 1, RoundingMode.HALF_UP)
+    } else BigDecimal.ZERO
     PressableCard(
         modifier = Modifier.fillMaxWidth(),
         onClick = onClick
@@ -411,25 +334,37 @@ private fun ReportRow(
             modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.tight)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 ColorDot(color = item.color)
-                Column(modifier = Modifier.weight(1f)) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(item.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        "${percent.stripTrailingZeros().toPlainString()}%",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
                         item.amount.asCurrencyText(baseCurrency),
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurface
                     )
+                    Text(
+                        trailingLabel,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
                 }
-                Text(
-                    trailingLabel,
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.primary
-                )
             }
-            LinearProgressIndicator(progress = { progress }, color = item.color, trackColor = MaterialTheme.colorScheme.surface)
+            LinearProgressIndicator(
+                progress = { progress },
+                color = item.color,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }
@@ -437,42 +372,50 @@ private fun ReportRow(
 @Composable
 private fun DonutChart(data: List<ReportSlice>, baseCurrency: String, title: String) {
     val total = totalAmount(data)
-    Column(
-        verticalArrangement = Arrangement.spacedBy(AppSpacing.inline),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.padding(top = 4.dp)
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = androidx.compose.foundation.BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.28f))
     ) {
-        Box(contentAlignment = Alignment.Center) {
-            Canvas(modifier = Modifier.size(212.dp)) {
-                val stroke = Stroke(width = 22.dp.toPx(), cap = StrokeCap.Butt)
-                val diameter = minOf(size.width, size.height)
-                val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
-                val rect = Rect(topLeft, Size(diameter, diameter))
-                var startAngle = -90f
-                data.forEach { slice ->
-                    val sweep = if (total > BigDecimal.ZERO) {
-                        slice.amount.divide(total, 6, RoundingMode.HALF_UP).toFloat() * 360f
-                    } else 0f
-                    drawArc(
-                        color = slice.color,
-                        startAngle = startAngle,
-                        sweepAngle = sweep,
-                        useCenter = false,
-                        topLeft = rect.topLeft,
-                        size = rect.size,
-                        style = stroke
-                    )
-                    startAngle += sweep
+        Column(
+            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.inline),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Canvas(modifier = Modifier.size(228.dp)) {
+                    val stroke = Stroke(width = 24.dp.toPx(), cap = StrokeCap.Butt)
+                    val diameter = minOf(size.width, size.height)
+                    val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
+                    val rect = Rect(topLeft, Size(diameter, diameter))
+                    var startAngle = -90f
+                    data.forEach { slice ->
+                        val sweep = if (total > BigDecimal.ZERO) {
+                            slice.amount.divide(total, 6, RoundingMode.HALF_UP).toFloat() * 360f
+                        } else 0f
+                        drawArc(
+                            color = slice.color,
+                            startAngle = startAngle,
+                            sweepAngle = sweep,
+                            useCenter = false,
+                            topLeft = rect.topLeft,
+                            size = rect.size,
+                            style = stroke
+                        )
+                        startAngle += sweep
+                    }
                 }
-            }
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(
-                    total.asCurrencyText(baseCurrency),
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
+                Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(
+                        total.asCurrencyText(baseCurrency),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         }
     }
@@ -501,23 +444,27 @@ private fun EmptyState(message: String) {
 
 @Composable
 private fun BudgetAlertCard(alerts: List<BudgetAlert>) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.error.copy(alpha = 0.06f), shape = MaterialTheme.shapes.medium)
-            .padding(AppSpacing.card),
-        verticalArrangement = Arrangement.spacedBy(6.dp)
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.error.copy(alpha = 0.06f),
+        border = androidx.compose.foundation.BorderStroke(0.6.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.18f))
     ) {
-        Text("本月超支提醒", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        alerts.take(3).forEach { alert ->
-            Row {
-                Text(alert.categoryName, style = MaterialTheme.typography.bodySmall)
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    "超支 ${alert.remaining.abs().asCurrencyText(alert.budget.currencyCode)}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
-                )
+        Column(
+            modifier = Modifier.padding(AppSpacing.card),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text("本月超支提醒", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            alerts.take(3).forEach { alert ->
+                Row {
+                    Text(alert.categoryName, style = MaterialTheme.typography.bodySmall)
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        "超支 ${alert.remaining.abs().asCurrencyText(alert.budget.currencyCode)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
             }
         }
     }
@@ -607,11 +554,10 @@ private fun filterTransactions(
     return transactions.filter { tx ->
         if (tx.transaction.type != type) return@filter false
         val date = tx.transaction.date
-        val inRange = when {
+        when {
             rangeStart == null || rangeEnd == null -> true
             else -> date >= rangeStart && date < rangeEnd
         }
-        inRange
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -65,9 +65,11 @@ import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySelectionSheetRow
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySheetHandle
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
@@ -208,8 +210,10 @@ fun ReportsScreen() {
         LazyColumn(
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(
-                horizontal = AppSpacing.screenHorizontal,
-                vertical = AppSpacing.screenVertical
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
             ),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.item)
         ) {
@@ -282,27 +286,14 @@ fun ReportsScreen() {
     }
 
     if (showFilterDialog) {
-        AlertDialog(
-            onDismissRequest = { showFilterDialog = false },
-            title = { Text("選擇區間") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                    ReportFilterType.values().forEach { type ->
-                        TextButton(onClick = { filterType = type }) {
-                            Text(type.label)
-                        }
-                    }
-                    Spacer(modifier = Modifier.size(6.dp))
-                    TextButton(onClick = {
-                        showDatePicker(context, selectedDate) { selectedDate = it }
-                    }) {
-                        Text(selectedDate.format(DateTimeFormatter.ISO_DATE))
-                    }
-                }
+        ReportFilterSheet(
+            filterType = filterType,
+            selectedDate = selectedDate,
+            onSelectFilterType = { filterType = it },
+            onPickDate = {
+                showDatePicker(context, selectedDate) { selectedDate = it }
             },
-            confirmButton = {
-                TextButton(onClick = { showFilterDialog = false }) { Text("完成") }
-            }
+            onDismiss = { showFilterDialog = false }
         )
     }
 
@@ -316,6 +307,78 @@ fun ReportsScreen() {
         ) {
             ReportDetailSheet(detail = reportDetail ?: return@ModalBottomSheet)
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReportFilterSheet(
+    filterType: ReportFilterType,
+    selectedDate: LocalDate,
+    onSelectFilterType: (ReportFilterType) -> Unit,
+    onPickDate: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        dragHandle = { ParitySheetHandle() }
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("選擇區間", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                "切換報表統計區間，日期選擇維持和 iOS 一樣的片段化流程。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            ReportFilterType.values().forEach { type ->
+                ParitySelectionSheetRow(
+                    title = type.label,
+                    subtitle = reportFilterSubtitle(type),
+                    selected = filterType == type,
+                    onClick = { onSelectFilterType(type) }
+                )
+            }
+
+            PressableCard(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onPickDate,
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                pressedContainerColor = MaterialTheme.colorScheme.surface
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                        Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                        Text(selectedDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    Text("調整", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                }
+            }
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text("完成") }
+            }
+            Spacer(modifier = Modifier.size(8.dp))
+        }
+    }
+}
+
+private fun reportFilterSubtitle(type: ReportFilterType): String {
+    return when (type) {
+        ReportFilterType.All -> "查看所有時間的累積統計"
+        ReportFilterType.Year -> "聚焦本年收入與支出"
+        ReportFilterType.Month -> "查看本月分類與標籤分佈"
+        ReportFilterType.Day -> "只看當日收支"
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -3,6 +3,7 @@ package org.duckdns.lhfser.aiaccounting.ui.screens
 import android.app.DatePickerDialog
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -64,6 +66,7 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySheetHandle
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
@@ -307,7 +310,9 @@ fun ReportsScreen() {
         val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
         ModalBottomSheet(
             onDismissRequest = { reportDetail = null },
-            sheetState = sheetState
+            sheetState = sheetState,
+            containerColor = MaterialTheme.colorScheme.background,
+            dragHandle = { ParitySheetHandle() }
         ) {
             ReportDetailSheet(detail = reportDetail ?: return@ModalBottomSheet)
         }
@@ -365,7 +370,9 @@ private fun ReportRow(
                 progress = { progress },
                 color = item.color,
                 trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(999.dp))
             )
         }
     }
@@ -374,6 +381,7 @@ private fun ReportRow(
 @Composable
 private fun DonutChart(data: List<ReportSlice>, baseCurrency: String, title: String) {
     val total = totalAmount(data)
+    val trackColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.72f)
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -391,6 +399,15 @@ private fun DonutChart(data: List<ReportSlice>, baseCurrency: String, title: Str
                     val diameter = minOf(size.width, size.height)
                     val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
                     val rect = Rect(topLeft, Size(diameter, diameter))
+                    drawArc(
+                        color = trackColor,
+                        startAngle = 0f,
+                        sweepAngle = 360f,
+                        useCenter = false,
+                        topLeft = rect.topLeft,
+                        size = rect.size,
+                        style = stroke
+                    )
                     var startAngle = -90f
                     data.forEach { slice ->
                         val sweep = if (total > BigDecimal.ZERO) {
@@ -416,6 +433,11 @@ private fun DonutChart(data: List<ReportSlice>, baseCurrency: String, title: Str
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
                         textAlign = TextAlign.Center
+                    )
+                    Text(
+                        "${data.size} 個項目",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -60,7 +60,9 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
@@ -339,7 +341,7 @@ private fun ReportRow(
                 Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(item.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                     Text(
-                        "${percent.stripTrailingZeros().toPlainString()}%",
+                        "${percent.stripTrailingZeros().toPlainString()}% · ${item.transactions.size} 筆",
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -432,38 +434,58 @@ private fun ColorDot(color: Color) {
 
 @Composable
 private fun EmptyState(message: String) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 48.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(message, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
+    ParityEmptyState(
+        title = "暫時沒有可顯示的圖表",
+        message = message
+    )
 }
 
 @Composable
 private fun BudgetAlertCard(alerts: List<BudgetAlert>) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.medium,
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.error.copy(alpha = 0.06f),
         border = androidx.compose.foundation.BorderStroke(0.6.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.18f))
     ) {
         Column(
             modifier = Modifier.padding(AppSpacing.card),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
         ) {
-            Text("本月超支提醒", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            ParitySectionHeader(
+                title = "本月超支提醒",
+                detail = "${alerts.size} 個分類"
+            )
             alerts.take(3).forEach { alert ->
-                Row {
-                    Text(alert.categoryName, style = MaterialTheme.typography.bodySmall)
-                    Spacer(modifier = Modifier.weight(1f))
-                    Text(
-                        "超支 ${alert.remaining.abs().asCurrencyText(alert.budget.currencyCode)}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error
-                    )
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = MaterialTheme.colorScheme.background.copy(alpha = 0.82f)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(
+                                alert.categoryName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                "預算 ${alert.budget.amount.asCurrencyText(alert.budget.currencyCode)}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Text(
+                            "超支 ${alert.remaining.abs().asCurrencyText(alert.budget.currencyCode)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
                 }
             }
         }
@@ -483,30 +505,70 @@ private fun ReportDetailSheet(detail: ReportDetail) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
     ) {
-        Text(detail.title, style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = detail.title,
+            detail = "${detail.transactions.size} 筆"
+        )
         LazyColumn(
             contentPadding = PaddingValues(bottom = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
         ) {
             grouped.forEach { (title, items) ->
                 item {
-                    Text(title, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(
+                        title,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 2.dp, vertical = 2.dp)
+                    )
                 }
-                items(items) { tx ->
-                    Row(
+                items(items, key = { it.transaction.id }) { tx ->
+                    Surface(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(tx.transaction.note.ifBlank { tx.category?.name ?: "未分類" }, style = MaterialTheme.typography.bodyMedium)
-                            Text(tx.transaction.date.toDateText(), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        }
-                        Text(
-                            tx.transaction.amount.asCurrencyText(tx.transaction.currencyCode),
-                            style = MaterialTheme.typography.bodyMedium
+                        shape = MaterialTheme.shapes.large,
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        border = androidx.compose.foundation.BorderStroke(
+                            0.6.dp,
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
                         )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                Text(
+                                    tx.transaction.note.ifBlank { tx.category?.name ?: "未分類" },
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                                Text(
+                                    listOfNotNull(tx.category?.name, tx.account?.name)
+                                        .joinToString(" · ")
+                                        .ifBlank { "未分類" },
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    tx.transaction.date.toDateText(),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Text(
+                                tx.transaction.amount.asCurrencyText(tx.transaction.currencyCode),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -60,6 +60,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
@@ -161,6 +162,17 @@ fun ReportsScreen() {
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(0.dp)
+        ) {
+            ParityTopSection(
+                title = "報表",
+                subtitle = "切換收支、分類與標籤，查看和 iOS 對齊的統計視圖。"
+            )
+        }
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
@@ -30,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -37,7 +39,9 @@ import kotlinx.coroutines.withContext
 import org.duckdns.lhfser.aiaccounting.core.ai.GeminiSettingsStore
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySettingRow
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
@@ -106,7 +110,12 @@ fun SettingsScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         ParityTopSection(
@@ -115,7 +124,7 @@ fun SettingsScreen(
         )
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text("新手與支援", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            ParitySectionHeader(title = "新手與支援")
             SectionCard {
                 ParitySettingRow(
                     title = "使用教學",
@@ -131,13 +140,17 @@ fun SettingsScreen(
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text("偏好設定", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            ParitySectionHeader(title = "偏好設定", detail = "和 iOS 一樣集中管理主幣別與 AI 設定")
             SectionCard {
                 ParitySettingRow(
                     title = "主要貨幣",
                     subtitle = "總覽與報表會優先以此幣別顯示",
                     trailing = {
-                        Button(onClick = { currencyMenuExpanded = true }, modifier = Modifier.height(42.dp)) {
+                        Button(
+                            onClick = { currencyMenuExpanded = true },
+                            modifier = Modifier.height(42.dp),
+                            shape = RoundedCornerShape(16.dp)
+                        ) {
                             Text(mainCurrency)
                         }
                         DropdownMenu(expanded = currencyMenuExpanded, onDismissRequest = { currencyMenuExpanded = false }) {
@@ -163,13 +176,14 @@ fun SettingsScreen(
                     },
                     label = { Text("Gemini API Key（可選）") },
                     placeholder = { Text("輸入後可使用 AI 預算與掃描功能") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(18.dp)
                 )
             }
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text("資料與工具", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            ParitySectionHeader(title = "資料與工具")
             SectionCard {
                 ParitySettingRow("分類管理", "支援收入 / 支出 / 兩者", onClick = onOpenCategories)
                 ParitySettingRow("標籤管理", "用於快速篩選與統計", onClick = onOpenTags)
@@ -180,24 +194,27 @@ fun SettingsScreen(
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text("資料安全", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            ParitySectionHeader(title = "資料安全", detail = "匯入、匯出與覆蓋策略都放在同一區")
             SectionCard {
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text("匯入時覆蓋現有資料", style = MaterialTheme.typography.titleSmall)
-                        Text("開啟後會以匯入檔案為準", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                ParitySettingRow(
+                    title = "匯入時覆蓋現有資料",
+                    subtitle = "開啟後會以匯入檔案為準",
+                    trailing = {
+                        Switch(checked = replaceExisting, onCheckedChange = { replaceExisting = it })
                     }
-                    Switch(checked = replaceExisting, onCheckedChange = { replaceExisting = it })
-                }
+                )
                 Button(
                     onClick = { exportLauncher.launch("Backup.json") },
-                    modifier = Modifier.fillMaxWidth().height(48.dp)
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    shape = RoundedCornerShape(18.dp)
                 ) {
                     Text("匯出 JSON 備份")
                 }
                 Button(
                     onClick = { importLauncher.launch(arrayOf("application/json")) },
-                    modifier = Modifier.fillMaxWidth().height(48.dp)
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    shape = RoundedCornerShape(18.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
                 ) {
                     Text("匯入 JSON 備份")
                 }
@@ -208,7 +225,7 @@ fun SettingsScreen(
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-            Text("偵錯與測試版資訊", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            ParitySectionHeader(title = "偵錯與測試版資訊")
             SectionCard {
                 ParitySettingRow(
                     title = "版本",

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -1,6 +1,9 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
 import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -89,8 +92,13 @@ fun SettingsScreen(
                 message = "匯入失敗：檔案內容為空。"
                 return@launch
             }
-            repository.importBackupJson(text, replaceExisting = replaceExisting)
-            message = "匯入完成。"
+            runCatching {
+                repository.importBackupJson(text, replaceExisting = replaceExisting)
+            }.onSuccess {
+                message = "匯入完成。"
+            }.onFailure {
+                message = "匯入失敗：${it.localizedMessage ?: "未知錯誤"}"
+            }
         }
     }
 
@@ -114,34 +122,39 @@ fun SettingsScreen(
                     subtitle = "查看 app 的主要流程與功能說明",
                     onClick = onOpenGuide
                 )
+                ParitySettingRow(
+                    title = "更改語言（系統設定）",
+                    subtitle = "前往系統頁面調整 app 語言與顯示偏好",
+                    onClick = { openSystemLanguageSettings(context) }
+                )
             }
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
             Text("偏好設定", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
             SectionCard {
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text("主要貨幣", style = MaterialTheme.typography.titleSmall)
-                        Text("總覽與報表會優先以此幣別顯示", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                    Button(onClick = { currencyMenuExpanded = true }, modifier = Modifier.height(42.dp)) {
-                        Text(mainCurrency)
-                    }
-                    DropdownMenu(expanded = currencyMenuExpanded, onDismissRequest = { currencyMenuExpanded = false }) {
-                        listOf("HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP").forEach { code ->
-                            DropdownMenuItem(
-                                text = { Text(code) },
-                                onClick = {
-                                    currencyMenuExpanded = false
-                                    mainCurrency = code
-                                    currencyService.mainCurrency = code
-                                    scope.launch { currencyService.fetchRates() }
-                                }
-                            )
+                ParitySettingRow(
+                    title = "主要貨幣",
+                    subtitle = "總覽與報表會優先以此幣別顯示",
+                    trailing = {
+                        Button(onClick = { currencyMenuExpanded = true }, modifier = Modifier.height(42.dp)) {
+                            Text(mainCurrency)
+                        }
+                        DropdownMenu(expanded = currencyMenuExpanded, onDismissRequest = { currencyMenuExpanded = false }) {
+                            listOf("HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP").forEach { code ->
+                                DropdownMenuItem(
+                                    text = { Text(code) },
+                                    onClick = {
+                                        currencyMenuExpanded = false
+                                        mainCurrency = code
+                                        currencyService.mainCurrency = code
+                                        scope.launch { currencyService.fetchRates() }
+                                    }
+                                )
+                            }
                         }
                     }
-                }
+                )
                 OutlinedTextField(
                     value = apiKey,
                     onValueChange = {
@@ -149,6 +162,7 @@ fun SettingsScreen(
                         geminiSettingsStore.apiKey = it
                     },
                     label = { Text("Gemini API Key（可選）") },
+                    placeholder = { Text("輸入後可使用 AI 預算與掃描功能") },
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -192,5 +206,43 @@ fun SettingsScreen(
                 }
             }
         }
+
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            Text("偵錯與測試版資訊", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            SectionCard {
+                ParitySettingRow(
+                    title = "版本",
+                    subtitle = "目前安裝的 Android 版本資訊",
+                    trailing = { Text(android.os.Build.VERSION.RELEASE ?: "Android", style = MaterialTheme.typography.labelMedium) }
+                )
+                ParitySettingRow(
+                    title = "AI 功能狀態",
+                    subtitle = if (apiKey.isBlank()) "尚未設定 Gemini API Key" else "Gemini API Key 已設定",
+                    trailing = { Text(if (apiKey.isBlank()) "未設定" else "已啟用", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                )
+            }
+        }
     }
+}
+
+private fun openSystemLanguageSettings(context: android.content.Context) {
+    val localeIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Intent(Settings.ACTION_APP_LOCALE_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    } else {
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+    runCatching { context.startActivity(localeIntent) }
+        .onFailure {
+            val fallbackIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            runCatching { context.startActivity(fallbackIntent) }
+        }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -6,15 +6,11 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -22,9 +18,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,11 +34,14 @@ import kotlinx.coroutines.withContext
 import org.duckdns.lhfser.aiaccounting.core.ai.GeminiSettingsStore
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySettingRow
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 
 @Composable
 fun SettingsScreen(
+    onOpenGuide: () -> Unit,
     onOpenCategories: () -> Unit,
     onOpenTags: () -> Unit,
     onOpenBudgets: () -> Unit,
@@ -84,10 +80,7 @@ fun SettingsScreen(
         ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
-        context.contentResolver.takePersistableUriPermission(
-            uri,
-            Intent.FLAG_GRANT_READ_URI_PERMISSION
-        )
+        context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
         scope.launch {
             val text = withContext(Dispatchers.IO) {
                 context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
@@ -104,108 +97,100 @@ fun SettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
-        Text("偏好設定", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-        SectionCard {
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("主要貨幣", style = MaterialTheme.typography.titleSmall)
-                    Text("報表與總覽以此幣別顯示", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-                Button(onClick = { currencyMenuExpanded = true }, modifier = Modifier.height(42.dp)) {
-                    Text(mainCurrency)
-                }
-                DropdownMenu(expanded = currencyMenuExpanded, onDismissRequest = { currencyMenuExpanded = false }) {
-                    listOf("HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP").forEach { code ->
-                        DropdownMenuItem(
-                            text = { Text(code) },
-                            onClick = {
-                                currencyMenuExpanded = false
-                                mainCurrency = code
-                                currencyService.mainCurrency = code
-                                scope.launch { currencyService.fetchRates() }
-                            }
-                        )
+        ParityTopSection(
+            title = "設定",
+            subtitle = "管理語言、主幣別、備份、AI 功能和資料工具。"
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            Text("新手與支援", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            SectionCard {
+                ParitySettingRow(
+                    title = "使用教學",
+                    subtitle = "查看 app 的主要流程與功能說明",
+                    onClick = onOpenGuide
+                )
+            }
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            Text("偏好設定", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            SectionCard {
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("主要貨幣", style = MaterialTheme.typography.titleSmall)
+                        Text("總覽與報表會優先以此幣別顯示", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    Button(onClick = { currencyMenuExpanded = true }, modifier = Modifier.height(42.dp)) {
+                        Text(mainCurrency)
+                    }
+                    DropdownMenu(expanded = currencyMenuExpanded, onDismissRequest = { currencyMenuExpanded = false }) {
+                        listOf("HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP").forEach { code ->
+                            DropdownMenuItem(
+                                text = { Text(code) },
+                                onClick = {
+                                    currencyMenuExpanded = false
+                                    mainCurrency = code
+                                    currencyService.mainCurrency = code
+                                    scope.launch { currencyService.fetchRates() }
+                                }
+                            )
+                        }
                     }
                 }
+                OutlinedTextField(
+                    value = apiKey,
+                    onValueChange = {
+                        apiKey = it
+                        geminiSettingsStore.apiKey = it
+                    },
+                    label = { Text("Gemini API Key（可選）") },
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
-            OutlinedTextField(
-                value = apiKey,
-                onValueChange = {
-                    apiKey = it
-                    geminiSettingsStore.apiKey = it
-                },
-                label = { Text("Gemini API Key（可選）") },
-                modifier = Modifier.fillMaxWidth()
-            )
         }
 
-        Text("資料與工具", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-        SectionCard {
-            SettingRow(title = "分類管理", subtitle = "支援收入/支出/兩者", onClick = onOpenCategories)
-            SettingRow(title = "標籤管理", subtitle = "用於快速篩選與統計", onClick = onOpenTags)
-            SettingRow(title = "代墊追蹤", subtitle = "查看待還款與還款紀錄", onClick = onOpenAdvances)
-            SettingRow(title = "預算與超支提醒", subtitle = "設定每月分類預算", onClick = onOpenBudgets)
-            SettingRow(title = "資料健康檢查", subtitle = "檢查缺失分類/帳戶", onClick = onOpenHealth)
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            Text("資料與工具", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            SectionCard {
+                ParitySettingRow("分類管理", "支援收入 / 支出 / 兩者", onClick = onOpenCategories)
+                ParitySettingRow("標籤管理", "用於快速篩選與統計", onClick = onOpenTags)
+                ParitySettingRow("代墊追蹤", "查看待還款與還款紀錄", onClick = onOpenAdvances)
+                ParitySettingRow("預算與超支提醒", "設定每月分類預算與 AI 建議", onClick = onOpenBudgets)
+                ParitySettingRow("資料健康檢查", "檢查缺失分類、帳戶與歷史異常", onClick = onOpenHealth)
+            }
         }
 
-        Text("備份與匯入", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-        SectionCard {
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("匯入時覆蓋現有資料", style = MaterialTheme.typography.titleSmall)
-                    Text("開啟後會以匯入檔案為準", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            Text("資料安全", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            SectionCard {
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("匯入時覆蓋現有資料", style = MaterialTheme.typography.titleSmall)
+                        Text("開啟後會以匯入檔案為準", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    Switch(checked = replaceExisting, onCheckedChange = { replaceExisting = it })
                 }
-                Switch(checked = replaceExisting, onCheckedChange = { replaceExisting = it })
+                Button(
+                    onClick = { exportLauncher.launch("Backup.json") },
+                    modifier = Modifier.fillMaxWidth().height(48.dp)
+                ) {
+                    Text("匯出 JSON 備份")
+                }
+                Button(
+                    onClick = { importLauncher.launch(arrayOf("application/json")) },
+                    modifier = Modifier.fillMaxWidth().height(48.dp)
+                ) {
+                    Text("匯入 JSON 備份")
+                }
+                if (message != null) {
+                    Text(message.orEmpty(), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
             }
-            Spacer(modifier = Modifier.padding(top = 4.dp))
-            Button(
-                onClick = { exportLauncher.launch("Backup.json") },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
-            ) {
-                Text("匯出 JSON 備份")
-            }
-            Button(
-                onClick = { importLauncher.launch(arrayOf("application/json")) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
-            ) {
-                Text("匯入 JSON 備份")
-            }
-            if (message != null) {
-                Text(message ?: "", style = MaterialTheme.typography.bodySmall)
-            }
-        }
-    }
-}
-
-
-@Composable
-private fun SettingRow(title: String, subtitle: String, onClick: () -> Unit) {
-    Surface(
-        tonalElevation = 0.dp,
-        color = MaterialTheme.colorScheme.surface,
-        modifier = Modifier.fillMaxWidth(),
-        onClick = onClick
-    ) {
-        Row(
-            modifier = Modifier.padding(
-                horizontal = AppSpacing.card,
-                vertical = 12.dp
-            ),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(subtitle, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
         }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -43,6 +42,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
@@ -141,17 +144,28 @@ fun TransactionEditorScreen(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                end = AppSpacing.screenHorizontal,
+                bottom = ParityTokens.FloatingContentBottomPadding
+            )
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Text("交易模式", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "交易模式",
+            detail = "先選記帳方式，再決定這筆是收入還是支出。"
+        )
         SectionCard {
             ModePicker(entryMode = entryMode, onModeChange = { entryMode = it })
             TypePicker(type = transactionType, onChange = { transactionType = it })
         }
 
-        Text("交易內容", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "交易內容",
+            detail = "帳戶、金額與拆分方式會跟著模式一起保存。"
+        )
         SectionCard {
             when (entryMode) {
                 EntryMode.Normal -> {
@@ -225,7 +239,10 @@ fun TransactionEditorScreen(
             }
         }
 
-        Text("日期", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "日期",
+            detail = "預設使用現在時間，也可以改成過去或未來的日期。"
+        )
         SectionCard {
             TextButton(onClick = {
                 showDatePicker(context, date) { picked ->
@@ -236,7 +253,10 @@ fun TransactionEditorScreen(
             }
         }
 
-        Text("分類與標籤", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "分類與標籤",
+            detail = "分類會影響報表與預算，標籤則方便之後再查。"
+        )
         SectionCard {
             CategoryPicker(
                 categories = filteredCategories,
@@ -254,7 +274,10 @@ fun TransactionEditorScreen(
             TagPicker(tags = tags, selected = selectedTags, onChange = { selectedTags = it })
         }
 
-        Text("備註", style = MaterialTheme.typography.titleMedium)
+        ParitySectionHeader(
+            title = "備註",
+            detail = "補充這筆交易的背景，之後搜尋和回看會更清楚。"
+        )
         SectionCard {
             OutlinedTextField(
                 value = note,
@@ -291,7 +314,8 @@ fun TransactionEditorScreen(
                 selectedAccount = selectedAccount,
                 splitLegs = splitLegs,
                 mergeLegs = mergeLegs
-            )
+            ),
+            modifier = Modifier.fillMaxWidth()
         ) {
             Text("儲存")
         }
@@ -398,34 +422,24 @@ fun TransactionEditorScreen(
 private fun ModePicker(entryMode: EntryMode, onModeChange: (EntryMode) -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text("記帳模式", style = MaterialTheme.typography.titleSmall)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            EntryMode.values().forEach { mode ->
-                FilterChip(
-                    selected = entryMode == mode,
-                    onClick = { onModeChange(mode) },
-                    label = { Text(mode.label) }
-                )
-            }
-        }
+        ParitySegmentedControl(
+            options = EntryMode.values().toList(),
+            selected = entryMode,
+            label = { it.label },
+            onSelect = onModeChange
+        )
     }
 }
 
 @Composable
 private fun TypePicker(type: TransactionType, onChange: (TransactionType) -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text("類型", style = MaterialTheme.typography.titleSmall)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            FilterChip(
-                selected = type == TransactionType.Expense,
-                onClick = { onChange(TransactionType.Expense) },
-                label = { Text("支出") }
-            )
-            FilterChip(
-                selected = type == TransactionType.Income,
-                onClick = { onChange(TransactionType.Income) },
-                label = { Text("收入") }
-            )
-        }
+        ParitySegmentedControl(
+            options = listOf(TransactionType.Expense, TransactionType.Income),
+            selected = type,
+            label = { if (it == TransactionType.Expense) "支出" else "收入" },
+            onSelect = onChange
+        )
     }
 }
 
@@ -460,10 +474,12 @@ private fun AccountPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.titleSmall)
-        TextButton(onClick = { expanded = true }) {
-            Text(selected?.name ?: "選擇帳戶")
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.name.orEmpty(),
+            placeholder = "選擇帳戶",
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             accounts.forEach { account ->
                 DropdownMenuItem(
@@ -486,10 +502,12 @@ private fun CategoryPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text("分類", style = MaterialTheme.typography.titleSmall)
-        TextButton(onClick = { expanded = true }) {
-            Text(selected?.name ?: "無分類")
-        }
+        ParityMenuField(
+            label = "分類",
+            value = selected?.name.orEmpty(),
+            placeholder = "無分類",
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             DropdownMenuItem(
                 text = { Text("無分類") },
@@ -557,7 +575,10 @@ private fun SplitLegEditor(
     onRemove: (() -> Unit)?
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text("分拆項 ${index + 1}", style = MaterialTheme.typography.titleSmall)
+        ParitySectionHeader(
+            title = "分拆項 ${index + 1}",
+            detail = "每一項都會變成獨立帳目，方便之後分開追蹤。"
+        )
         AccountPicker(
             label = "帳戶",
             accounts = accounts,
@@ -587,7 +608,10 @@ private fun MergeLegEditor(
     onRemove: (() -> Unit)?
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text("合併項 ${index + 1}", style = MaterialTheme.typography.titleSmall)
+        ParitySectionHeader(
+            title = "合併項 ${index + 1}",
+            detail = "先填各來源金額，最後一起合併進目標帳戶。"
+        )
         AmountRow(
             label = "金額",
             amount = leg.amount,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -22,11 +22,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -57,6 +60,8 @@ import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySearchField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySelectionSheetRow
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySheetHandle
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
@@ -89,7 +94,7 @@ private sealed interface LedgerItem {
 private data class DailySection(val date: LocalDate, val items: List<LedgerItem>)
 
 @Composable
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 fun TransactionsScreen(
     onEdit: (String) -> Unit,
     onEditTransfer: (String) -> Unit,
@@ -194,8 +199,10 @@ fun TransactionsScreen(
         LazyColumn(
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(
-                horizontal = AppSpacing.screenHorizontal,
-                vertical = AppSpacing.screenVertical
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
             ),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.item)
         ) {
@@ -374,37 +381,148 @@ fun TransactionsScreen(
     }
 
     if (showFilterDialog) {
-        AlertDialog(
-            onDismissRequest = { showFilterDialog = false },
-            title = { Text("篩選區間") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    DateFilterType.values().forEach { type ->
-                        TextButton(onClick = { filterType = type }) {
-                            Text(type.label)
-                        }
-                    }
-                    if (filterType == DateFilterType.Custom) {
-                        Spacer(modifier = Modifier.padding(top = 4.dp))
-                        Text("開始日期", style = MaterialTheme.typography.labelMedium)
-                        TextButton(onClick = {
-                            showDatePicker(context, customStartDate) { customStartDate = it }
-                        }) {
-                            Text(customStartDate.format(DateTimeFormatter.ISO_DATE))
-                        }
-                        Text("結束日期", style = MaterialTheme.typography.labelMedium)
-                        TextButton(onClick = {
-                            showDatePicker(context, customEndDate) { customEndDate = it }
-                        }) {
-                            Text(customEndDate.format(DateTimeFormatter.ISO_DATE))
+        TransactionFilterSheet(
+            filterType = filterType,
+            selectedDate = selectedDate,
+            customStartDate = customStartDate,
+            customEndDate = customEndDate,
+            onSelectFilterType = { filterType = it },
+            onPickSelectedDate = {
+                showDatePicker(context, selectedDate) { selectedDate = it }
+            },
+            onPickCustomStart = {
+                showDatePicker(context, customStartDate) { customStartDate = it }
+            },
+            onPickCustomEnd = {
+                showDatePicker(context, customEndDate) { customEndDate = it }
+            },
+            onDismiss = { showFilterDialog = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TransactionFilterSheet(
+    filterType: DateFilterType,
+    selectedDate: LocalDate,
+    customStartDate: LocalDate,
+    customEndDate: LocalDate,
+    onSelectFilterType: (DateFilterType) -> Unit,
+    onPickSelectedDate: () -> Unit,
+    onPickCustomStart: () -> Unit,
+    onPickCustomEnd: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        dragHandle = { ParitySheetHandle() }
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("篩選區間", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                "選擇要在帳目頁固定顯示的日期範圍。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            DateFilterType.values().forEach { type ->
+                ParitySelectionSheetRow(
+                    title = type.label,
+                    subtitle = transactionFilterSubtitle(type),
+                    selected = filterType == type,
+                    onClick = { onSelectFilterType(type) }
+                )
+            }
+
+            when (filterType) {
+                DateFilterType.Month, DateFilterType.Year -> {
+                    PressableCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = onPickSelectedDate,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(
+                                    if (filterType == DateFilterType.Year) {
+                                        "${selectedDate.year}年"
+                                    } else {
+                                        selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
+                                    },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Text("調整", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                         }
                     }
                 }
-            },
-            confirmButton = {
-                TextButton(onClick = { showFilterDialog = false }) { Text("完成") }
+                DateFilterType.Custom -> {
+                    PressableCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = onPickCustomStart,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                Text("開始日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(customStartDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+                    PressableCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = onPickCustomEnd,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                Text("結束日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(customEndDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+                }
             }
-        )
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text("完成") }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+private fun transactionFilterSubtitle(type: DateFilterType): String {
+    return when (type) {
+        DateFilterType.Month -> "聚焦本月帳目與代墊摘要"
+        DateFilterType.Year -> "查看本年累積的收支紀錄"
+        DateFilterType.Custom -> "自訂開始與結束日期"
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -1,16 +1,16 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
 import android.app.DatePickerDialog
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -18,19 +18,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -43,22 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.ExperimentalFoundationApi
-import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
-import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
-import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
-import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
-import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
-import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
-import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
-import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
-import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
-import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
-import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import androidx.compose.ui.unit.sp
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -66,6 +48,20 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlinx.coroutines.launch
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySearchField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 
 private enum class DateFilterType(val label: String) {
     Month("本月"),
@@ -89,10 +85,6 @@ private sealed interface LedgerItem {
 }
 
 private data class DailySection(val date: LocalDate, val items: List<LedgerItem>)
-private val LedgerFilterShape = RoundedCornerShape(18.dp)
-private val ShortcutTileWidth = 76.dp
-private val ShortcutTileHeight = 88.dp
-private val ShortcutIconContainerSize = 46.dp
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -153,52 +145,49 @@ fun TransactionsScreen(
             modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
             subtitle = "搜尋、篩選、編輯所有交易與代墊摘要。"
         )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = AppSpacing.screenHorizontal, vertical = 10.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Surface(
-                modifier = Modifier.clickable { showFilterDialog = true },
-                shape = LedgerFilterShape,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
-                border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = AppSpacing.screenHorizontal, vertical = 10.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    Icon(Icons.Default.DateRange, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                    Text(
-                        filterLabel(filterType, selectedDate, customStartDate, customEndDate),
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
+                ParityFilterCapsule(
+                    label = filterLabel(filterType, selectedDate, customStartDate, customEndDate),
+                    icon = Icons.Default.DateRange,
+                    onClick = { showFilterDialog = true }
+                )
+            }
+
+            HorizontalDivider()
+
+            ShortcutsBar(
+                modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal),
+                shortcuts = shortcuts,
+                onAddShortcut = onAddShortcut,
+                onShortcutTap = {
+                    pendingShortcut = it
+                    showShortcutConfirm = true
+                },
+                onShortcutLongPress = {
+                    shortcutToDelete = it
+                    showShortcutDeleteConfirm = true
                 }
-            }
+            )
+
+            HorizontalDivider()
+
+            ParitySearchField(
+                value = searchText,
+                onValueChange = { searchText = it },
+                placeholder = "搜尋備註、分類、標籤、金額",
+                modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 12.dp)
+            )
+
+            HorizontalDivider()
         }
-
-        HorizontalDivider()
-
-        ShortcutsBar(
-            modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal),
-            shortcuts = shortcuts,
-            onAddShortcut = onAddShortcut,
-            onShortcutTap = {
-                pendingShortcut = it
-                showShortcutConfirm = true
-            },
-            onShortcutLongPress = {
-                shortcutToDelete = it
-                showShortcutDeleteConfirm = true
-            }
-        )
-
-        HorizontalDivider()
 
         LazyColumn(
             modifier = Modifier.weight(1f),
@@ -208,24 +197,6 @@ fun TransactionsScreen(
             ),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.item)
         ) {
-            item {
-                OutlinedTextField(
-                    value = searchText,
-                    onValueChange = { searchText = it },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text("搜尋備註、分類、標籤、金額") },
-                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                    trailingIcon = {
-                        if (searchText.isNotBlank()) {
-                            IconButton(onClick = { searchText = "" }) {
-                                Icon(Icons.Default.Clear, contentDescription = "清除")
-                            }
-                        }
-                    },
-                    singleLine = true
-                )
-            }
-
             if (ledgerItems.isEmpty()) {
                 item {
                     Column(
@@ -246,12 +217,9 @@ fun TransactionsScreen(
                         ) {
                             Text(
                                 text = formatHeaderDate(section.date),
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.Medium,
-                                modifier = Modifier.padding(
-                                    horizontal = AppSpacing.screenHorizontal,
-                                    vertical = 10.dp
-                                ),
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(vertical = 8.dp),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
@@ -410,9 +378,7 @@ fun TransactionsScreen(
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     DateFilterType.values().forEach { type ->
-                        TextButton(onClick = {
-                            filterType = type
-                        }) {
+                        TextButton(onClick = { filterType = type }) {
                             Text(type.label)
                         }
                     }
@@ -573,7 +539,7 @@ private fun ShortcutsBar(
     ) {
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(vertical = 10.dp)
+            contentPadding = PaddingValues(vertical = 12.dp)
         ) {
             item {
                 AddShortcutTile(onClick = onAddShortcut)
@@ -593,8 +559,8 @@ private fun ShortcutsBar(
 private fun AddShortcutTile(onClick: () -> Unit) {
     PressableCard(
         modifier = Modifier
-            .width(ShortcutTileWidth)
-            .height(ShortcutTileHeight)
+            .width(ParityTokens.ShortcutTileWidth)
+            .height(ParityTokens.ShortcutTileHeight)
             .padding(vertical = 2.dp),
         onClick = onClick,
         containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -610,7 +576,7 @@ private fun AddShortcutTile(onClick: () -> Unit) {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Surface(
-                modifier = Modifier.size(ShortcutIconContainerSize),
+                modifier = Modifier.size(ParityTokens.ShortcutIconSize),
                 shape = RoundedCornerShape(14.dp),
                 color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
             ) {
@@ -642,8 +608,8 @@ private fun ShortcutTile(
 ) {
     PressableCard(
         modifier = Modifier
-            .width(ShortcutTileWidth)
-            .height(ShortcutTileHeight)
+            .width(ParityTokens.ShortcutTileWidth)
+            .height(ParityTokens.ShortcutTileHeight)
             .padding(vertical = 2.dp),
         onClick = onClick,
         onLongClick = onLongClick,
@@ -660,7 +626,7 @@ private fun ShortcutTile(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Surface(
-                modifier = Modifier.size(ShortcutIconContainerSize),
+                modifier = Modifier.size(ParityTokens.ShortcutIconSize),
                 shape = RoundedCornerShape(14.dp),
                 color = MaterialTheme.colorScheme.surface
             ) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -54,8 +54,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySearchField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
@@ -199,14 +201,14 @@ fun TransactionsScreen(
         ) {
             if (ledgerItems.isEmpty()) {
                 item {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text("沒有符合條件的帳目", style = MaterialTheme.typography.bodyMedium)
-                    }
+                    ParityEmptyState(
+                        title = if (searchText.isBlank()) "還沒有帳目" else "沒有符合條件的帳目",
+                        message = if (searchText.isBlank()) {
+                            "先新增一筆交易，或切換日期區間看看。"
+                        } else {
+                            "可以調整搜尋關鍵字或日期篩選，再試一次。"
+                        }
+                    )
                 }
             } else {
                 dailySections.forEach { section ->
@@ -452,7 +454,10 @@ private fun TransactionRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            Column(horizontalAlignment = Alignment.End) {
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
                 Text(
                     amountText,
                     color = amountColor,
@@ -460,7 +465,7 @@ private fun TransactionRow(
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    item.transaction.currencyCode,
+                    "${transactionTypeLabel(item.transaction.type)} · ${item.transaction.currencyCode}",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -492,11 +497,20 @@ private fun AdvanceSummaryRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    item.advanceCase.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        item.advanceCase.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    ParityStatusPill(
+                        text = "代墊",
+                        tint = Color(0xFFEF6C00)
+                    )
+                }
                 Text(
                     "${item.participants.size} 人 · $payerText",
                     style = MaterialTheme.typography.labelMedium,
@@ -782,4 +796,10 @@ private fun formatHeaderDate(date: LocalDate): String {
         today.minusDays(1) -> "昨天"
         else -> date.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
     }
+}
+
+private fun transactionTypeLabel(type: TransactionType): String = when (type) {
+    TransactionType.Income -> "收入"
+    TransactionType.Expense -> "支出"
+    TransactionType.Transfer -> "轉帳"
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -54,6 +54,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
@@ -147,6 +148,11 @@ fun TransactionsScreen(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
+        ParityTopSection(
+            title = "帳目明細",
+            modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
+            subtitle = "搜尋、篩選、編輯所有交易與代墊摘要。"
+        )
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/UserGuideScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/UserGuideScreen.kt
@@ -1,37 +1,194 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.Assessment
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 
 @Composable
-fun UserGuideScreen(onDone: () -> Unit) {
+fun UserGuideScreen(
+    onDone: () -> Unit,
+    isFirstLaunch: Boolean = false
+) {
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .verticalScroll(scrollState)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
-        Text("歡迎使用 AI 記帳", style = MaterialTheme.typography.titleLarge)
-        Text("1. 先新增帳戶與分類。")
-        Text("2. 用「記一筆」新增收入/支出。")
-        Text("3. 轉帳與代墊可從右下角新增。")
-        Text("4. 報表可點擊分類查看明細。")
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = onDone) { Text("開始使用") }
+        HeroGuideCard()
+
+        GuideSectionCard(
+            title = "1. 先建立帳戶",
+            icon = Icons.Default.AccountBalanceWallet,
+            points = listOf(
+                "在「帳戶」頁新增現金、銀行、信用卡或借貸帳戶。",
+                "每個帳戶可設定基礎餘額與幣別，資產估算會自動換算。"
+            )
+        )
+
+        GuideSectionCard(
+            title = "2. 記錄日常收支",
+            icon = Icons.Default.Description,
+            points = listOf(
+                "使用右下角「新增」按鈕建立收入、支出、轉帳、借貸或代墊。",
+                "每筆交易可帶分類、標籤、備註與交易幣別。",
+                "轉帳與代墊支援完整編輯，不需刪除重建。"
+            )
+        )
+
+        GuideSectionCard(
+            title = "3. 看懂報表",
+            icon = Icons.Default.Assessment,
+            points = listOf(
+                "在「報表」切換收入/支出、分類/標籤檢視。",
+                "點擊分類或標籤可查看對應交易明細。"
+            )
+        )
+
+        GuideSectionCard(
+            title = "4. 備份與資料安全",
+            icon = Icons.Default.Settings,
+            points = listOf(
+                "在「設定 > 資料安全」匯入或匯出 JSON 備份。",
+                "建議定期匯出完整備份；換機時可直接還原。",
+                "Gemini API Key 只會保留在本機設定。"
+            )
+        )
+
+        GuideSectionCard(
+            title = "5. 進階功能",
+            icon = Icons.Default.Settings,
+            points = listOf(
+                "代墊追蹤：管理多人分帳、還款進度與入帳帳戶。",
+                "預算與超支提醒：按分類管理每月上限。",
+                "資料健康檢查：快速找出連結或歷史資料異常。"
+            )
+        )
+
+        Button(
+            onClick = onDone,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
+            shape = RoundedCornerShape(18.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+        ) {
+            Text(if (isFirstLaunch) "開始使用" else "完成")
+        }
+    }
+}
+
+@Composable
+private fun HeroGuideCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                "一個畫面掌握收支、轉帳、借貸與代墊。",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                "建議流程：先建立帳戶，再開始記帳，最後到報表與設定確認資料。",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun GuideSectionCard(
+    title: String,
+    icon: ImageVector,
+    points: List<String>
+) {
+    SectionCard {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Surface(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f), RoundedCornerShape(14.dp)),
+                shape = RoundedCornerShape(14.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.padding(10.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        points.forEach { point ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                Text(
+                    text = "•",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 1.dp)
+                )
+                Text(
+                    text = point,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/theme/Spacing.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/theme/Spacing.kt
@@ -3,11 +3,11 @@ package org.duckdns.lhfser.aiaccounting.ui.theme
 import androidx.compose.ui.unit.dp
 
 object AppSpacing {
-    val screenHorizontal = 16.dp
-    val screenVertical = 12.dp
-    val section = 12.dp
-    val card = 14.dp
-    val item = 10.dp
-    val inline = 8.dp
+    val screenHorizontal = 20.dp
+    val screenVertical = 14.dp
+    val section = 16.dp
+    val card = 16.dp
+    val item = 12.dp
+    val inline = 10.dp
     val tight = 6.dp
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/theme/Theme.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/theme/Theme.kt
@@ -1,27 +1,28 @@
 package org.duckdns.lhfser.aiaccounting.ui.theme
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
-import androidx.compose.material3.Typography
-import androidx.compose.material3.Shapes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 private val LightColors = lightColorScheme(
     primary = Color(0xFF006C4C),
     secondary = Color(0xFF3E6472),
     tertiary = Color(0xFF56643B),
-    background = Color(0xFFF2F2F7),
+    background = Color(0xFFF3F4F7),
     surface = Color(0xFFFFFFFF),
     surfaceVariant = Color(0xFFF7F8FA),
-    outline = Color(0xFFE1E4E8)
+    outline = Color(0xFFDDE2E8),
+    onSurfaceVariant = Color(0xFF69727D)
 )
 
 private val DarkColors = darkColorScheme(
@@ -32,26 +33,38 @@ private val DarkColors = darkColorScheme(
 
 private val AppShapes = Shapes(
     small = RoundedCornerShape(10.dp),
-    medium = RoundedCornerShape(14.dp),
-    large = RoundedCornerShape(18.dp)
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(22.dp)
 )
 
 private val AppTypography = Typography(
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 31.sp,
+        lineHeight = 36.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 26.sp,
+        lineHeight = 30.sp
+    ),
     titleLarge = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.SemiBold,
-        fontSize = 23.sp,
+        fontSize = 24.sp,
         lineHeight = 30.sp
     ),
     titleMedium = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.SemiBold,
-        fontSize = 19.sp,
+        fontSize = 20.sp,
         lineHeight = 26.sp
     ),
     titleSmall = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Medium,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 16.sp,
         lineHeight = 22.sp
     ),
@@ -73,11 +86,23 @@ private val AppTypography = Typography(
         fontSize = 12.sp,
         lineHeight = 18.sp
     ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        lineHeight = 18.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp
+    ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Normal,
+        fontWeight = FontWeight.Medium,
         fontSize = 11.sp,
-        lineHeight = 16.sp
+        lineHeight = 14.sp
     )
 )
 

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -73,3 +73,9 @@
 - Keep ledger filter, shortcut rail, and search field visually distinct but rhythmically aligned with iOS.
 - Use parity-styled add sheet rows with supporting descriptions instead of bare text buttons.
 - Tighten Reports chart card, list rows, and Settings section density toward the iOS source of truth.
+
+## Wave 3 Refinements
+- Add shared parity empty states and compact status pills so empty/list/detail views no longer fall back to plain text.
+- Tighten Accounts and Account Detail rhythm toward iOS with clearer summary hierarchy, archived badges, and softer disclosure emphasis.
+- Refine Reports drill-down sheets and budget alert cards so bottom-sheet detail and empty states feel closer to the iOS information density.
+- Keep Ledger rows visually lightweight while improving empty-state guidance and advance-summary labeling.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -1,0 +1,68 @@
+# Android / iOS Parity Source of Truth
+
+## Goal
+- iOS is the product source of truth.
+- Android should match iOS page structure, wording, navigation rhythm, and core feature coverage.
+- The only accepted platform-specific extension is the Android widget.
+
+## Top-Level Screens
+
+### Overview
+- Large in-page title section, not a shared global top app bar.
+- Date filter near the top.
+- Quick start panel.
+- Period summary cards.
+- Entry points to ledger, reports, accounts, and guide.
+
+### Ledger
+- Large in-page title section.
+- Fixed date filter row.
+- Shortcut rail.
+- Search field.
+- Daily section headers.
+- Initial advance creation is collapsed into one advance summary row.
+
+### Reports
+- Large in-page title section.
+- Date filter near the top.
+- Income/expense and category/tag controls on the same level.
+- Donut / pie chart with drill-down path.
+
+### Accounts
+- Large in-page title section.
+- Total estimated assets.
+- Holdings by currency.
+- Account list opens account detail before editing.
+- Archived visibility is controlled from the page.
+
+### Settings
+- Large in-page title section.
+- Beginner/help section.
+- Preferences section.
+- Tools section.
+- Backup/import section.
+
+## Required Flow Parity
+- Add action sheet order:
+  1. Transaction
+  2. Scan receipt (AI)
+  3. Transfer
+  4. Debt (borrow / repay)
+  5. Advance case
+- Receipt scanning flow: pick image -> AI analyze -> user review -> save expense transaction.
+- Debt flow: create transfer pair(s) matching iOS notes and entry modes.
+- Account detail flow: account list -> account detail -> edit transaction / transfer / account.
+- First-launch guide behavior stays aligned with iOS.
+
+## Allowed Differences
+- Android widget is Android-only.
+- System pickers (date picker, file picker, permissions, media picker) may stay platform-native.
+- Typeface may be a legal Android-native approximation, but hierarchy and spacing should remain aligned.
+
+## Verification Matrix
+- Overview / Ledger / Reports / Accounts / Settings title hierarchy matches iOS.
+- Bottom tab and floating add button do not overlap hit targets.
+- Add sheet routes match iOS ordering and wording.
+- Receipt scan, debt entry, account detail all exist on Android.
+- Android build and unit tests pass after each parity wave.
+- iOS build passes after each parity wave to protect source-of-truth stability.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -90,3 +90,8 @@
 - Add extra floating-action safe clearance and navigation-bar-aware bottom chrome to reduce crowding on devices like Samsung A53.
 - Tighten Overview, Accounts, and Settings bottom rhythm so the final rows do not compete with the FAB or bottom tab hit area.
 - Use section headers and denser utility grouping in Settings to better mirror the iOS information architecture.
+
+## Wave 6 Refinements
+- Bring deeper Android flows closer to iOS by reusing parity-style picker fields in debt entry and receipt scan review.
+- Add floating-action safe clearance to account detail, debt, and receipt flows so deeper pages no longer feel tighter than the iOS source of truth.
+- Tighten section hierarchy in debt entry, receipt scan, and account detail so the detailed flows match the same product voice as the top-level screens.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -99,3 +99,8 @@
 ## Wave 7 Refinements
 - Upgrade the Android user guide from a placeholder checklist to a full parity-style onboarding page with the same five-step structure and product emphasis as iOS.
 - Keep first-launch and settings-entry guide flows aligned by using the same guide content with only the closing CTA label changing by context.
+
+## Wave 8 Refinements
+- Bring the highest-traffic Android editor flows closer to iOS by replacing plain section titles with parity section headers and adding the same floating-action safe clearance used elsewhere.
+- Tighten transaction, transfer, and advance creation screens around parity segmented controls and parity picker fields so their form rhythm no longer falls back to generic Material defaults.
+- Keep deep editing flows in the same product voice as the top-level parity screens, especially for mode switching, account/category picking, and bottom CTA spacing.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -79,3 +79,8 @@
 - Tighten Accounts and Account Detail rhythm toward iOS with clearer summary hierarchy, archived badges, and softer disclosure emphasis.
 - Refine Reports drill-down sheets and budget alert cards so bottom-sheet detail and empty states feel closer to the iOS information density.
 - Keep Ledger rows visually lightweight while improving empty-state guidance and advance-summary labeling.
+
+## Wave 4 Refinements
+- Tighten microinteractions with softer spring press feedback, clearer sheet handles, and more polished add-sheet presentation.
+- Refine Overview entry rows and Floating Add Button emphasis so primary actions feel closer to iOS weight and disclosure rhythm.
+- Improve Reports chart legibility with a softer track ring, clearer totals, rounded progress bars, and parity-styled drill-down sheets.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -66,3 +66,10 @@
 - Receipt scan, debt entry, account detail all exist on Android.
 - Android build and unit tests pass after each parity wave.
 - iOS build passes after each parity wave to protect source-of-truth stability.
+
+
+## Wave 2 Refinements
+- Replace ad-hoc filter/search controls with shared parity capsules and segmented controls.
+- Keep ledger filter, shortcut rail, and search field visually distinct but rhythmically aligned with iOS.
+- Use parity-styled add sheet rows with supporting descriptions instead of bare text buttons.
+- Tighten Reports chart card, list rows, and Settings section density toward the iOS source of truth.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -95,3 +95,7 @@
 - Bring deeper Android flows closer to iOS by reusing parity-style picker fields in debt entry and receipt scan review.
 - Add floating-action safe clearance to account detail, debt, and receipt flows so deeper pages no longer feel tighter than the iOS source of truth.
 - Tighten section hierarchy in debt entry, receipt scan, and account detail so the detailed flows match the same product voice as the top-level screens.
+
+## Wave 7 Refinements
+- Upgrade the Android user guide from a placeholder checklist to a full parity-style onboarding page with the same five-step structure and product emphasis as iOS.
+- Keep first-launch and settings-entry guide flows aligned by using the same guide content with only the closing CTA label changing by context.

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -84,3 +84,9 @@
 - Tighten microinteractions with softer spring press feedback, clearer sheet handles, and more polished add-sheet presentation.
 - Refine Overview entry rows and Floating Add Button emphasis so primary actions feel closer to iOS weight and disclosure rhythm.
 - Improve Reports chart legibility with a softer track ring, clearer totals, rounded progress bars, and parity-styled drill-down sheets.
+
+## Wave 5 Refinements
+- Convert Android ledger and report range pickers from plain dialogs into parity-styled bottom sheets so filter selection feels closer to iOS.
+- Add extra floating-action safe clearance and navigation-bar-aware bottom chrome to reduce crowding on devices like Samsung A53.
+- Tighten Overview, Accounts, and Settings bottom rhythm so the final rows do not compete with the FAB or bottom tab hit area.
+- Use section headers and denser utility grouping in Settings to better mirror the iOS information architecture.


### PR DESCRIPTION
## Summary
- refactor Android root into an iOS-first shell with in-page titles, parity bottom bar, and iOS-aligned add sheet routing
- add missing Android parity flows for receipt scan, debt entry, and account detail, plus a shared parity component layer
- realign Android top-level pages and document the parity source of truth in docs/specs/android-ios-parity.md

## Testing
- ./gradlew assembleDebug
- ./gradlew testDebugUnitTest
- xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build