### PR TITLE
Split income and debt flows with exchange-rate hints

### DIFF
--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -18,7 +18,8 @@ struct ContentView: View {
 
     @State private var selectedTab: RootTab = .ledger
     @State private var showingAddOptions = false
-    @State private var showingAddTransaction = false
+    @State private var showingAddExpense = false
+    @State private var showingAddIncome = false
     @State private var showingAddTransfer = false
     @State private var showingScanReceipt = false
     @State private var showingAddDebt = false
@@ -115,14 +116,20 @@ struct ContentView: View {
             }
         }
         .confirmationDialog("新增內容", isPresented: $showingAddOptions, titleVisibility: .visible) {
-            Button("記一筆（收入/支出）") { showingAddTransaction = true }
+            Button("支出") { showingAddExpense = true }
+            Button("收入") { showingAddIncome = true }
             Button("掃描收據（AI）") { showingScanReceipt = true }
             Button("轉帳") { showingAddTransfer = true }
-            Button("借貸（借入/還款）") { showingAddDebt = true }
+            Button("債務管理（借入 / 還款 / 免除債務）") { showingAddDebt = true }
             Button("新增代墊單（多人分帳）") { showingAddAdvanceCase = true }
             Button("取消", role: .cancel) {}
         }
-        .sheet(isPresented: $showingAddTransaction) { AddTransactionView() }
+        .sheet(isPresented: $showingAddExpense) {
+            AddTransactionView(initialType: .expense, locksTransactionType: true)
+        }
+        .sheet(isPresented: $showingAddIncome) {
+            AddTransactionView(initialType: .income, locksTransactionType: true)
+        }
         .sheet(isPresented: $showingAddTransfer) { AddTransferView() }
         .sheet(isPresented: $showingScanReceipt) { ScanReceiptView() }
         .sheet(isPresented: $showingAddDebt) { AddDebtView() }
@@ -134,7 +141,8 @@ struct ContentView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CloseAddFlow"))) { _ in
             showingScanReceipt = false
-            showingAddTransaction = false
+            showingAddExpense = false
+            showingAddIncome = false
             showingAddTransfer = false
             showingAddDebt = false
             showingAddAdvanceCase = false

--- a/AI 記帳/Services/CurrencyService.swift
+++ b/AI 記帳/Services/CurrencyService.swift
@@ -15,6 +15,8 @@ class CurrencyService: ObservableObject {
     }
     
     @Published var rates: [String: Double] = [:]
+    @Published private(set) var rateSourceState: RateSourceState = .unavailable
+    private var staleRates: [String: Double] = [:]
     
     var mainCurrency: String {
         get { UserDefaults.standard.string(forKey: "mainCurrency") ?? "HKD" }
@@ -49,12 +51,20 @@ class CurrencyService: ObservableObject {
                 guard requestedBase == self.mainCurrency.uppercased() else { return }
                 
                 self.rates = result.rates
+                self.staleRates = result.rates
+                self.rateSourceState = .live
                 // 🔥 成功獲取後，儲存到本地
                 self.saveRatesToLocal(base: requestedBase, rates: result.rates)
             }
         } catch {
             print("匯率獲取失敗: \(error)")
-            // 失敗時，init 已經讀取了舊緩存，所以這裡不需要做什麼
+            await MainActor.run {
+                if requestedBase == self.mainCurrency.uppercased(), !self.staleRates.isEmpty {
+                    self.rateSourceState = .cached
+                } else {
+                    self.rateSourceState = .unavailable
+                }
+            }
         }
     }
     
@@ -68,24 +78,28 @@ class CurrencyService: ObservableObject {
     
     private func loadRatesFromLocal() {
         let currentBase = mainCurrency.uppercased()
+        self.rates = [:]
+        self.staleRates = [:]
+        self.rateSourceState = .unavailable
         
         if let data = UserDefaults.standard.data(forKey: ratesCacheKey),
            let payload = try? JSONDecoder().decode(ExchangeRateCache.self, from: data) {
             guard payload.base.uppercased() == currentBase else {
                 // base 不一致時忽略，避免錯用他幣快取
-                self.rates = [:]
                 print("⚠️ 忽略不匹配 base 的匯率快取: \(payload.base) -> \(currentBase)")
                 return
             }
             
+            self.staleRates = payload.rates
             let age = Date().timeIntervalSince(payload.fetchedAt)
-            guard age <= cacheTTL else {
-                self.rates = [:]
+            if age > cacheTTL {
+                self.rateSourceState = payload.rates.isEmpty ? .unavailable : .cached
                 print("⚠️ 匯率快取已過期，等待重新抓取")
                 return
             }
             
             self.rates = payload.rates
+            self.rateSourceState = .cached
             print("✅ 已載入本地匯率緩存 (\(payload.base))")
             return
         }
@@ -94,13 +108,12 @@ class CurrencyService: ObservableObject {
         if UserDefaults.standard.data(forKey: legacyRatesKey) != nil {
             UserDefaults.standard.removeObject(forKey: legacyRatesKey)
             print("⚠️ 已清除舊版匯率快取（缺少 base 資訊）")
-            self.rates = [:]
         }
     }
     
     func convert(amount: Decimal, from currency: String) -> Decimal {
         if currency == mainCurrency { return amount }
-        guard let rate = rates[currency], rate.isFinite, rate > 0 else { return amount } // 避免異常匯率造成非有限數值
+        guard let rate = resolvedRates[currency.uppercased()], rate.isFinite, rate > 0 else { return amount } // 避免異常匯率造成非有限數值
         return amount / Decimal(rate)
     }
     
@@ -108,7 +121,7 @@ class CurrencyService: ObservableObject {
         if source == target { return amount }
         
         if source == mainCurrency {
-            guard let targetRate = rates[target], targetRate.isFinite, targetRate > 0 else { return amount }
+            guard let targetRate = resolvedRates[target.uppercased()], targetRate.isFinite, targetRate > 0 else { return amount }
             return amount * Decimal(targetRate)
         }
         
@@ -116,14 +129,30 @@ class CurrencyService: ObservableObject {
             return convert(amount: amount, from: source)
         }
         
-        guard let targetRate = rates[target], targetRate.isFinite, targetRate > 0 else { return amount }
+        guard let targetRate = resolvedRates[target.uppercased()], targetRate.isFinite, targetRate > 0 else { return amount }
         let inMain = convert(amount: amount, from: source)
         return inMain * Decimal(targetRate)
     }
     
     func getMarketRate(from source: String, to target: String) -> Double? {
         if source == target { return 1.0 }
-        guard let rateSource = rates[source], let rateTarget = rates[target] else { return nil }
+        guard let rateSource = resolvedRates[source.uppercased()], let rateTarget = resolvedRates[target.uppercased()] else { return nil }
         return (1.0 / rateSource) * rateTarget
+    }
+
+    func previewInMainCurrency(amount: Decimal, from currency: String) -> (amount: Decimal, source: RateSourceState)? {
+        guard currency.uppercased() != mainCurrency.uppercased() else { return nil }
+        guard !resolvedRates.isEmpty else { return nil }
+        return (convert(amount: amount, from: currency.uppercased()), resolvedRateSourceState)
+    }
+
+    var resolvedRateSourceState: RateSourceState {
+        if !rates.isEmpty { return rateSourceState }
+        if !staleRates.isEmpty { return .cached }
+        return .unavailable
+    }
+
+    private var resolvedRates: [String: Double] {
+        rates.isEmpty ? staleRates : rates
     }
 }

--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -30,6 +30,7 @@ enum DataHealthCheckService {
         let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
         let categories = (try? modelContext.fetch(FetchDescriptor<Category>())) ?? []
         let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
+        let shortcuts = (try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []
         let advanceCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
         let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
         let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
@@ -39,6 +40,7 @@ enum DataHealthCheckService {
         checkTransactionBasics(transactions, into: &issues)
         checkLinkedTransfers(transactions, into: &issues)
         checkTransferGroups(transactions, into: &issues)
+        checkDebtIncomeConflicts(transactions: transactions, shortcuts: shortcuts, into: &issues)
         checkCategories(categories, into: &issues)
         checkBudgets(budgets, into: &issues)
         checkAdvances(
@@ -167,6 +169,36 @@ enum DataHealthCheckService {
                     title: "轉帳群組不完整",
                     detail: "共有 \(brokenGroups) 個 transferGroup 缺少轉出或轉入側。",
                     recommendation: "建議檢查該群組交易是否被不完整刪除。"
+                )
+            )
+        }
+    }
+
+    private static func checkDebtIncomeConflicts(
+        transactions: [FinancialTransaction],
+        shortcuts: [Shortcut],
+        into issues: inout [HealthIssue]
+    ) {
+        let incomeOnDebtAccount = transactions.filter { TransactionSemantics.isLegacyDebtIncome($0) }
+        if !incomeOnDebtAccount.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "收入記到了借貸帳戶",
+                    detail: "共有 \(incomeOnDebtAccount.count) 筆收入交易使用借貸帳戶，這類資料建議改為「免除債務」。",
+                    recommendation: "請逐筆檢查，確認是否應改成債務管理內的「免除債務」，避免收入報表失真。"
+                )
+            )
+        }
+
+        let incomeShortcutsOnDebtAccount = shortcuts.filter { TransactionSemantics.isLegacyDebtIncome($0) }
+        if !incomeShortcutsOnDebtAccount.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "收入捷徑綁到了借貸帳戶",
+                    detail: "共有 \(incomeShortcutsOnDebtAccount.count) 個收入捷徑綁定借貸帳戶。",
+                    recommendation: "請把這些捷徑改到自己的賬戶，或改走債務管理流程。"
                 )
             )
         }

--- a/AI 記帳/Services/LegacyDebtIncomeRepairService.swift
+++ b/AI 記帳/Services/LegacyDebtIncomeRepairService.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum LegacyDebtIncomeRepairService {
+    static func legacyDebtIncomeTransactions(from transactions: [FinancialTransaction]) -> [FinancialTransaction] {
+        transactions.filter(TransactionSemantics.isLegacyDebtIncome)
+    }
+
+    static func legacyDebtIncomeShortcuts(from shortcuts: [Shortcut]) -> [Shortcut] {
+        shortcuts.filter(TransactionSemantics.isLegacyDebtIncome)
+    }
+
+    @discardableResult
+    static func convertLegacyDebtIncomeTransactions(
+        _ transactions: [FinancialTransaction],
+        modelContext: ModelContext
+    ) throws -> Int {
+        var updatedCount = 0
+        for transaction in transactions {
+            guard convertLegacyDebtIncomeTransaction(transaction, modelContext: modelContext) else {
+                continue
+            }
+            updatedCount += 1
+        }
+        if updatedCount > 0 {
+            try modelContext.save()
+        }
+        return updatedCount
+    }
+
+    @discardableResult
+    static func convertLegacyDebtIncomeTransaction(
+        _ transaction: FinancialTransaction,
+        modelContext: ModelContext
+    ) -> Bool {
+        guard let account = transaction.account, account.type == .debt else {
+            return false
+        }
+
+        let direction: DebtForgivenessDirection = transaction.amount >= 0 ? .forgivenByOthers : .forgiveOthers
+        let normalizedAmount = abs(transaction.amount) * direction.amountSign
+        let baseNote = TransactionSemantics.debtForgivenessDisplayTitle(note: transaction.note)
+
+        transaction.amount = normalizedAmount
+        transaction.type = .transfer
+        transaction.note = TransactionSemantics.debtForgivenessNote(
+            baseNote: baseNote,
+            debtAccountName: account.name,
+            direction: direction
+        )
+        transaction.linkedTransactionID = nil
+        transaction.transferGroupID = nil
+        transaction.transferSide = nil
+        transaction.updatedAt = Date()
+        return true
+    }
+
+    @discardableResult
+    static func detachLegacyDebtIncomeShortcuts(
+        _ shortcuts: [Shortcut],
+        modelContext: ModelContext
+    ) throws -> Int {
+        var updatedCount = 0
+        for shortcut in shortcuts {
+            guard detachLegacyDebtIncomeShortcut(shortcut, modelContext: modelContext) else {
+                continue
+            }
+            updatedCount += 1
+        }
+        if updatedCount > 0 {
+            try modelContext.save()
+        }
+        return updatedCount
+    }
+
+    @discardableResult
+    static func detachLegacyDebtIncomeShortcut(
+        _ shortcut: Shortcut,
+        modelContext: ModelContext
+    ) -> Bool {
+        guard shortcut.type == .income, shortcut.account?.type == .debt else {
+            return false
+        }
+        shortcut.account = nil
+        return true
+    }
+}

--- a/AI 記帳/Services/TransactionSemantics.swift
+++ b/AI 記帳/Services/TransactionSemantics.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+enum DebtForgivenessDirection: String, CaseIterable, Identifiable {
+    case forgivenByOthers = "別人免除我欠的"
+    case forgiveOthers = "我免除別人欠我的"
+
+    var id: String { rawValue }
+
+    var detail: String {
+        switch self {
+        case .forgivenByOthers:
+            return "這會減少你對對方的負債，不計入收入。"
+        case .forgiveOthers:
+            return "這會減少對方欠你的金額，不計入收入。"
+        }
+    }
+
+    var amountSign: Decimal {
+        switch self {
+        case .forgivenByOthers:
+            return 1
+        case .forgiveOthers:
+            return -1
+        }
+    }
+
+    var displayTitle: String {
+        switch self {
+        case .forgivenByOthers:
+            return "免除債務（對方免除）"
+        case .forgiveOthers:
+            return "免除債務（我方免除）"
+        }
+    }
+}
+
+enum RateSourceState: String {
+    case live
+    case cached
+    case unavailable
+
+    var label: String {
+        switch self {
+        case .live:
+            return "即時匯率"
+        case .cached:
+            return "上次匯率"
+        case .unavailable:
+            return "暫無匯率"
+        }
+    }
+}
+
+enum TransactionSemantics {
+    static let debtForgivenessMarker = "[免除債務]"
+    static let assetAdjustmentMarker = "[資產調整]"
+
+    static func ownAccounts(from accounts: [Account]) -> [Account] {
+        accounts.filter { $0.type != .debt && !$0.isArchived }
+    }
+
+    static func debtAccounts(from accounts: [Account]) -> [Account] {
+        accounts.filter { $0.type == .debt && !$0.isArchived }
+    }
+
+    static func allowedAccounts(for type: TransactionType, from accounts: [Account]) -> [Account] {
+        switch type {
+        case .income:
+            return ownAccounts(from: accounts)
+        case .expense:
+            return ownAccounts(from: accounts)
+        case .transfer:
+            return accounts.filter { !$0.isArchived }
+        }
+    }
+
+    static func isDebtForgiveness(note: String) -> Bool {
+        note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix(debtForgivenessMarker)
+    }
+
+    static func debtForgivenessDirection(note: String) -> DebtForgivenessDirection? {
+        guard isDebtForgiveness(note: note) else { return nil }
+        if note.contains("對方免除") { return .forgivenByOthers }
+        if note.contains("我方免除") { return .forgiveOthers }
+        return nil
+    }
+
+    static func debtForgivenessNote(baseNote: String, debtAccountName: String, direction: DebtForgivenessDirection) -> String {
+        let trimmed = baseNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffix: String
+        switch direction {
+        case .forgivenByOthers:
+            suffix = "(對方免除：\(debtAccountName))"
+        case .forgiveOthers:
+            suffix = "(我方免除：\(debtAccountName))"
+        }
+
+        if trimmed.isEmpty {
+            return "\(debtForgivenessMarker) \(suffix)"
+        }
+        return "\(debtForgivenessMarker) \(trimmed) \(suffix)"
+    }
+
+    static func debtForgivenessDisplayTitle(note: String) -> String {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isDebtForgiveness(note: trimmed) else { return trimmed }
+
+        let withoutMarker = trimmed
+            .replacingOccurrences(of: debtForgivenessMarker, with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if withoutMarker.isEmpty {
+            return "免除債務"
+        }
+        return withoutMarker
+    }
+
+    static func isLegacyDebtIncome(_ transaction: FinancialTransaction) -> Bool {
+        transaction.type == .income && transaction.account?.type == .debt
+    }
+
+    static func isLegacyDebtIncome(_ shortcut: Shortcut) -> Bool {
+        shortcut.type == .income && shortcut.account?.type == .debt
+    }
+}

--- a/AI 記帳/Views/Accounts/AccountsView.swift
+++ b/AI 記帳/Views/Accounts/AccountsView.swift
@@ -96,7 +96,7 @@ struct AccountsView: View {
             headerSection
 
             if !assetAccounts.isEmpty {
-                Section("一般帳戶") {
+                Section("自己的賬戶") {
                     ForEach(assetAccounts) { account in
                         accountRow(account)
                     }

--- a/AI 記帳/Views/Shared/CurrencyRateHintView.swift
+++ b/AI 記帳/Views/Shared/CurrencyRateHintView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct CurrencyRateHintView: View {
+    @ObservedObject var currencyService: CurrencyService
+    let amount: Decimal?
+    let currencyCode: String
+
+    var body: some View {
+        if let amount,
+           let preview = currencyService.previewInMainCurrency(amount: amount, from: currencyCode) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("約 \(preview.amount.formatted(.currency(code: currencyService.mainCurrency)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(preview.source.label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if currencyCode.uppercased() != currencyService.mainCurrency.uppercased() {
+            Text("暫時無法取得匯率")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+struct TransferRateHintView: View {
+    @ObservedObject var currencyService: CurrencyService
+    let outgoingAmount: Decimal?
+    let outgoingCurrency: String
+    let incomingAmount: Decimal?
+    let incomingCurrency: String
+
+    private var inferredRateText: String? {
+        guard let outgoingAmount, let incomingAmount,
+              outgoingAmount > 0, incomingAmount > 0,
+              outgoingCurrency.uppercased() != incomingCurrency.uppercased() else { return nil }
+        let impliedRate = NSDecimalNumber(decimal: incomingAmount / outgoingAmount).doubleValue
+        guard impliedRate.isFinite, impliedRate > 0 else { return nil }
+        return String(format: "輸入匯率：1 %@ = %.4f %@", outgoingCurrency.uppercased(), impliedRate, incomingCurrency.uppercased())
+    }
+
+    private var marketRateText: String? {
+        guard outgoingCurrency.uppercased() != incomingCurrency.uppercased(),
+              let rate = currencyService.getMarketRate(from: outgoingCurrency, to: incomingCurrency) else {
+            return nil
+        }
+        return String(format: "參考匯率：1 %@ = %.4f %@（%@）", outgoingCurrency.uppercased(), rate, incomingCurrency.uppercased(), currencyService.resolvedRateSourceState.label)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let inferredRateText {
+                Text(inferredRateText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let marketRateText {
+                Text(marketRateText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else if outgoingCurrency.uppercased() != incomingCurrency.uppercased() {
+                Text("暫時無法取得匯率")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            CurrencyRateHintView(currencyService: currencyService, amount: outgoingAmount, currencyCode: outgoingCurrency)
+            CurrencyRateHintView(currencyService: currencyService, amount: incomingAmount, currencyCode: incomingCurrency)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/AI 記帳/Views/Shortcuts/AddShortcutView.swift
+++ b/AI 記帳/Views/Shortcuts/AddShortcutView.swift
@@ -9,8 +9,7 @@ struct AddShortcutView: View {
     @Query(sort: \Category.name) private var categories: [Category]
     @Query(sort: \Tag.name) private var tags: [Tag]
     
-    // 過濾已歸檔帳戶 (不讓用戶建立關聯到已歸檔帳戶的捷徑)
-    var accounts: [Account] { allAccounts.filter { !$0.isArchived } }
+    var accounts: [Account] { TransactionSemantics.allowedAccounts(for: selectedType, from: allAccounts) }
     
     @State private var name: String = ""
     @State private var icon: String = "⚡️"
@@ -56,6 +55,12 @@ struct AddShortcutView: View {
                     .onChange(of: selectedType) { _, _ in
                         if let current = selectedCategory, !current.kind.supports(selectedType) {
                             selectedCategory = nil
+                        }
+                        if let selectedAccount, !accounts.contains(where: { $0.id == selectedAccount.id }) {
+                            self.selectedAccount = accounts.first
+                            if let selectedAccount = self.selectedAccount {
+                                selectedCurrency = selectedAccount.currency
+                            }
                         }
                     }
                     

--- a/AI 記帳/Views/Tools/DataHealthCheckView.swift
+++ b/AI 記帳/Views/Tools/DataHealthCheckView.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 struct DataHealthCheckView: View {
     @Environment(\.modelContext) private var modelContext
+    @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
+    @Query(sort: \Shortcut.name) private var shortcuts: [Shortcut]
     
     @State private var report: HealthReport?
     @State private var isRunning = false
@@ -30,6 +32,8 @@ struct DataHealthCheckView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            legacyDebtIncomeSection
             
             if let report {
                 issuesSection("錯誤", severity: .error, report: report)
@@ -55,6 +59,69 @@ struct DataHealthCheckView: View {
             Button("好", role: .cancel) {}
         } message: {
             Text(alertMessage)
+        }
+    }
+
+    @ViewBuilder
+    private var legacyDebtIncomeSection: some View {
+        let legacyTransactions = LegacyDebtIncomeRepairService.legacyDebtIncomeTransactions(from: transactions)
+        let legacyShortcuts = LegacyDebtIncomeRepairService.legacyDebtIncomeShortcuts(from: shortcuts)
+
+        if !legacyTransactions.isEmpty || !legacyShortcuts.isEmpty {
+            Section("收入 / 借貸清理") {
+                if !legacyTransactions.isEmpty {
+                    Button(isRunning ? "處理中..." : "全部轉成免除債務 (\(legacyTransactions.count))") {
+                        convertAllLegacyDebtIncomeTransactions(legacyTransactions)
+                    }
+                    .disabled(isRunning)
+
+                    ForEach(legacyTransactions) { transaction in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(transaction.account?.name ?? "未指定借貸帳戶")
+                                .font(.headline)
+                            Text(transaction.amount.formatted(.currency(code: transaction.currencyCode)))
+                                .font(.subheadline)
+                            Text(transaction.date.formatted(date: .abbreviated, time: .shortened))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(transaction.note.isEmpty ? "沒有備註" : transaction.note)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Button("轉成免除債務") {
+                                convertLegacyDebtIncomeTransaction(transaction)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(isRunning)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+
+                if !legacyShortcuts.isEmpty {
+                    Button(isRunning ? "處理中..." : "清除收入捷徑的借貸帳戶綁定 (\(legacyShortcuts.count))") {
+                        detachAllLegacyDebtIncomeShortcuts(legacyShortcuts)
+                    }
+                    .disabled(isRunning)
+
+                    ForEach(legacyShortcuts) { shortcut in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("\(shortcut.icon) \(shortcut.name)")
+                                .font(.headline)
+                            Text("目前綁定：\(shortcut.account?.name ?? "未指定帳戶")")
+                                .font(.subheadline)
+                            Text("金額：\(shortcut.amount.formatted(.currency(code: shortcut.currencyCode)))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Button("移除借貸帳戶綁定") {
+                                detachLegacyDebtIncomeShortcut(shortcut)
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(isRunning)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
         }
     }
     
@@ -140,6 +207,76 @@ struct DataHealthCheckView: View {
             alertMessage = "修復失敗：\(error.localizedDescription)"
         }
         
+        isRunning = false
+        showingAlert = true
+    }
+
+    private func convertLegacyDebtIncomeTransaction(_ transaction: FinancialTransaction) {
+        isRunning = true
+        do {
+            guard LegacyDebtIncomeRepairService.convertLegacyDebtIncomeTransaction(transaction, modelContext: modelContext) else {
+                alertMessage = "這筆資料已經不是舊版收入 / 借貸異常紀錄。"
+                showingAlert = true
+                isRunning = false
+                return
+            }
+            try modelContext.save()
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            alertMessage = "已把這筆資料轉成免除債務。"
+        } catch {
+            alertMessage = "轉換失敗：\(error.localizedDescription)"
+        }
+        isRunning = false
+        showingAlert = true
+    }
+
+    private func convertAllLegacyDebtIncomeTransactions(_ transactions: [FinancialTransaction]) {
+        isRunning = true
+        do {
+            let converted = try LegacyDebtIncomeRepairService.convertLegacyDebtIncomeTransactions(
+                transactions,
+                modelContext: modelContext
+            )
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            alertMessage = "已把 \(converted) 筆舊版收入 / 借貸紀錄轉成免除債務。"
+        } catch {
+            alertMessage = "批量轉換失敗：\(error.localizedDescription)"
+        }
+        isRunning = false
+        showingAlert = true
+    }
+
+    private func detachLegacyDebtIncomeShortcut(_ shortcut: Shortcut) {
+        isRunning = true
+        do {
+            guard LegacyDebtIncomeRepairService.detachLegacyDebtIncomeShortcut(shortcut, modelContext: modelContext) else {
+                alertMessage = "這個捷徑已經不是舊版收入 / 借貸異常綁定。"
+                showingAlert = true
+                isRunning = false
+                return
+            }
+            try modelContext.save()
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            alertMessage = "已移除這個收入捷徑的借貸帳戶綁定。"
+        } catch {
+            alertMessage = "清理失敗：\(error.localizedDescription)"
+        }
+        isRunning = false
+        showingAlert = true
+    }
+
+    private func detachAllLegacyDebtIncomeShortcuts(_ shortcuts: [Shortcut]) {
+        isRunning = true
+        do {
+            let detached = try LegacyDebtIncomeRepairService.detachLegacyDebtIncomeShortcuts(
+                shortcuts,
+                modelContext: modelContext
+            )
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            alertMessage = "已清除 \(detached) 個收入捷徑的借貸帳戶綁定。"
+        } catch {
+            alertMessage = "批量清理失敗：\(error.localizedDescription)"
+        }
         isRunning = false
         showingAlert = true
     }

--- a/AI 記帳/Views/Transactions/AddDebtView.swift
+++ b/AI 記帳/Views/Transactions/AddDebtView.swift
@@ -4,8 +4,10 @@ import SwiftData
 struct AddDebtView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var currencyService = CurrencyService.shared
 
     @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
+    private let existingForgivenessTransactionID: UUID?
 
     private var debtAccounts: [Account] {
         allAccounts.filter { $0.type == .debt && !$0.isArchived }.sorted { $0.name < $1.name }
@@ -18,6 +20,7 @@ struct AddDebtView: View {
     enum DebtMode: String, CaseIterable {
         case borrow = "借入 (我欠人)"
         case repay = "還款 (還給人)"
+        case forgive = "免除債務"
     }
 
     private enum EntryMode: String, CaseIterable, Identifiable {
@@ -50,6 +53,7 @@ struct AddDebtView: View {
     }
 
     @State private var mode: DebtMode = .borrow
+    @State private var forgivenessDirection: DebtForgivenessDirection = .forgivenByOthers
     @State private var entryMode: EntryMode = .normal
 
     @State private var selectedDebtAccount: Account?
@@ -68,6 +72,10 @@ struct AddDebtView: View {
 
     @FocusState private var isAmountFocused: Bool
 
+    init(existingForgivenessTransaction: FinancialTransaction? = nil) {
+        self.existingForgivenessTransactionID = existingForgivenessTransaction?.id
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -79,12 +87,21 @@ struct AddDebtView: View {
                     }
                     .pickerStyle(.segmented)
 
-                    Picker("模式", selection: $entryMode) {
-                        ForEach(EntryMode.allCases) { option in
-                            Text(option.title).tag(option)
+                    if mode == .forgive {
+                        Picker("免除方向", selection: $forgivenessDirection) {
+                            ForEach(DebtForgivenessDirection.allCases) { option in
+                                Text(option.rawValue).tag(option)
+                            }
                         }
+                        .pickerStyle(.segmented)
+                    } else {
+                        Picker("模式", selection: $entryMode) {
+                            ForEach(EntryMode.allCases) { option in
+                                Text(option.title).tag(option)
+                            }
+                        }
+                        .pickerStyle(.segmented)
                     }
-                    .pickerStyle(.segmented)
                 }
 
                 Section {
@@ -93,15 +110,20 @@ struct AddDebtView: View {
                             .foregroundStyle(.red)
                             .font(.caption)
                     } else {
-                        Picker(mode == .borrow ? "跟誰借" : "還給誰", selection: $selectedDebtAccount) {
+                        Picker(debtAccountLabel, selection: $selectedDebtAccount) {
                             Text("請選擇對象").tag(nil as Account?)
                             ForEach(debtAccounts) { acc in
                                 Text(acc.name).tag(acc as Account?)
                             }
                         }
+                        .onChange(of: selectedDebtAccount) { _, newValue in
+                            if mode == .forgive, let newValue {
+                                selectedCurrency = newValue.currency
+                            }
+                        }
                     }
 
-                    if entryMode != .split {
+                    if mode != .forgive && entryMode != .split {
                         Picker(mode == .borrow ? "存入帳戶" : "付款帳戶", selection: $selectedMyAccount) {
                             Text("請選擇帳戶").tag(nil as Account?)
                             ForEach(myAccounts) { acc in
@@ -117,7 +139,7 @@ struct AddDebtView: View {
                 }
 
                 Section("金額與幣種") {
-                    switch entryMode {
+                    switch effectiveEntryMode {
                     case .normal:
                         normalAmountRow
                     case .split:
@@ -145,7 +167,7 @@ struct AddDebtView: View {
                     Button("取消") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("確認") { saveTransaction() }
+                    Button(existingForgivenessTransactionID == nil ? "確認" : "儲存") { saveTransaction() }
                         .disabled(!canSubmit)
                 }
                 ToolbarItemGroup(placement: .keyboard) {
@@ -154,6 +176,19 @@ struct AddDebtView: View {
                 }
             }
             .onAppear {
+                if let existingForgivenessTransactionID,
+                   let transaction = allAccounts
+                    .flatMap(\.transactions)
+                    .first(where: { $0.id == existingForgivenessTransactionID && TransactionSemantics.isDebtForgiveness(note: $0.note) }) {
+                    mode = .forgive
+                    forgivenessDirection = TransactionSemantics.debtForgivenessDirection(note: transaction.note)
+                        ?? (transaction.amount >= 0 ? .forgivenByOthers : .forgiveOthers)
+                    selectedDebtAccount = transaction.account
+                    selectedCurrency = transaction.currencyCode
+                    amountString = NSDecimalNumber(decimal: abs(transaction.amount)).stringValue
+                    date = transaction.date
+                    note = extractForgivenessNote(transaction.note)
+                }
                 if selectedMyAccount == nil {
                     selectedMyAccount = myAccounts.first
                 }
@@ -167,27 +202,43 @@ struct AddDebtView: View {
                     splitLegs[0].account = first
                     splitLegs[0].currency = first.currency
                 }
+                Task { await currencyService.fetchRates() }
+            }
+            .onChange(of: mode) { _, newMode in
+                if newMode == .forgive {
+                    entryMode = .normal
+                    if let selectedDebtAccount {
+                        selectedCurrency = selectedDebtAccount.currency
+                    }
+                }
             }
         }
     }
 
     @ViewBuilder
     private var normalAmountRow: some View {
-        HStack {
-            Picker("", selection: $selectedCurrency) {
-                ForEach(currencies, id: \.self) { code in
-                    Text(code).tag(code)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Picker("", selection: $selectedCurrency) {
+                    ForEach(currencies, id: \.self) { code in
+                        Text(code).tag(code)
+                    }
                 }
-            }
-            .labelsHidden()
-            .frame(width: 80)
+                .labelsHidden()
+                .frame(width: 80)
 
-            TextField("0", text: Binding(
-                get: { amountString },
-                set: { amountString = sanitizePositiveDecimalInput($0) }
-            ))
-            .keyboardType(.decimalPad)
-            .focused($isAmountFocused)
+                TextField("0", text: Binding(
+                    get: { amountString },
+                    set: { amountString = sanitizePositiveDecimalInput($0) }
+                ))
+                .keyboardType(.decimalPad)
+                .focused($isAmountFocused)
+            }
+            CurrencyRateHintView(
+                currencyService: currencyService,
+                amount: positiveDecimal(from: amountString),
+                currencyCode: selectedCurrency
+            )
         }
     }
 
@@ -223,6 +274,11 @@ struct AddDebtView: View {
                     .keyboardType(.decimalPad)
                     .focused($isAmountFocused)
                 }
+                CurrencyRateHintView(
+                    currencyService: currencyService,
+                    amount: positiveDecimal(from: leg.amountString),
+                    currencyCode: leg.currency
+                )
 
                 if splitLegs.count > 1 {
                     Button(role: .destructive) {
@@ -261,6 +317,11 @@ struct AddDebtView: View {
                 .keyboardType(.decimalPad)
                 .focused($isAmountFocused)
             }
+            CurrencyRateHintView(
+                currencyService: currencyService,
+                amount: positiveDecimal(from: leg.amountString),
+                currencyCode: leg.currency
+            )
 
             if mergeLegs.count > 1 {
                 Button(role: .destructive) {
@@ -290,9 +351,12 @@ struct AddDebtView: View {
                 if mode == .borrow {
                     Text("對象：\(debtAcc.name)")
                     Text("動作：借入（我方資產增加）")
-                } else {
+                } else if mode == .repay {
                     Text("對象：\(debtAcc.name)")
                     Text("動作：還款（我方資產減少）")
+                } else {
+                    Text("對象：\(debtAcc.name)")
+                    Text("動作：\(forgivenessDirection.displayTitle)")
                 }
 
                 if let total {
@@ -305,7 +369,7 @@ struct AddDebtView: View {
     }
 
     private var totalInputAmount: Decimal? {
-        switch entryMode {
+        switch effectiveEntryMode {
         case .normal:
             return positiveDecimal(from: amountString)
         case .split:
@@ -322,8 +386,11 @@ struct AddDebtView: View {
     private var canSubmit: Bool {
         guard selectedDebtAccount != nil else { return false }
 
-        switch entryMode {
+        switch effectiveEntryMode {
         case .normal:
+            if mode == .forgive {
+                return positiveDecimal(from: amountString) != nil
+            }
             return selectedMyAccount != nil && positiveDecimal(from: amountString) != nil
         case .split:
             return splitLegs.contains { $0.account != nil && positiveDecimal(from: $0.amountString) != nil }
@@ -341,15 +408,27 @@ struct AddDebtView: View {
             return
         }
 
-        switch entryMode {
+        switch effectiveEntryMode {
         case .normal:
-            guard let myAcc = selectedMyAccount,
-                  let amount = positiveDecimal(from: amountString)
-            else {
-                showValidation("請輸入完整金額並選擇帳戶。")
+            guard let amount = positiveDecimal(from: amountString) else {
+                showValidation("請輸入有效金額。")
                 return
             }
-            createTransferPair(debtAccount: debtAcc, myAccount: myAcc, amount: amount, currencyCode: selectedCurrency, memo: note)
+            if mode == .forgive {
+                createDebtForgivenessTransaction(
+                    debtAccount: debtAcc,
+                    amount: amount,
+                    currencyCode: selectedCurrency,
+                    memo: note,
+                    direction: forgivenessDirection
+                )
+            } else {
+                guard let myAcc = selectedMyAccount else {
+                    showValidation("請輸入完整金額並選擇帳戶。")
+                    return
+                }
+                createTransferPair(debtAccount: debtAcc, myAccount: myAcc, amount: amount, currencyCode: selectedCurrency, memo: note)
+            }
 
         case .split:
             var legs: [(account: Account, amount: Decimal, currency: String)] = []
@@ -466,6 +545,52 @@ struct AddDebtView: View {
         }
     }
 
+    private func createDebtForgivenessTransaction(
+        debtAccount: Account,
+        amount: Decimal,
+        currencyCode: String,
+        memo: String,
+        direction: DebtForgivenessDirection
+    ) {
+        let normalizedAmount = abs(amount) * direction.amountSign
+        if let existingForgivenessTransactionID,
+           let transaction = allAccounts
+            .flatMap(\.transactions)
+            .first(where: { $0.id == existingForgivenessTransactionID }) {
+            transaction.amount = normalizedAmount
+            transaction.currencyCode = currencyCode
+            transaction.date = date
+            transaction.note = TransactionSemantics.debtForgivenessNote(
+                baseNote: memo,
+                debtAccountName: debtAccount.name,
+                direction: direction
+            )
+            transaction.type = .transfer
+            transaction.linkedTransactionID = nil
+            transaction.transferGroupID = nil
+            transaction.transferSide = nil
+            transaction.account = debtAccount
+            transaction.updatedAt = Date()
+        } else {
+            let transaction = FinancialTransaction(
+                amount: normalizedAmount,
+                currencyCode: currencyCode,
+                date: date,
+                note: TransactionSemantics.debtForgivenessNote(
+                    baseNote: memo,
+                    debtAccountName: debtAccount.name,
+                    direction: direction
+                ),
+                type: .transfer,
+                linkedTransactionID: nil,
+                transferGroupID: nil,
+                transferSide: nil,
+                account: debtAccount
+            )
+            modelContext.insert(transaction)
+        }
+    }
+
     private func indexedMemo(base: String, mode: EntryMode, index: Int, count: Int) -> String {
         let suffix: String
         switch mode {
@@ -508,5 +633,35 @@ struct AddDebtView: View {
     private func showValidation(_ message: String) {
         validationMessage = message
         showingValidationAlert = true
+    }
+
+    private var debtAccountLabel: String {
+        switch mode {
+        case .borrow:
+            return "跟誰借"
+        case .repay:
+            return "還給誰"
+        case .forgive:
+            switch forgivenessDirection {
+            case .forgivenByOthers:
+                return "誰免除了你的欠款"
+            case .forgiveOthers:
+                return "你要免除誰的欠款"
+            }
+        }
+    }
+
+    private var effectiveEntryMode: EntryMode {
+        mode == .forgive ? .normal : entryMode
+    }
+
+    private func extractForgivenessNote(_ note: String) -> String {
+        let cleaned = note
+            .replacingOccurrences(of: TransactionSemantics.debtForgivenessMarker, with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let range = cleaned.range(of: "(對方免除：") ?? cleaned.range(of: "(我方免除：") {
+            return cleaned[..<range.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return cleaned
     }
 }

--- a/AI 記帳/Views/Transactions/AddTransactionView.swift
+++ b/AI 記帳/Views/Transactions/AddTransactionView.swift
@@ -4,10 +4,14 @@ import SwiftData
 struct AddTransactionView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var currencyService = CurrencyService.shared
 
     @Query(sort: \Account.sortOrder) private var accounts: [Account]
     @Query(sort: \Category.name) private var categories: [Category]
     @Query(sort: \Tag.name) private var tags: [Tag]
+
+    private let initialType: TransactionType
+    private let locksTransactionType: Bool
 
     private enum EntryMode: String, CaseIterable, Identifiable {
         case normal
@@ -41,7 +45,7 @@ struct AddTransactionView: View {
     @State private var entryMode: EntryMode = .normal
 
     @State private var amountString = ""
-    @State private var selectedType: TransactionType = .expense
+    @State private var selectedType: TransactionType
     @State private var date = Date()
     @State private var note = ""
     @State private var selectedAccount: Account?
@@ -63,7 +67,13 @@ struct AddTransactionView: View {
     @FocusState private var isAmountFocused: Bool
 
     private var activeAccounts: [Account] {
-        accounts.filter { !$0.isArchived }
+        TransactionSemantics.allowedAccounts(for: selectedType, from: accounts)
+    }
+
+    init(initialType: TransactionType = .expense, locksTransactionType: Bool = false) {
+        self.initialType = initialType
+        self.locksTransactionType = locksTransactionType
+        _selectedType = State(initialValue: initialType)
     }
 
     var body: some View {
@@ -79,14 +89,30 @@ struct AddTransactionView: View {
                 }
 
                 Section("金額與類型") {
-                    Picker("類型", selection: $selectedType) {
-                        Text("支出").tag(TransactionType.expense)
-                        Text("收入").tag(TransactionType.income)
-                    }
-                    .pickerStyle(.segmented)
-                    .onChange(of: selectedType) { _, _ in
-                        if let current = selectedCategory, !current.kind.supports(selectedType) {
-                            selectedCategory = nil
+                    if locksTransactionType {
+                        LabeledContent("類型") {
+                            Text(selectedType == .expense ? "支出" : "收入")
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Picker("類型", selection: $selectedType) {
+                            Text("支出").tag(TransactionType.expense)
+                            Text("收入").tag(TransactionType.income)
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(of: selectedType) { _, _ in
+                            if let current = selectedCategory, !current.kind.supports(selectedType) {
+                                selectedCategory = nil
+                            }
+                            selectedAccount = reconcileSelectedAccount(selectedAccount)
+                            splitLegs = splitLegs.map { leg in
+                                var updated = leg
+                                updated.account = reconcileSplitAccount(leg.account)
+                                if let account = updated.account {
+                                    updated.currency = account.currency
+                                }
+                                return updated
+                            }
                         }
                     }
 
@@ -195,14 +221,18 @@ struct AddTransactionView: View {
                 Text(validationMessage)
             }
             .onAppear {
-                if selectedAccount == nil, let firstAccount = activeAccounts.first {
-                    selectedAccount = firstAccount
-                    selectedCurrency = firstAccount.currency
+                selectedType = initialType
+                if selectedAccount == nil || !activeAccounts.contains(where: { $0.id == selectedAccount?.id }) {
+                    selectedAccount = activeAccounts.first
+                }
+                if let selectedAccount {
+                    selectedCurrency = selectedAccount.currency
                 }
                 if splitLegs.first?.account == nil, let firstAccount = activeAccounts.first {
                     splitLegs[0].account = firstAccount
                     splitLegs[0].currency = firstAccount.currency
                 }
+                Task { await currencyService.fetchRates() }
             }
         }
     }
@@ -224,22 +254,29 @@ struct AddTransactionView: View {
 
     @ViewBuilder
     private var normalAmountRow: some View {
-        HStack {
-            Picker("", selection: $selectedCurrency) {
-                ForEach(currencies, id: \.self) { code in
-                    Text(code).tag(code)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Picker("", selection: $selectedCurrency) {
+                    ForEach(currencies, id: \.self) { code in
+                        Text(code).tag(code)
+                    }
                 }
-            }
-            .labelsHidden()
-            .frame(width: 80)
+                .labelsHidden()
+                .frame(width: 80)
 
-            TextField("0", text: Binding(
-                get: { amountString },
-                set: { amountString = sanitizePositiveDecimalInput($0) }
-            ))
-            .font(.largeTitle)
-            .keyboardType(.decimalPad)
-            .focused($isAmountFocused)
+                TextField("0", text: Binding(
+                    get: { amountString },
+                    set: { amountString = sanitizePositiveDecimalInput($0) }
+                ))
+                .font(.largeTitle)
+                .keyboardType(.decimalPad)
+                .focused($isAmountFocused)
+            }
+            CurrencyRateHintView(
+                currencyService: currencyService,
+                amount: positiveDecimal(from: amountString),
+                currencyCode: selectedCurrency
+            )
         }
     }
 
@@ -275,6 +312,11 @@ struct AddTransactionView: View {
                     .keyboardType(.decimalPad)
                     .focused($isAmountFocused)
                 }
+                CurrencyRateHintView(
+                    currencyService: currencyService,
+                    amount: positiveDecimal(from: leg.amountString),
+                    currencyCode: leg.currency
+                )
 
                 if splitLegs.count > 1 {
                     Button(role: .destructive) {
@@ -313,6 +355,11 @@ struct AddTransactionView: View {
                 .keyboardType(.decimalPad)
                 .focused($isAmountFocused)
             }
+            CurrencyRateHintView(
+                currencyService: currencyService,
+                amount: positiveDecimal(from: leg.amountString),
+                currencyCode: leg.currency
+            )
 
             if mergeLegs.count > 1 {
                 Button(role: .destructive) {
@@ -482,5 +529,15 @@ struct AddTransactionView: View {
 
     private var filteredCategories: [Category] {
         categories.filter { $0.kind.supports(selectedType) }
+    }
+
+    private func reconcileSelectedAccount(_ account: Account?) -> Account? {
+        guard let account else { return activeAccounts.first }
+        return activeAccounts.first(where: { $0.id == account.id }) ?? activeAccounts.first
+    }
+
+    private func reconcileSplitAccount(_ account: Account?) -> Account? {
+        guard let account else { return activeAccounts.first }
+        return activeAccounts.first(where: { $0.id == account.id }) ?? activeAccounts.first
     }
 }

--- a/AI 記帳/Views/Transactions/AddTransferView.swift
+++ b/AI 記帳/Views/Transactions/AddTransferView.swift
@@ -5,16 +5,17 @@ import UIKit
 struct AddTransferView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
-    
+    @StateObject private var currencyService = CurrencyService.shared
+
     @Query(sort: \Account.name) private var accounts: [Account]
-    
+
     private enum TransferMode: String, CaseIterable, Identifiable {
         case oneToOne
         case oneToMany
         case manyToOne
-        
+
         var id: String { rawValue }
-        
+
         var title: String {
             switch self {
             case .oneToOne: return "一般 (1 -> 1)"
@@ -23,16 +24,16 @@ struct AddTransferView: View {
             }
         }
     }
-    
+
     private struct TransferLegInput: Identifiable {
         let id = UUID()
         var account: Account?
         var currency: String = "HKD"
         var amountString: String = ""
     }
-    
+
     @State private var mode: TransferMode = .oneToOne
-    
+
     // 1 -> 1
     @State private var fromAccount: Account?
     @State private var toAccount: Account?
@@ -40,30 +41,30 @@ struct AddTransferView: View {
     @State private var currencyIn: String = "HKD"
     @State private var amountOutString: String = ""
     @State private var amountInString: String = ""
-    
+
     // 1 -> many
     @State private var sourceAccount: Account?
     @State private var sourceCurrency: String = "HKD"
     @State private var sourceAmountString: String = ""
     @State private var destinationLegs: [TransferLegInput] = [TransferLegInput()]
-    
+
     // many -> 1
     @State private var destinationAccount: Account?
     @State private var destinationCurrency: String = "HKD"
     @State private var destinationAmountString: String = ""
     @State private var sourceLegs: [TransferLegInput] = [TransferLegInput()]
-    
+
     @State private var date: Date = Date()
     @State private var note: String = ""
     @State private var showingValidationAlert = false
     @State private var validationMessage = ""
-    
+
     private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
-    
+
     private var activeAccounts: [Account] {
         accounts.filter { !$0.isArchived }
     }
-    
+
     private var canSubmit: Bool {
         switch mode {
         case .oneToOne:
@@ -90,7 +91,7 @@ struct AddTransferView: View {
             }
         }
     }
-    
+
     var body: some View {
         NavigationStack {
             Form {
@@ -105,7 +106,7 @@ struct AddTransferView: View {
                         dismissKeyboard()
                     }
                 }
-                
+
                 switch mode {
                 case .oneToOne:
                     oneToOneSections
@@ -114,7 +115,7 @@ struct AddTransferView: View {
                 case .manyToOne:
                     manyToOneSections
                 }
-                
+
                 Section("其他") {
                     DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
                     TextField("備註", text: $note)
@@ -139,9 +140,12 @@ struct AddTransferView: View {
                     Button("完成") { dismissKeyboard() }
                 }
             }
+            .onAppear {
+                Task { await currencyService.fetchRates() }
+            }
         }
     }
-    
+
     @ViewBuilder
     private var oneToOneSections: some View {
         Section("轉出方 (支出)") {
@@ -159,32 +163,39 @@ struct AddTransferView: View {
                     }
                 }
             }
-            
+
             if fromAccount != nil {
-                HStack {
-                    Picker("", selection: $currencyOut) {
-                        ForEach(currencies, id: \.self) { code in
-                            Text(code).tag(code)
-                        }
-                    }
-                    .labelsHidden()
-                    .frame(width: 80)
-                    
-                    TextField("轉出金額", text: Binding(
-                        get: { amountOutString },
-                        set: { newValue in
-                            let sanitized = sanitizePositiveDecimalInput(newValue)
-                            amountOutString = sanitized
-                            if currencyOut == currencyIn {
-                                amountInString = sanitized
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Picker("", selection: $currencyOut) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
                             }
                         }
-                    ))
-                    .keyboardType(.decimalPad)
+                        .labelsHidden()
+                        .frame(width: 80)
+
+                        TextField("轉出金額", text: Binding(
+                            get: { amountOutString },
+                            set: { newValue in
+                                let sanitized = sanitizePositiveDecimalInput(newValue)
+                                amountOutString = sanitized
+                                if currencyOut == currencyIn {
+                                    amountInString = sanitized
+                                }
+                            }
+                        ))
+                        .keyboardType(.decimalPad)
+                    }
+                    CurrencyRateHintView(
+                        currencyService: currencyService,
+                        amount: positiveDecimal(from: amountOutString),
+                        currencyCode: currencyOut
+                    )
                 }
             }
         }
-        
+
         Section("轉入方 (收入)") {
             Picker("到帳戶", selection: $toAccount) {
                 Text("選擇帳戶").tag(nil as Account?)
@@ -200,24 +211,39 @@ struct AddTransferView: View {
                     }
                 }
             }
-            
+
             if toAccount != nil {
-                HStack {
-                    Picker("", selection: $currencyIn) {
-                        ForEach(currencies, id: \.self) { code in
-                            Text(code).tag(code)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Picker("", selection: $currencyIn) {
+                            ForEach(currencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
                         }
+                        .labelsHidden()
+                        .frame(width: 80)
+
+                        TextField("轉入金額 (實收)", text: Binding(
+                            get: { amountInString },
+                            set: { amountInString = sanitizePositiveDecimalInput($0) }
+                        ))
+                        .keyboardType(.decimalPad)
                     }
-                    .labelsHidden()
-                    .frame(width: 80)
-                    
-                    TextField("轉入金額 (實收)", text: Binding(
-                        get: { amountInString },
-                        set: { amountInString = sanitizePositiveDecimalInput($0) }
-                    ))
-                    .keyboardType(.decimalPad)
+                    CurrencyRateHintView(
+                        currencyService: currencyService,
+                        amount: positiveDecimal(from: amountInString),
+                        currencyCode: currencyIn
+                    )
                 }
-                
+
+                TransferRateHintView(
+                    currencyService: currencyService,
+                    outgoingAmount: positiveDecimal(from: amountOutString),
+                    outgoingCurrency: currencyOut,
+                    incomingAmount: positiveDecimal(from: amountInString),
+                    incomingCurrency: currencyIn
+                )
+
                 if currencyOut == currencyIn {
                     Text("幣種相同，金額自動對應")
                         .font(.caption)
@@ -226,7 +252,7 @@ struct AddTransferView: View {
             }
         }
     }
-    
+
     @ViewBuilder
     private var oneToManySections: some View {
         Section("單一轉出") {
@@ -246,24 +272,31 @@ struct AddTransferView: View {
                     }
                 }
             }
-            
-            HStack {
-                Picker("", selection: $sourceCurrency) {
-                    ForEach(currencies, id: \.self) { code in
-                        Text(code).tag(code)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Picker("", selection: $sourceCurrency) {
+                        ForEach(currencies, id: \.self) { code in
+                            Text(code).tag(code)
+                        }
                     }
+                    .labelsHidden()
+                    .frame(width: 80)
+
+                    TextField("轉出總額", text: Binding(
+                        get: { sourceAmountString },
+                        set: { sourceAmountString = sanitizePositiveDecimalInput($0) }
+                    ))
+                    .keyboardType(.decimalPad)
                 }
-                .labelsHidden()
-                .frame(width: 80)
-                
-                TextField("轉出總額", text: Binding(
-                    get: { sourceAmountString },
-                    set: { sourceAmountString = sanitizePositiveDecimalInput($0) }
-                ))
-                .keyboardType(.decimalPad)
+                CurrencyRateHintView(
+                    currencyService: currencyService,
+                    amount: positiveDecimal(from: sourceAmountString),
+                    currencyCode: sourceCurrency
+                )
             }
         }
-        
+
         Section("分拆轉入") {
             ForEach($destinationLegs) { $leg in
                 VStack(spacing: 10) {
@@ -278,23 +311,30 @@ struct AddTransferView: View {
                             leg.currency = acc.currency
                         }
                     }
-                    
-                    HStack {
-                        Picker("", selection: $leg.currency) {
-                            ForEach(currencies, id: \.self) { code in
-                                Text(code).tag(code)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Picker("", selection: $leg.currency) {
+                                ForEach(currencies, id: \.self) { code in
+                                    Text(code).tag(code)
+                                }
                             }
+                            .labelsHidden()
+                            .frame(width: 80)
+
+                            TextField("轉入金額", text: Binding(
+                                get: { leg.amountString },
+                                set: { leg.amountString = sanitizePositiveDecimalInput($0) }
+                            ))
+                            .keyboardType(.decimalPad)
                         }
-                        .labelsHidden()
-                        .frame(width: 80)
-                        
-                        TextField("轉入金額", text: Binding(
-                            get: { leg.amountString },
-                            set: { leg.amountString = sanitizePositiveDecimalInput($0) }
-                        ))
-                        .keyboardType(.decimalPad)
+                        CurrencyRateHintView(
+                            currencyService: currencyService,
+                            amount: positiveDecimal(from: leg.amountString),
+                            currencyCode: leg.currency
+                        )
                     }
-                    
+
                     if destinationLegs.count > 1 {
                         Button(role: .destructive) {
                             destinationLegs.removeAll { $0.id == leg.id }
@@ -305,7 +345,7 @@ struct AddTransferView: View {
                 }
                 .padding(.vertical, 4)
             }
-            
+
             Button {
                 destinationLegs.append(TransferLegInput(currency: sourceCurrency))
             } label: {
@@ -313,7 +353,7 @@ struct AddTransferView: View {
             }
         }
     }
-    
+
     @ViewBuilder
     private var manyToOneSections: some View {
         Section("多個轉出") {
@@ -330,23 +370,30 @@ struct AddTransferView: View {
                             leg.currency = acc.currency
                         }
                     }
-                    
-                    HStack {
-                        Picker("", selection: $leg.currency) {
-                            ForEach(currencies, id: \.self) { code in
-                                Text(code).tag(code)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Picker("", selection: $leg.currency) {
+                                ForEach(currencies, id: \.self) { code in
+                                    Text(code).tag(code)
+                                }
                             }
+                            .labelsHidden()
+                            .frame(width: 80)
+
+                            TextField("轉出金額", text: Binding(
+                                get: { leg.amountString },
+                                set: { leg.amountString = sanitizePositiveDecimalInput($0) }
+                            ))
+                            .keyboardType(.decimalPad)
                         }
-                        .labelsHidden()
-                        .frame(width: 80)
-                        
-                        TextField("轉出金額", text: Binding(
-                            get: { leg.amountString },
-                            set: { leg.amountString = sanitizePositiveDecimalInput($0) }
-                        ))
-                        .keyboardType(.decimalPad)
+                        CurrencyRateHintView(
+                            currencyService: currencyService,
+                            amount: positiveDecimal(from: leg.amountString),
+                            currencyCode: leg.currency
+                        )
                     }
-                    
+
                     if sourceLegs.count > 1 {
                         Button(role: .destructive) {
                             sourceLegs.removeAll { $0.id == leg.id }
@@ -357,14 +404,14 @@ struct AddTransferView: View {
                 }
                 .padding(.vertical, 4)
             }
-            
+
             Button {
                 sourceLegs.append(TransferLegInput(currency: destinationCurrency))
             } label: {
                 Label("新增轉出帳戶", systemImage: "plus.circle")
             }
         }
-        
+
         Section("單一轉入") {
             Picker("到帳戶", selection: $destinationAccount) {
                 Text("選擇帳戶").tag(nil as Account?)
@@ -382,25 +429,32 @@ struct AddTransferView: View {
                     }
                 }
             }
-            
-            HStack {
-                Picker("", selection: $destinationCurrency) {
-                    ForEach(currencies, id: \.self) { code in
-                        Text(code).tag(code)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Picker("", selection: $destinationCurrency) {
+                        ForEach(currencies, id: \.self) { code in
+                            Text(code).tag(code)
+                        }
                     }
+                    .labelsHidden()
+                    .frame(width: 80)
+
+                    TextField("轉入總額", text: Binding(
+                        get: { destinationAmountString },
+                        set: { destinationAmountString = sanitizePositiveDecimalInput($0) }
+                    ))
+                    .keyboardType(.decimalPad)
                 }
-                .labelsHidden()
-                .frame(width: 80)
-                
-                TextField("轉入總額", text: Binding(
-                    get: { destinationAmountString },
-                    set: { destinationAmountString = sanitizePositiveDecimalInput($0) }
-                ))
-                .keyboardType(.decimalPad)
+                CurrencyRateHintView(
+                    currencyService: currencyService,
+                    amount: positiveDecimal(from: destinationAmountString),
+                    currencyCode: destinationCurrency
+                )
             }
         }
     }
-    
+
     private func saveTransfer() {
         switch mode {
         case .oneToOne:
@@ -411,7 +465,7 @@ struct AddTransferView: View {
             saveManyToOneTransfer()
         }
     }
-    
+
     private func saveOneToOneTransfer() {
         guard let from = fromAccount, let to = toAccount else { return }
         guard from.id != to.id else {
@@ -422,7 +476,7 @@ struct AddTransferView: View {
             showValidation("請輸入大於 0 的轉出金額。")
             return
         }
-        
+
         var amountIn = amountOut
         if currencyOut != currencyIn {
             guard let customIn = positiveDecimal(from: amountInString) else {
@@ -431,12 +485,12 @@ struct AddTransferView: View {
             }
             amountIn = customIn
         }
-        
+
         let txID1 = UUID()
         let txID2 = UUID()
         let transferGroupID = UUID()
         let memo = note.isEmpty ? "轉帳" : note
-        
+
         let outTx = FinancialTransaction(
             id: txID1,
             amount: -abs(amountOut),
@@ -449,7 +503,7 @@ struct AddTransferView: View {
             transferSide: .outgoing,
             account: from
         )
-        
+
         let inTx = FinancialTransaction(
             id: txID2,
             amount: abs(amountIn),
@@ -462,12 +516,12 @@ struct AddTransferView: View {
             transferSide: .incoming,
             account: to
         )
-        
+
         modelContext.insert(outTx)
         modelContext.insert(inTx)
         saveContextAndDismiss()
     }
-    
+
     private func saveOneToManyTransfer() {
         guard let source = sourceAccount else {
             showValidation("請選擇轉出帳戶。")
@@ -477,7 +531,7 @@ struct AddTransferView: View {
             showValidation("請輸入大於 0 的轉出總額。")
             return
         }
-        
+
         let parsedLegs = destinationLegs.enumerated().compactMap { index, leg -> (index: Int, account: Account, currency: String, amount: Decimal)? in
             guard let account = leg.account,
                   let amount = positiveDecimal(from: leg.amountString) else {
@@ -485,12 +539,12 @@ struct AddTransferView: View {
             }
             return (index + 1, account, leg.currency, amount)
         }
-        
+
         if parsedLegs.count != destinationLegs.count || parsedLegs.isEmpty {
             showValidation("請完整填寫每一個轉入帳戶與金額。")
             return
         }
-        
+
         var accountIDs = Set<UUID>()
         for leg in parsedLegs {
             if leg.account.id == source.id {
@@ -503,7 +557,7 @@ struct AddTransferView: View {
             }
             accountIDs.insert(leg.account.id)
         }
-        
+
         let sameCurrencyOnly = parsedLegs.allSatisfy { $0.currency == sourceCurrency }
         if sameCurrencyOnly {
             let totalIn = parsedLegs.reduce(Decimal.zero) { $0 + $1.amount }
@@ -512,10 +566,10 @@ struct AddTransferView: View {
                 return
             }
         }
-        
+
         let transferGroupID = UUID()
         let memo = note.isEmpty ? "轉帳" : note
-        
+
         let outTx = FinancialTransaction(
             amount: -abs(sourceAmount),
             currencyCode: sourceCurrency,
@@ -527,7 +581,7 @@ struct AddTransferView: View {
             account: source
         )
         modelContext.insert(outTx)
-        
+
         for leg in parsedLegs {
             let inTx = FinancialTransaction(
                 amount: abs(leg.amount),
@@ -541,10 +595,10 @@ struct AddTransferView: View {
             )
             modelContext.insert(inTx)
         }
-        
+
         saveContextAndDismiss()
     }
-    
+
     private func saveManyToOneTransfer() {
         guard let destination = destinationAccount else {
             showValidation("請選擇轉入帳戶。")
@@ -554,7 +608,7 @@ struct AddTransferView: View {
             showValidation("請輸入大於 0 的轉入總額。")
             return
         }
-        
+
         let parsedLegs = sourceLegs.enumerated().compactMap { index, leg -> (index: Int, account: Account, currency: String, amount: Decimal)? in
             guard let account = leg.account,
                   let amount = positiveDecimal(from: leg.amountString) else {
@@ -562,12 +616,12 @@ struct AddTransferView: View {
             }
             return (index + 1, account, leg.currency, amount)
         }
-        
+
         if parsedLegs.count != sourceLegs.count || parsedLegs.isEmpty {
             showValidation("請完整填寫每一個轉出帳戶與金額。")
             return
         }
-        
+
         var accountIDs = Set<UUID>()
         for leg in parsedLegs {
             if leg.account.id == destination.id {
@@ -580,7 +634,7 @@ struct AddTransferView: View {
             }
             accountIDs.insert(leg.account.id)
         }
-        
+
         let sameCurrencyOnly = parsedLegs.allSatisfy { $0.currency == destinationCurrency }
         if sameCurrencyOnly {
             let totalOut = parsedLegs.reduce(Decimal.zero) { $0 + $1.amount }
@@ -589,10 +643,10 @@ struct AddTransferView: View {
                 return
             }
         }
-        
+
         let transferGroupID = UUID()
         let memo = note.isEmpty ? "轉帳" : note
-        
+
         for leg in parsedLegs {
             let outTx = FinancialTransaction(
                 amount: -abs(leg.amount),
@@ -606,7 +660,7 @@ struct AddTransferView: View {
             )
             modelContext.insert(outTx)
         }
-        
+
         let inTx = FinancialTransaction(
             amount: abs(destinationAmount),
             currencyCode: destinationCurrency,
@@ -618,10 +672,10 @@ struct AddTransferView: View {
             account: destination
         )
         modelContext.insert(inTx)
-        
+
         saveContextAndDismiss()
     }
-    
+
     private func saveContextAndDismiss() {
         do {
             try modelContext.save()
@@ -630,17 +684,17 @@ struct AddTransferView: View {
             showValidation("儲存失敗：\(error.localizedDescription)")
         }
     }
-    
+
     private func positiveDecimal(from value: String) -> Decimal? {
         guard let parsed = Decimal(string: value), parsed > 0 else { return nil }
         return parsed
     }
-    
+
     private func sanitizePositiveDecimalInput(_ value: String) -> String {
         let allowed = value.filter { "0123456789.".contains($0) }
         var result = ""
         var hasDot = false
-        
+
         for char in allowed {
             if char == "." {
                 if hasDot { continue }
@@ -648,14 +702,14 @@ struct AddTransferView: View {
             }
             result.append(char)
         }
-        
+
         return result == "." ? "" : result
     }
-    
+
     private func dismissKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
-    
+
     private func showValidation(_ message: String) {
         validationMessage = message
         showingValidationAlert = true

--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct EditTransactionView: View {
     @Environment(\.dismiss) private var dismiss
     @Bindable var transaction: FinancialTransaction
+    @StateObject private var currencyService = CurrencyService.shared
     
     @Query(sort: \Account.sortOrder) private var accounts: [Account]
     @Query(sort: \Category.name) private var categories: [Category]
@@ -14,6 +15,15 @@ struct EditTransactionView: View {
     
     // 🔥 新增：焦點控制
     @FocusState private var isAmountFocused: Bool
+
+    private var selectableAccounts: [Account] {
+        let allowed = TransactionSemantics.allowedAccounts(for: transaction.type, from: accounts)
+        guard let current = transaction.account else { return allowed }
+        if allowed.contains(where: { $0.id == current.id }) {
+            return allowed
+        }
+        return [current] + allowed
+    }
     
     var body: some View {
         NavigationStack {
@@ -35,6 +45,10 @@ struct EditTransactionView: View {
                             if let category = transaction.category, !category.kind.supports(newType) {
                                 transaction.category = nil
                             }
+                            if let currentAccount = transaction.account,
+                               !TransactionSemantics.allowedAccounts(for: newType, from: accounts).contains(where: { $0.id == currentAccount.id }) {
+                                transaction.account = TransactionSemantics.allowedAccounts(for: newType, from: accounts).first
+                            }
                         }
                     }
 
@@ -45,12 +59,17 @@ struct EditTransactionView: View {
                             .focused($isAmountFocused) // 🔥 綁定焦點
                             .onChange(of: amountString) { _, _ in updateTransactionAmount() }
                     }
+                    CurrencyRateHintView(
+                        currencyService: currencyService,
+                        amount: Decimal(string: amountString),
+                        currencyCode: transaction.currencyCode
+                    )
                 }
 
                 Section("詳細資訊") {
                     Picker("帳戶", selection: $transaction.account) {
                         Text("無").tag(nil as Account?)
-                        ForEach(accounts.filter { !$0.isArchived }) { acc in
+                        ForEach(selectableAccounts) { acc in
                             Text(acc.name).tag(acc as Account?)
                         }
                     }
@@ -114,6 +133,7 @@ struct EditTransactionView: View {
             .onAppear {
                 amountString = String(format: "%.2f", abs(NSDecimalNumber(decimal: transaction.amount).doubleValue))
                 selectedTags = Set(transaction.tags)
+                Task { await currencyService.fetchRates() }
             }
         }
     }

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct EditTransferView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var currencyService = CurrencyService.shared
 
     let originalTransaction: FinancialTransaction
 
@@ -111,6 +112,12 @@ struct EditTransferView: View {
                                 }
                             }
                             .padding(.vertical, 4)
+
+                            CurrencyRateHintView(
+                                currencyService: currencyService,
+                                amount: positiveDecimal(from: leg.amountString),
+                                currencyCode: leg.currency
+                            )
                         }
 
                         Button {
@@ -166,6 +173,12 @@ struct EditTransferView: View {
                                 }
                             }
                             .padding(.vertical, 4)
+
+                            CurrencyRateHintView(
+                                currencyService: currencyService,
+                                amount: positiveDecimal(from: leg.amountString),
+                                currencyCode: leg.currency
+                            )
                         }
 
                         Button {
@@ -185,6 +198,15 @@ struct EditTransferView: View {
                     Section("其他") {
                         DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
                         TextField("備註", text: $note)
+                        if outgoingLegs.count == 1, incomingLegs.count == 1 {
+                            TransferRateHintView(
+                                currencyService: currencyService,
+                                outgoingAmount: positiveDecimal(from: outgoingLegs[0].amountString),
+                                outgoingCurrency: outgoingLegs[0].currency,
+                                incomingAmount: positiveDecimal(from: incomingLegs[0].amountString),
+                                incomingCurrency: incomingLegs[0].currency
+                            )
+                        }
                     }
                 }
             }
@@ -207,7 +229,10 @@ struct EditTransferView: View {
                     Button("完成") { focusedFieldID = nil }
                 }
             }
-            .onAppear { loadData() }
+            .onAppear {
+                loadData()
+                Task { await currencyService.fetchRates() }
+            }
         }
     }
 

--- a/AI 記帳/Views/Transactions/ScannedResultView.swift
+++ b/AI 記帳/Views/Transactions/ScannedResultView.swift
@@ -4,18 +4,18 @@ import SwiftData
 struct ScannedResultView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss // dismiss 當前視圖
-    
+
     // 為了能夠直接關閉整個掃描流程回到主頁，我們可能需要回調
     // 這裡簡單處理：存檔後發送通知或使用 NavigationPath (如果你的 App 架構支援)
     // 這裡示範存檔後 dismiss 到根視圖的簡單做法：
-    
+
     let info: ReceiptInfo
     let receiptImage: UIImage
-    
+
     @Query private var accounts: [Account]
     @Query private var categories: [Category]
     @Query private var tags: [Tag]
-    
+
     // 表單狀態
     @State private var amountString: String = ""
     @State private var selectedAccount: Account?
@@ -23,7 +23,11 @@ struct ScannedResultView: View {
     @State private var date: Date = Date()
     @State private var note: String = ""
     @State private var selectedTags: Set<Tag> = []
-    
+
+    private var selectableAccounts: [Account] {
+        TransactionSemantics.ownAccounts(from: accounts)
+    }
+
     var body: some View {
         Form {
             Section("AI 識別結果 (請確認)") {
@@ -35,13 +39,13 @@ struct ScannedResultView: View {
                 DatePicker("日期時間", selection: $date, displayedComponents: [.date, .hourAndMinute])
                 TextField("商戶/備註", text: $note)
             }
-            
+
             Section("帳戶與分類") {
                 Picker("帳戶", selection: $selectedAccount) {
                     Text("選擇帳戶").tag(nil as Account?)
-                    ForEach(accounts) { acc in Text(acc.name).tag(acc as Account?) }
+                    ForEach(selectableAccounts) { acc in Text(acc.name).tag(acc as Account?) }
                 }
-                
+
                 Picker("分類", selection: $selectedCategory) {
                     Text("選擇分類").tag(nil as Category?)
                     ForEach(expenseCategories) { cat in
@@ -52,7 +56,7 @@ struct ScannedResultView: View {
                     }
                 }
             }
-            
+
             Section("圖片存檔") {
                 Image(uiImage: receiptImage)
                     .resizable()
@@ -74,27 +78,27 @@ struct ScannedResultView: View {
             // 填充 AI 資料
             amountString = "\(info.amount)"
             note = "\(info.merchant) - \(info.note)"
-            
+
             date = parseDateTime(info: info) ?? Date()
-            
+
             // 嘗試自動匹配分類
             if let match = matchCategory(named: info.categoryName) {
                 selectedCategory = match
             }
-            
+
             // 預設帳戶
-            if let first = accounts.first {
+            if let first = selectableAccounts.first {
                 selectedAccount = first
             }
         }
     }
-    
+
     private func saveTransaction() {
         guard let amount = Decimal(string: amountString),
               let account = selectedAccount else { return }
-        
+
         let txCurrency = normalizedCurrencyCode(info.currency, fallback: account.currency)
-        
+
         let tx = FinancialTransaction(
             amount: -abs(amount), // 預設為支出
             currencyCode: txCurrency,
@@ -106,17 +110,17 @@ struct ScannedResultView: View {
             tags: Array(selectedTags)
             // photoPath: 如果你有實作圖片儲存，這裡可以存檔名
         )
-        
+
         modelContext.insert(tx)
-        
+
         // 這裡需要連續 dismiss 兩次 (回到主頁)，或者使用 Binding 控制
         // 簡單做法：發送 Notification 讓 ContentView 關閉 Sheet
         NotificationCenter.default.post(name: NSNotification.Name("CloseAddFlow"), object: nil)
     }
-    
+
     private func normalizedCurrencyCode(_ raw: String, fallback: String) -> String {
         let value = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        
+
         switch value {
         case "HKD", "HK$", "H$":
             return "HKD"
@@ -139,7 +143,7 @@ struct ScannedResultView: View {
             return fallback.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
         }
     }
-    
+
     private var expenseCategories: [Category] {
         categories.filter { $0.kind.supports(.expense) }
     }

--- a/AI 記帳/Views/Transactions/TransactionRow.swift
+++ b/AI 記帳/Views/Transactions/TransactionRow.swift
@@ -8,6 +8,7 @@ struct TransactionRow: View {
     private enum AdvanceTransferKind {
         case created
         case repayment
+        case debtForgiveness
         case none
     }
     
@@ -30,6 +31,9 @@ struct TransactionRow: View {
         if compacted.contains("(還款至") || compacted.contains("(還款給") {
             return .repayment
         }
+        if TransactionSemantics.isDebtForgiveness(note: transaction.note) {
+            return .debtForgiveness
+        }
         return .none
     }
 
@@ -43,6 +47,8 @@ struct TransactionRow: View {
             return "person.2.fill"
         case .repayment:
             return "arrow.down.circle.fill"
+        case .debtForgiveness:
+            return "scissors.circle.fill"
         case .none:
             return "arrow.left.arrow.right"
         }
@@ -54,6 +60,8 @@ struct TransactionRow: View {
             return "代墊建立"
         case .repayment:
             return "代墊還款"
+        case .debtForgiveness:
+            return "免除債務"
         case .none:
             return "轉帳"
         }
@@ -65,6 +73,8 @@ struct TransactionRow: View {
             return .orange
         case .repayment:
             return .teal
+        case .debtForgiveness:
+            return .purple
         case .none:
             return .blue
         }
@@ -99,8 +109,12 @@ struct TransactionRow: View {
                 let mainText = transaction.note.isEmpty ?
                     (transaction.category?.name ?? (transaction.type == .transfer ? transferBadgeText : "未分類"))
                     : transaction.note
+
+                let displayText = advanceTransferKind == .debtForgiveness
+                    ? TransactionSemantics.debtForgivenessDisplayTitle(note: mainText)
+                    : mainText
                 
-                Text(mainText)
+                Text(displayText)
                     .font(.body).bold()
                     .lineLimit(1)
                 

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -146,6 +146,8 @@ struct TransactionsListView: View {
                 if tx.type == .transfer {
                     if isAdvanceTransfer(tx) {
                         EditAdvanceTransferView(originalTransaction: tx)
+                    } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+                        AddDebtView(existingForgivenessTransaction: tx)
                     } else {
                         EditTransferView(originalTransaction: tx)
                     }
@@ -260,7 +262,7 @@ struct TransactionsListView: View {
     var filteredTransactions: [FinancialTransaction] {
         let calendar = Calendar.current
         let timeFiltered = transactions.filter { tx in
-            if tx.type == .transfer && tx.amount > 0 { return false }
+            if tx.type == .transfer && tx.amount > 0 && !TransactionSemantics.isDebtForgiveness(note: tx.note) { return false }
             if tx.type == .transfer,
                tx.transferGroupID == nil,
                tx.linkedTransactionID == nil,
@@ -438,7 +440,7 @@ struct TransactionsListView: View {
     }
     
     private func isAssetAdjustment(note: String) -> Bool {
-        note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("[資產調整]")
+        note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix(TransactionSemantics.assetAdjustmentMarker)
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/currency/CurrencyService.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/currency/CurrencyService.kt
@@ -8,6 +8,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.duckdns.lhfser.aiaccounting.core.transactions.RateSourceState
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.net.HttpURLConnection
@@ -25,6 +26,11 @@ private data class ExchangeRateCache(
     val fetchedAt: Long
 )
 
+data class CurrencyPreview(
+    val amount: BigDecimal,
+    val source: RateSourceState
+)
+
 class CurrencyService(context: Context) {
     private val prefs = context.getSharedPreferences("currency_service", Context.MODE_PRIVATE)
     private val gson = Gson()
@@ -33,6 +39,11 @@ class CurrencyService(context: Context) {
     private val cacheTtlMs = 7L * 24L * 60L * 60L * 1000L
 
     var rates by mutableStateOf<Map<String, Double>>(emptyMap())
+        private set
+
+    private var staleRates by mutableStateOf<Map<String, Double>>(emptyMap())
+
+    var rateSourceState by mutableStateOf(RateSourceState.Unavailable)
         private set
 
     var mainCurrency: String
@@ -68,7 +79,11 @@ class CurrencyService(context: Context) {
 
         if (parsed != null && parsed.base.equals(requestedBase, ignoreCase = true)) {
             rates = parsed.rates
+            staleRates = parsed.rates
+            rateSourceState = RateSourceState.Live
             saveRatesToLocal(base = requestedBase, rates = parsed.rates)
+        } else {
+            loadRatesFromLocal(preferStale = true)
         }
     }
 
@@ -77,16 +92,26 @@ class CurrencyService(context: Context) {
         prefs.edit().putString(cacheKey, gson.toJson(cache)).apply()
     }
 
-    private fun loadRatesFromLocal() {
+    private fun loadRatesFromLocal(preferStale: Boolean = true) {
         val currentBase = mainCurrency.uppercase()
+        rates = emptyMap()
+        staleRates = emptyMap()
+        rateSourceState = RateSourceState.Unavailable
+
         val cached = prefs.getString(cacheKey, null)
         if (cached != null) {
             val type = object : TypeToken<ExchangeRateCache>() {}.type
             val payload = gson.fromJson<ExchangeRateCache>(cached, type)
             if (payload.base.equals(currentBase, ignoreCase = true)) {
                 val age = Instant.now().toEpochMilli() - payload.fetchedAt
+                staleRates = payload.rates
                 if (age <= cacheTtlMs) {
                     rates = payload.rates
+                    rateSourceState = RateSourceState.Cached
+                    return
+                }
+                if (preferStale && payload.rates.isNotEmpty()) {
+                    rateSourceState = RateSourceState.Cached
                     return
                 }
             }
@@ -95,13 +120,11 @@ class CurrencyService(context: Context) {
         if (prefs.contains(legacyCacheKey)) {
             prefs.edit().remove(legacyCacheKey).apply()
         }
-
-        rates = emptyMap()
     }
 
     fun convert(amount: BigDecimal, from: String): BigDecimal {
         if (from.equals(mainCurrency, ignoreCase = true)) return amount
-        val rate = rates[from.uppercase()] ?: return amount
+        val rate = resolvedRates[from.uppercase()] ?: return amount
         if (rate <= 0.0) return amount
         return amount.divide(rate.toBigDecimal(), 6, RoundingMode.HALF_UP)
     }
@@ -109,14 +132,14 @@ class CurrencyService(context: Context) {
     fun convert(amount: BigDecimal, from: String, to: String): BigDecimal {
         if (from.equals(to, ignoreCase = true)) return amount
         if (from.equals(mainCurrency, ignoreCase = true)) {
-            val targetRate = rates[to.uppercase()] ?: return amount
+            val targetRate = resolvedRates[to.uppercase()] ?: return amount
             if (targetRate <= 0.0) return amount
             return amount.multiply(targetRate.toBigDecimal()).setScale(6, RoundingMode.HALF_UP)
         }
         if (to.equals(mainCurrency, ignoreCase = true)) {
             return convert(amount, from)
         }
-        val targetRate = rates[to.uppercase()] ?: return amount
+        val targetRate = resolvedRates[to.uppercase()] ?: return amount
         if (targetRate <= 0.0) return amount
         val inMain = convert(amount, from)
         return inMain.multiply(targetRate.toBigDecimal()).setScale(6, RoundingMode.HALF_UP)
@@ -124,9 +147,30 @@ class CurrencyService(context: Context) {
 
     fun getMarketRate(from: String, to: String): Double? {
         if (from.equals(to, ignoreCase = true)) return 1.0
-        val rateFrom = rates[from.uppercase()] ?: return null
-        val rateTo = rates[to.uppercase()] ?: return null
+        val rateFrom = resolvedRates[from.uppercase()] ?: return null
+        val rateTo = resolvedRates[to.uppercase()] ?: return null
         if (rateFrom <= 0.0 || rateTo <= 0.0) return null
         return (1.0 / rateFrom) * rateTo
     }
+
+    fun previewInMainCurrency(amount: BigDecimal, from: String): CurrencyPreview? {
+        if (from.equals(mainCurrency, ignoreCase = true)) return null
+        val converted = convert(amount, from)
+        if (converted == amount && resolvedRates[from.uppercase()] == null) return null
+        return CurrencyPreview(converted, resolvedRateSourceState)
+    }
+
+    val resolvedRateSourceState: RateSourceState
+        get() = when {
+            rates.isNotEmpty() -> rateSourceState
+            staleRates.isNotEmpty() -> RateSourceState.Cached
+            else -> RateSourceState.Unavailable
+        }
+
+    private val resolvedRates: Map<String, Double>
+        get() = when {
+            rates.isNotEmpty() -> rates
+            staleRates.isNotEmpty() -> staleRates
+            else -> emptyMap()
+        }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/health/DataHealthChecker.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/health/DataHealthChecker.kt
@@ -8,6 +8,8 @@ import org.duckdns.lhfser.aiaccounting.data.db.AdvanceRepaymentEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.Locale
@@ -41,7 +43,8 @@ data class DataHealthSnapshot(
     val budgets: List<CategoryMonthlyBudgetEntity>,
     val advanceCases: List<AdvanceCaseWithDetails>,
     val advanceParticipants: List<AdvanceParticipantEntity>,
-    val advanceRepayments: List<AdvanceRepaymentEntity>
+    val advanceRepayments: List<AdvanceRepaymentEntity>,
+    val shortcuts: List<ShortcutWithDetails>
 )
 
 object DataHealthChecker {
@@ -49,6 +52,7 @@ object DataHealthChecker {
         val issues = mutableListOf<HealthIssue>()
 
         checkTransactionBasics(snapshot.transactions, now, issues)
+        checkLegacyDebtIncome(snapshot.transactions, snapshot.shortcuts, issues)
         checkLinkedTransfers(snapshot.transactions, issues)
         checkTransferGroups(snapshot.transactions, issues)
         checkCategories(snapshot.categories, snapshot.transactions, snapshot.budgets, snapshot.advanceCases, issues)
@@ -134,6 +138,32 @@ object DataHealthChecker {
                 title = "交易日期在未來",
                 detail = "共有 ${futureTransactions.size} 筆交易日期晚於現在 24 小時以上。",
                 recommendation = "請確認是否誤設日期。"
+            )
+        }
+    }
+
+    private fun checkLegacyDebtIncome(
+        transactions: List<TransactionWithDetails>,
+        shortcuts: List<ShortcutWithDetails>,
+        issues: MutableList<HealthIssue>
+    ) {
+        val legacyTransactions = transactions.filter { TransactionSemantics.isLegacyDebtIncome(it) }
+        if (legacyTransactions.isNotEmpty()) {
+            issues += HealthIssue(
+                severity = HealthSeverity.Warning,
+                title = "收入交易記到了借貸帳戶",
+                detail = "共有 ${legacyTransactions.size} 筆收入交易仍記在借貸帳戶，建議改為債務管理或免除債務。",
+                recommendation = "請逐筆檢查這些舊資料，避免收入與債務語義混在一起。"
+            )
+        }
+
+        val legacyShortcuts = shortcuts.filter { TransactionSemantics.isLegacyDebtIncome(it) }
+        if (legacyShortcuts.isNotEmpty()) {
+            issues += HealthIssue(
+                severity = HealthSeverity.Warning,
+                title = "收入捷徑綁到了借貸帳戶",
+                detail = "共有 ${legacyShortcuts.size} 個收入捷徑仍綁定借貸帳戶。",
+                recommendation = "建議改綁自己的帳戶，或改由債務管理入口處理。"
             )
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/transactions/TransactionSemantics.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/transactions/TransactionSemantics.kt
@@ -1,0 +1,88 @@
+package org.duckdns.lhfser.aiaccounting.core.transactions
+
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import java.math.BigDecimal
+
+enum class DebtForgivenessDirection(val label: String, val detail: String, val amountSign: BigDecimal) {
+    ForgivenByOthers(
+        label = "別人免除我欠的",
+        detail = "這會減少你對對方的負債，不計入收入。",
+        amountSign = BigDecimal.ONE
+    ),
+    ForgiveOthers(
+        label = "我免除別人欠我的",
+        detail = "這會減少對方欠你的金額，不計入收入。",
+        amountSign = BigDecimal.ONE.negate()
+    )
+}
+
+enum class RateSourceState(val label: String) {
+    Live("即時匯率"),
+    Cached("上次匯率"),
+    Unavailable("暫無匯率")
+}
+
+object TransactionSemantics {
+    const val DEBT_FORGIVENESS_MARKER = "[免除債務]"
+    const val ASSET_ADJUSTMENT_MARKER = "[資產調整]"
+
+    fun ownAccounts(accounts: List<AccountEntity>): List<AccountEntity> {
+        return accounts.filter { it.type != AccountType.Debt && !it.isArchived }
+    }
+
+    fun debtAccounts(accounts: List<AccountEntity>): List<AccountEntity> {
+        return accounts.filter { it.type == AccountType.Debt && !it.isArchived }
+    }
+
+    fun allowedAccounts(type: TransactionType, accounts: List<AccountEntity>): List<AccountEntity> {
+        return when (type) {
+            TransactionType.Income, TransactionType.Expense -> ownAccounts(accounts)
+            TransactionType.Transfer -> accounts.filter { !it.isArchived }
+        }
+    }
+
+    fun isDebtForgiveness(note: String): Boolean {
+        return note.trim().startsWith(DEBT_FORGIVENESS_MARKER)
+    }
+
+    fun debtForgivenessDirection(note: String): DebtForgivenessDirection? {
+        if (!isDebtForgiveness(note)) return null
+        return when {
+            note.contains("對方免除") -> DebtForgivenessDirection.ForgivenByOthers
+            note.contains("我方免除") -> DebtForgivenessDirection.ForgiveOthers
+            else -> null
+        }
+    }
+
+    fun debtForgivenessNote(baseNote: String, debtAccountName: String, direction: DebtForgivenessDirection): String {
+        val trimmed = baseNote.trim()
+        val suffix = when (direction) {
+            DebtForgivenessDirection.ForgivenByOthers -> "(對方免除：$debtAccountName)"
+            DebtForgivenessDirection.ForgiveOthers -> "(我方免除：$debtAccountName)"
+        }
+        return if (trimmed.isBlank()) {
+            "$DEBT_FORGIVENESS_MARKER $suffix"
+        } else {
+            "$DEBT_FORGIVENESS_MARKER $trimmed $suffix"
+        }
+    }
+
+    fun debtForgivenessDisplayTitle(note: String): String {
+        val trimmed = note.trim()
+        if (!isDebtForgiveness(trimmed)) return trimmed
+        val withoutMarker = trimmed.removePrefix(DEBT_FORGIVENESS_MARKER).trim()
+        return withoutMarker.ifBlank { "免除債務" }
+    }
+
+    fun isLegacyDebtIncome(transaction: TransactionWithDetails): Boolean {
+        return transaction.transaction.type == TransactionType.Income && transaction.account?.type == AccountType.Debt
+    }
+
+    fun isLegacyDebtIncome(shortcut: ShortcutWithDetails): Boolean {
+        return shortcut.shortcut.type == TransactionType.Income && shortcut.account?.type == AccountType.Debt
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
@@ -131,6 +131,10 @@ interface ShortcutDao {
     @Query("SELECT * FROM shortcuts")
     suspend fun getAll(): List<ShortcutEntity>
 
+    @Transaction
+    @Query("SELECT * FROM shortcuts ORDER BY name ASC")
+    suspend fun getAllWithDetails(): List<ShortcutWithDetails>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(shortcut: ShortcutEntity)
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -15,6 +15,7 @@ import org.duckdns.lhfser.aiaccounting.core.health.DataHealthReport
 import org.duckdns.lhfser.aiaccounting.core.health.DataHealthSnapshot
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceParticipantEntity
@@ -114,9 +115,84 @@ class AccountingRepository(
                 budgets = budgetDao.getAll(),
                 advanceCases = advanceDao.getAllCasesWithDetails(),
                 advanceParticipants = advanceDao.getAllParticipants(),
-                advanceRepayments = advanceDao.getAllRepayments()
+                advanceRepayments = advanceDao.getAllRepayments(),
+                shortcuts = shortcutDao.getAllWithDetails()
             )
         )
+    }
+
+    suspend fun legacyDebtIncomeTransactions(): List<TransactionWithDetails> {
+        return transactionDao.getAllWithDetails().filter(TransactionSemantics::isLegacyDebtIncome)
+    }
+
+    suspend fun legacyDebtIncomeShortcuts(): List<ShortcutWithDetails> {
+        return shortcutDao.getAllWithDetails().filter(TransactionSemantics::isLegacyDebtIncome)
+    }
+
+    suspend fun convertLegacyDebtIncomeTransaction(transactionId: UUID): Boolean {
+        return database.withTransaction {
+            val existing = transactionDao.getTransaction(transactionId) ?: return@withTransaction false
+            val account = existing.account ?: return@withTransaction false
+            if (!TransactionSemantics.isLegacyDebtIncome(existing)) {
+                return@withTransaction false
+            }
+
+            val direction = if (existing.transaction.amount >= BigDecimal.ZERO) {
+                org.duckdns.lhfser.aiaccounting.core.transactions.DebtForgivenessDirection.ForgivenByOthers
+            } else {
+                org.duckdns.lhfser.aiaccounting.core.transactions.DebtForgivenessDirection.ForgiveOthers
+            }
+
+            val updated = existing.transaction.copy(
+                amount = existing.transaction.amount.abs().multiply(direction.amountSign),
+                note = TransactionSemantics.debtForgivenessNote(
+                    baseNote = TransactionSemantics.debtForgivenessDisplayTitle(existing.transaction.note),
+                    debtAccountName = account.name,
+                    direction = direction
+                ),
+                type = TransactionType.Transfer,
+                linkedTransactionId = null,
+                transferGroupId = null,
+                transferSide = null,
+                updatedAt = Instant.now(),
+                accountId = account.id,
+                categoryId = null
+            )
+            transactionDao.upsert(updated)
+            transactionDao.clearTransactionTags(updated.id)
+            syncAllBudgetHistory()
+            true
+        }
+    }
+
+    suspend fun convertAllLegacyDebtIncomeTransactions(): Int {
+        var converted = 0
+        for (transaction in legacyDebtIncomeTransactions()) {
+            if (convertLegacyDebtIncomeTransaction(transaction.transaction.id)) {
+                converted += 1
+            }
+        }
+        return converted
+    }
+
+    suspend fun detachLegacyDebtIncomeShortcut(shortcutId: UUID): Boolean {
+        return database.withTransaction {
+            val shortcut = shortcutDao.getAllWithDetails().firstOrNull { it.shortcut.id == shortcutId } ?: return@withTransaction false
+            if (!TransactionSemantics.isLegacyDebtIncome(shortcut)) {
+                return@withTransaction false
+            }
+            shortcutDao.upsert(shortcut.shortcut.copy(accountId = null))
+            true
+        }
+    }
+
+    suspend fun detachAllLegacyDebtIncomeShortcuts(): Int {
+        val shortcuts = legacyDebtIncomeShortcuts()
+        if (shortcuts.isEmpty()) return 0
+        database.withTransaction {
+            shortcutDao.upsertAll(shortcuts.map { it.shortcut.copy(accountId = null) })
+        }
+        return shortcuts.size
     }
 
     suspend fun upsertAccount(account: AccountEntity) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -86,7 +86,8 @@ private sealed class AppDestination(
     data object Accounts : AppDestination("accounts", "帳戶", Icons.Default.AccountBalanceWallet)
     data object Settings : AppDestination("settings", "設定", Icons.Default.Settings)
 
-    data object TransactionAdd : AppDestination("transaction/add", "記一筆")
+    data object ExpenseAdd : AppDestination("transaction/add/expense", "新增支出")
+    data object IncomeAdd : AppDestination("transaction/add/income", "新增收入")
     data object TransactionEdit : AppDestination("transaction/edit/{transactionId}", "編輯記帳")
     data object TransferAdd : AppDestination("transfer/add", "轉帳")
     data object TransferEdit : AppDestination("transfer/edit/{groupId}", "編輯轉帳")
@@ -237,6 +238,7 @@ fun AIAccountingRoot(
                 TransactionsScreen(
                     onEdit = { id -> navController.navigate("transaction/edit/$id") },
                     onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") },
+                    onEditDebt = { id -> navController.navigate("debt/edit/$id") },
                     onOpenAdvanceCase = { caseId -> navController.navigate("advance/$caseId") },
                     onAddShortcut = { navController.navigate("shortcuts/edit/${UUID.randomUUID()}") }
                 )
@@ -259,8 +261,19 @@ fun AIAccountingRoot(
                 )
             }
 
-            composable(AppDestination.TransactionAdd.route) {
-                TransactionEditorScreen(onDone = { navController.popBackStack() })
+            composable(AppDestination.ExpenseAdd.route) {
+                TransactionEditorScreen(
+                    initialType = org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Expense,
+                    locksTransactionType = true,
+                    onDone = { navController.popBackStack() }
+                )
+            }
+            composable(AppDestination.IncomeAdd.route) {
+                TransactionEditorScreen(
+                    initialType = org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Income,
+                    locksTransactionType = true,
+                    onDone = { navController.popBackStack() }
+                )
             }
             composable(
                 AppDestination.TransactionEdit.route,
@@ -291,6 +304,15 @@ fun AIAccountingRoot(
             }
             composable(AppDestination.DebtAdd.route) {
                 DebtEntryScreen(onDone = { navController.popBackStack() })
+            }
+            composable(
+                "debt/edit/{transactionId}",
+                arguments = listOf(navArgument("transactionId") { type = NavType.StringType })
+            ) { entry ->
+                DebtEntryScreen(
+                    transactionId = entry.arguments?.getString("transactionId"),
+                    onDone = { navController.popBackStack() }
+                )
             }
             composable("advances") {
                 AdvancesScreen(onOpenCase = { caseId -> navController.navigate("advance/$caseId") })
@@ -344,7 +366,8 @@ fun AIAccountingRoot(
                     accountId = entry.arguments?.getString("accountId"),
                     onEditAccount = { id -> navController.navigate("accounts/edit/$id") },
                     onEditTransaction = { id -> navController.navigate("transaction/edit/$id") },
-                    onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") }
+                    onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") },
+                    onEditDebt = { id -> navController.navigate("debt/edit/$id") }
                 )
             }
             composable(
@@ -424,10 +447,15 @@ private fun AddActionSheet(
             Text("選擇現在想建立的記錄類型。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Spacer(modifier = Modifier.height(4.dp))
             ParityActionSheetRow(
-                title = "記一筆（收入/支出）",
-                subtitle = "快速新增收入或支出交易",
+                title = "支出",
+                subtitle = "只記錄自己的帳戶支出",
                 icon = Icons.Default.Description
-            ) { onAction(AppDestination.TransactionAdd.route) }
+            ) { onAction(AppDestination.ExpenseAdd.route) }
+            ParityActionSheetRow(
+                title = "收入",
+                subtitle = "只記錄自己的帳戶收入",
+                icon = Icons.Default.Description
+            ) { onAction(AppDestination.IncomeAdd.route) }
             ParityActionSheetRow(
                 title = "掃描收據（AI）",
                 subtitle = "上傳照片後由 AI 分析帳單內容",
@@ -439,8 +467,8 @@ private fun AddActionSheet(
                 icon = Icons.Default.SwapHoriz
             ) { onAction(AppDestination.TransferAdd.route) }
             ParityActionSheetRow(
-                title = "借貸（借入/還款）",
-                subtitle = "建立借貸或記錄還款流向",
+                title = "債務管理",
+                subtitle = "借入、還款或免除債務",
                 icon = Icons.Default.AccountBalanceWallet
             ) { onAction(AppDestination.DebtAdd.route) }
             ParityActionSheetRow(
@@ -457,10 +485,12 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
     val route = backStackEntry?.destination?.route ?: return "AI 記帳"
     return when {
         route.startsWith("transaction/edit") -> "編輯記帳"
-        route == AppDestination.TransactionAdd.route -> "記一筆"
+        route == AppDestination.ExpenseAdd.route -> "新增支出"
+        route == AppDestination.IncomeAdd.route -> "新增收入"
         route == AppDestination.TransferAdd.route -> "轉帳"
         route == AppDestination.ReceiptScan.route -> "掃描單據"
         route == AppDestination.DebtAdd.route -> "借貸管理"
+        route.startsWith("debt/edit") -> "編輯免除債務"
         route == AppDestination.AdvanceAdd.route -> "新增代墊"
         route.startsWith("advance/") -> "代墊明細"
         route == AppDestination.Categories.route -> "分類"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/RateHintComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/RateHintComponents.kt
@@ -1,0 +1,121 @@
+package org.duckdns.lhfser.aiaccounting.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.transactions.RateSourceState
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Composable
+fun CurrencyRateHint(
+    currencyService: CurrencyService,
+    amount: BigDecimal?,
+    currencyCode: String,
+    modifier: Modifier = Modifier
+) {
+    val preview = remember(amount, currencyCode, currencyService.mainCurrency, currencyService.rateSourceState, currencyService.rates) {
+        amount?.let { currencyService.previewInMainCurrency(it, currencyCode) }
+    }
+
+    when {
+        amount == null || amount <= BigDecimal.ZERO || currencyCode.equals(currencyService.mainCurrency, ignoreCase = true) -> Unit
+        preview != null -> {
+            Column(
+                modifier = modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                Text(
+                    text = "約 ${preview.amount.asCurrencyText(currencyService.mainCurrency)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = preview.source.label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+        else -> {
+            Text(
+                text = "暫時無法取得匯率",
+                modifier = modifier.fillMaxWidth(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}
+
+@Composable
+fun TransferRateHint(
+    currencyService: CurrencyService,
+    outgoingAmount: BigDecimal?,
+    outgoingCurrency: String,
+    incomingAmount: BigDecimal?,
+    incomingCurrency: String,
+    modifier: Modifier = Modifier
+) {
+    val canCompare = outgoingAmount != null && incomingAmount != null && outgoingAmount > BigDecimal.ZERO && incomingAmount > BigDecimal.ZERO
+    val impliedRate = remember(outgoingAmount, incomingAmount, outgoingCurrency, incomingCurrency) {
+        if (!canCompare || outgoingCurrency.equals(incomingCurrency, ignoreCase = true)) {
+            null
+        } else {
+            incomingAmount!!.divide(outgoingAmount, 6, RoundingMode.HALF_UP)
+        }
+    }
+    val marketRate = remember(outgoingCurrency, incomingCurrency, currencyService.rateSourceState, currencyService.rates) {
+        currencyService.getMarketRate(outgoingCurrency, incomingCurrency)
+    }
+
+    if (!canCompare || outgoingCurrency.equals(incomingCurrency, ignoreCase = true)) return
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        impliedRate?.let {
+            Text(
+                text = "輸入匯率 1 $outgoingCurrency = ${it.stripTrailingZeros().toPlainString()} $incomingCurrency",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium
+            )
+        }
+        marketRate?.let {
+            Text(
+                text = "參考匯率 1 $outgoingCurrency = ${BigDecimal.valueOf(it).setScale(4, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString()} $incomingCurrency（${currencyService.resolvedRateSourceState.label}）",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+            CurrencyRateHint(
+                currencyService = currencyService,
+                amount = outgoingAmount,
+                currencyCode = outgoingCurrency,
+                modifier = Modifier.weight(1f)
+            )
+            CurrencyRateHint(
+                currencyService = currencyService,
+                amount = incomingAmount,
+                currencyCode = incomingCurrency,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
@@ -43,7 +44,8 @@ fun AccountDetailScreen(
     accountId: String?,
     onEditAccount: (String) -> Unit,
     onEditTransaction: (String) -> Unit,
-    onEditTransfer: (String) -> Unit
+    onEditTransfer: (String) -> Unit,
+    onEditDebt: (String) -> Unit
 ) {
     val repository = LocalRepository.current
     val accounts by repository.accounts.collectAsState(initial = emptyList())
@@ -149,10 +151,10 @@ fun AccountDetailScreen(
                     item = item,
                     onClick = {
                         val groupId = item.transaction.transferGroupId?.toString()
-                        if (item.transaction.type == TransactionType.Transfer && groupId != null) {
-                            onEditTransfer(groupId)
-                        } else {
-                            onEditTransaction(item.transaction.id.toString())
+                        when {
+                            item.transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(item.transaction.note) -> onEditDebt(item.transaction.id.toString())
+                            item.transaction.type == TransactionType.Transfer && groupId != null -> onEditTransfer(groupId)
+                            else -> onEditTransaction(item.transaction.id.toString())
                         }
                     }
                 )
@@ -173,6 +175,12 @@ private fun AccountTransactionRow(
         else -> MaterialTheme.colorScheme.onSurface
     }
     val categoryText = item.category?.name ?: defaultTransactionTitle(transaction.type)
+    val isDebtForgiveness = transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(transaction.note)
+    val displayTitle = if (isDebtForgiveness) {
+        TransactionSemantics.debtForgivenessDisplayTitle(transaction.note)
+    } else {
+        transaction.note.ifBlank { categoryText }
+    }
     val metaText = listOfNotNull(categoryText, item.account?.name)
         .distinct()
         .joinToString(" · ")
@@ -199,11 +207,19 @@ private fun AccountTransactionRow(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    Text(
-                        text = transaction.note.ifBlank { categoryText },
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = displayTitle,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        if (isDebtForgiveness) {
+                            ParityStatusPill(text = "免除債務", tint = MaterialTheme.colorScheme.tertiary)
+                        }
+                    }
                     Text(
                         text = metaText,
                         style = MaterialTheme.typography.labelMedium,
@@ -226,7 +242,11 @@ private fun AccountTransactionRow(
                         fontWeight = FontWeight.SemiBold
                     )
                     Text(
-                        text = if (transaction.type == TransactionType.Transfer) "編輯轉帳" else "查看 / 編輯",
+                        text = when {
+                            isDebtForgiveness -> "編輯免除債務"
+                            transaction.type == TransactionType.Transfer -> "編輯轉帳"
+                            else -> "查看 / 編輯"
+                        },
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.primary
                     )

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,14 +28,17 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.TransferLeg
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyRateHint
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import org.duckdns.lhfser.aiaccounting.ui.components.TransferRateHint
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import java.math.BigDecimal
 import java.time.Instant
@@ -55,10 +59,15 @@ private data class AddTransferLegInput(
 @Composable
 fun AddTransferScreen(onDone: () -> Unit) {
     val repository = LocalRepository.current
+    val currencyService = LocalCurrencyService.current
     val scope = rememberCoroutineScope()
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val scrollState = rememberScrollState()
     val activeAccounts = accounts.filter { !it.isArchived }
+
+    LaunchedEffect(currencyService.mainCurrency) {
+        currencyService.fetchRates()
+    }
 
     var mode by remember { mutableStateOf(AddTransferMode.OneToOne) }
 
@@ -125,7 +134,8 @@ fun AddTransferScreen(onDone: () -> Unit) {
                             if (currencyOut == currencyIn) amountIn = amountOut
                         },
                         currency = currencyOut,
-                        onCurrencyChange = { currencyOut = it }
+                        onCurrencyChange = { currencyOut = it },
+                        currencyService = currencyService
                     )
                     AccountPicker(label = "轉入帳戶", accounts = activeAccounts, selected = toAccount) { acc ->
                         toAccount = acc
@@ -136,7 +146,15 @@ fun AddTransferScreen(onDone: () -> Unit) {
                         amount = amountIn,
                         onAmountChange = { amountIn = sanitizeAmount(it) },
                         currency = currencyIn,
-                        onCurrencyChange = { currencyIn = it }
+                        onCurrencyChange = { currencyIn = it },
+                        currencyService = currencyService
+                    )
+                    TransferRateHint(
+                        currencyService = currencyService,
+                        outgoingAmount = parsePositive(amountOut),
+                        outgoingCurrency = currencyOut,
+                        incomingAmount = parsePositive(amountIn),
+                        incomingCurrency = currencyIn
                     )
                 }
                 AddTransferMode.OneToMany -> {
@@ -149,13 +167,15 @@ fun AddTransferScreen(onDone: () -> Unit) {
                         amount = sourceAmount,
                         onAmountChange = { sourceAmount = sanitizeAmount(it) },
                         currency = sourceCurrency,
-                        onCurrencyChange = { sourceCurrency = it }
+                        onCurrencyChange = { sourceCurrency = it },
+                        currencyService = currencyService
                     )
                     destinationLegs.forEachIndexed { index, leg ->
                         TransferLegEditor(
                             title = "轉入帳戶 ${index + 1}",
                             leg = leg,
                             accounts = activeAccounts.filter { it.id != sourceAccount?.id },
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 destinationLegs = destinationLegs.toMutableList().also { it[index] = updated }
                             },
@@ -178,13 +198,15 @@ fun AddTransferScreen(onDone: () -> Unit) {
                         amount = destinationAmount,
                         onAmountChange = { destinationAmount = sanitizeAmount(it) },
                         currency = destinationCurrency,
-                        onCurrencyChange = { destinationCurrency = it }
+                        onCurrencyChange = { destinationCurrency = it },
+                        currencyService = currencyService
                     )
                     sourceLegs.forEachIndexed { index, leg ->
                         TransferLegEditor(
                             title = "轉出帳戶 ${index + 1}",
                             leg = leg,
                             accounts = activeAccounts.filter { it.id != destinationAccount?.id },
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 sourceLegs = sourceLegs.toMutableList().also { it[index] = updated }
                             },
@@ -317,7 +339,8 @@ private fun AmountRow(
     amount: String,
     onAmountChange: (String) -> Unit,
     currency: String,
-    onCurrencyChange: (String) -> Unit
+    onCurrencyChange: (String) -> Unit,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(label, style = MaterialTheme.typography.titleSmall)
@@ -330,6 +353,11 @@ private fun AmountRow(
                 modifier = Modifier.weight(1f)
             )
         }
+        CurrencyRateHint(
+            currencyService = currencyService,
+            amount = parsePositive(amount),
+            currencyCode = currency
+        )
     }
 }
 
@@ -347,6 +375,7 @@ private fun TransferLegEditor(
     title: String,
     leg: AddTransferLegInput,
     accounts: List<AccountEntity>,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     onUpdate: (AddTransferLegInput) -> Unit,
     onRemove: (() -> Unit)?
 ) {
@@ -363,7 +392,8 @@ private fun TransferLegEditor(
             amount = leg.amount,
             onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
             currency = leg.currency,
-            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) },
+            currencyService = currencyService
         )
         if (onRemove != null) {
             TextButton(onClick = onRemove) { Text("移除") }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DataHealthScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DataHealthScreen.kt
@@ -25,8 +25,11 @@ import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.health.DataHealthReport
 import org.duckdns.lhfser.aiaccounting.core.health.HealthIssue
 import org.duckdns.lhfser.aiaccounting.core.health.HealthSeverity
+import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 
 @Composable
 fun DataHealthScreen() {
@@ -35,7 +38,10 @@ fun DataHealthScreen() {
     val scrollState = rememberScrollState()
 
     var report by remember { mutableStateOf<DataHealthReport?>(null) }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var legacyTransactions by remember { mutableStateOf<List<TransactionWithDetails>>(emptyList()) }
+    var legacyShortcuts by remember { mutableStateOf<List<ShortcutWithDetails>>(emptyList()) }
+    var statusMessage by remember { mutableStateOf<String?>(null) }
+    var statusIsError by remember { mutableStateOf(false) }
     var isRunning by remember { mutableStateOf(false) }
 
     Column(
@@ -64,11 +70,15 @@ fun DataHealthScreen() {
                     onClick = {
                         scope.launch {
                             isRunning = true
-                            errorMessage = null
+                            statusMessage = null
+                            statusIsError = false
                             try {
                                 report = repository.buildDataHealthReport()
+                                legacyTransactions = repository.legacyDebtIncomeTransactions()
+                                legacyShortcuts = repository.legacyDebtIncomeShortcuts()
                             } catch (error: Exception) {
-                                errorMessage = error.message ?: "資料健康檢查失敗。"
+                                statusMessage = error.message ?: "資料健康檢查失敗。"
+                                statusIsError = true
                             } finally {
                                 isRunning = false
                             }
@@ -77,8 +87,139 @@ fun DataHealthScreen() {
                 ) {
                     Text(if (isRunning) "檢查中..." else "開始檢查")
                 }
-                errorMessage?.let {
-                    Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error)
+                statusMessage?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (statusIsError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+
+        if (legacyTransactions.isNotEmpty() || legacyShortcuts.isNotEmpty()) {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+                border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(AppSpacing.card),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text("收入 / 借貸清理", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "這裡會列出舊版把收入記到借貸帳戶的資料。你可以逐筆轉成免除債務，也可以批量整理。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    if (legacyTransactions.isNotEmpty()) {
+                        Button(
+                            onClick = {
+                                scope.launch {
+                                    isRunning = true
+                                    statusMessage = null
+                                    statusIsError = false
+                                    try {
+                                        val converted = repository.convertAllLegacyDebtIncomeTransactions()
+                                        report = repository.buildDataHealthReport()
+                                        legacyTransactions = repository.legacyDebtIncomeTransactions()
+                                        legacyShortcuts = repository.legacyDebtIncomeShortcuts()
+                                        statusMessage = "已把 $converted 筆舊版收入 / 借貸紀錄轉成免除債務。"
+                                    } catch (error: Exception) {
+                                        statusMessage = error.message ?: "批量轉換失敗。"
+                                        statusIsError = true
+                                    } finally {
+                                        isRunning = false
+                                    }
+                                }
+                            },
+                            enabled = !isRunning
+                        ) {
+                            Text(if (isRunning) "處理中..." else "全部轉成免除債務 (${legacyTransactions.size})")
+                        }
+
+                        legacyTransactions.forEach { transaction ->
+                            LegacyTransactionCard(
+                                transaction = transaction,
+                                isRunning = isRunning,
+                                onConvert = {
+                                    scope.launch {
+                                        isRunning = true
+                                        statusMessage = null
+                                        statusIsError = false
+                                        try {
+                                            repository.convertLegacyDebtIncomeTransaction(transaction.transaction.id)
+                                            report = repository.buildDataHealthReport()
+                                            legacyTransactions = repository.legacyDebtIncomeTransactions()
+                                            legacyShortcuts = repository.legacyDebtIncomeShortcuts()
+                                            statusMessage = "已把這筆資料轉成免除債務。"
+                                        } catch (error: Exception) {
+                                            statusMessage = error.message ?: "轉換失敗。"
+                                            statusIsError = true
+                                        } finally {
+                                            isRunning = false
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                    }
+
+                    if (legacyShortcuts.isNotEmpty()) {
+                        Button(
+                            onClick = {
+                                scope.launch {
+                                    isRunning = true
+                                    statusMessage = null
+                                    statusIsError = false
+                                    try {
+                                        val detached = repository.detachAllLegacyDebtIncomeShortcuts()
+                                        report = repository.buildDataHealthReport()
+                                        legacyTransactions = repository.legacyDebtIncomeTransactions()
+                                        legacyShortcuts = repository.legacyDebtIncomeShortcuts()
+                                        statusMessage = "已清除 $detached 個收入捷徑的借貸帳戶綁定。"
+                                    } catch (error: Exception) {
+                                        statusMessage = error.message ?: "批量清理失敗。"
+                                        statusIsError = true
+                                    } finally {
+                                        isRunning = false
+                                    }
+                                }
+                            },
+                            enabled = !isRunning
+                        ) {
+                            Text(if (isRunning) "處理中..." else "清除收入捷徑的借貸帳戶綁定 (${legacyShortcuts.size})")
+                        }
+
+                        legacyShortcuts.forEach { shortcut ->
+                            LegacyShortcutCard(
+                                shortcut = shortcut,
+                                isRunning = isRunning,
+                                onDetach = {
+                                    scope.launch {
+                                        isRunning = true
+                                        statusMessage = null
+                                        statusIsError = false
+                                        try {
+                                            repository.detachLegacyDebtIncomeShortcut(shortcut.shortcut.id)
+                                            report = repository.buildDataHealthReport()
+                                            legacyTransactions = repository.legacyDebtIncomeTransactions()
+                                            legacyShortcuts = repository.legacyDebtIncomeShortcuts()
+                                            statusMessage = "已移除這個收入捷徑的借貸帳戶綁定。"
+                                        } catch (error: Exception) {
+                                            statusMessage = error.message ?: "清理失敗。"
+                                            statusIsError = true
+                                        } finally {
+                                            isRunning = false
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -88,6 +229,77 @@ fun DataHealthScreen() {
             IssueSection("錯誤", HealthSeverity.Error, current)
             IssueSection("警告", HealthSeverity.Warning, current)
             IssueSection("資訊", HealthSeverity.Info, current)
+        }
+    }
+}
+
+@Composable
+private fun LegacyTransactionCard(
+    transaction: TransactionWithDetails,
+    isRunning: Boolean,
+    onConvert: () -> Unit
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.75f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text(transaction.account?.name ?: "未指定借貸帳戶", style = MaterialTheme.typography.titleSmall)
+            Text(
+                transaction.transaction.amount.abs().toPlainString() + " " + transaction.transaction.currencyCode,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                transaction.transaction.date.toDateText(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (transaction.transaction.note.isNotBlank()) {
+                Text(
+                    transaction.transaction.note,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Button(onClick = onConvert, enabled = !isRunning) {
+                Text("轉成免除債務")
+            }
+        }
+    }
+}
+
+@Composable
+private fun LegacyShortcutCard(
+    shortcut: ShortcutWithDetails,
+    isRunning: Boolean,
+    onDetach: () -> Unit
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.75f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text("${shortcut.shortcut.icon} ${shortcut.shortcut.name}", style = MaterialTheme.typography.titleSmall)
+            Text(
+                "目前綁定：${shortcut.account?.name ?: "未指定帳戶"}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                shortcut.shortcut.amount.toPlainString() + " " + shortcut.shortcut.currencyCode,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Button(onClick = onDetach, enabled = !isRunning) {
+                Text("移除借貸帳戶綁定")
+            }
         }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,14 +28,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-import org.duckdns.lhfser.aiaccounting.core.model.AccountType
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
+import org.duckdns.lhfser.aiaccounting.core.transactions.DebtForgivenessDirection
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyRateHint
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
@@ -53,7 +57,8 @@ import java.util.UUID
 
 private enum class DebtMode(val label: String) {
     Borrow("借入 (我欠人)"),
-    Repay("還款 (還給人)")
+    Repay("還款 (還給人)"),
+    Forgive("免除債務")
 }
 
 private enum class DebtEntryMode(val label: String) {
@@ -76,18 +81,23 @@ private data class DebtMergeLeg(
 )
 
 @Composable
-fun DebtEntryScreen(onDone: () -> Unit) {
+fun DebtEntryScreen(
+    transactionId: String? = null,
+    onDone: () -> Unit
+) {
     val repository = LocalRepository.current
+    val currencyService = LocalCurrencyService.current
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val scrollState = rememberScrollState()
 
     val accounts by repository.accounts.collectAsState(initial = emptyList())
-    val debtAccounts = remember(accounts) { accounts.filter { it.type == AccountType.Debt && !it.isArchived }.sortedBy { it.name } }
-    val myAccounts = remember(accounts) { accounts.filter { it.type != AccountType.Debt && !it.isArchived }.sortedBy { it.sortOrder } }
+    val debtAccounts = remember(accounts) { TransactionSemantics.debtAccounts(accounts).sortedBy { it.name } }
+    val myAccounts = remember(accounts) { TransactionSemantics.ownAccounts(accounts).sortedBy { it.sortOrder } }
 
     var mode by remember { mutableStateOf(DebtMode.Borrow) }
     var entryMode by remember { mutableStateOf(DebtEntryMode.Normal) }
+    var forgivenessDirection by remember { mutableStateOf(DebtForgivenessDirection.ForgivenByOthers) }
     var selectedDebtAccount by remember { mutableStateOf<AccountEntity?>(null) }
     var selectedMyAccount by remember { mutableStateOf<AccountEntity?>(null) }
     var selectedCurrency by remember { mutableStateOf("HKD") }
@@ -98,12 +108,47 @@ fun DebtEntryScreen(onDone: () -> Unit) {
     var mergeLegs by remember { mutableStateOf(listOf(DebtMergeLeg())) }
     var validationMessage by remember { mutableStateOf<String?>(null) }
 
-    if (selectedDebtAccount == null && debtAccounts.isNotEmpty()) {
-        selectedDebtAccount = debtAccounts.first()
+    LaunchedEffect(currencyService.mainCurrency) {
+        currencyService.fetchRates()
     }
-    if (selectedMyAccount == null && myAccounts.isNotEmpty()) {
-        selectedMyAccount = myAccounts.first()
-        selectedCurrency = selectedMyAccount?.currency ?: selectedCurrency
+
+    LaunchedEffect(debtAccounts, myAccounts) {
+        if (selectedDebtAccount == null || debtAccounts.none { it.id == selectedDebtAccount?.id }) {
+            selectedDebtAccount = debtAccounts.firstOrNull()
+        }
+        if (selectedMyAccount == null || myAccounts.none { it.id == selectedMyAccount?.id }) {
+            selectedMyAccount = myAccounts.firstOrNull()
+        }
+        if (mode == DebtMode.Forgive) {
+            selectedCurrency = selectedDebtAccount?.currency ?: selectedCurrency
+        } else {
+            selectedCurrency = selectedMyAccount?.currency ?: selectedCurrency
+        }
+    }
+
+    LaunchedEffect(mode, selectedDebtAccount, selectedMyAccount) {
+        if (mode == DebtMode.Forgive) {
+            entryMode = DebtEntryMode.Normal
+            selectedCurrency = selectedDebtAccount?.currency ?: selectedCurrency
+        } else {
+            selectedCurrency = selectedMyAccount?.currency ?: selectedCurrency
+        }
+    }
+
+    LaunchedEffect(transactionId, accounts) {
+        val id = transactionId?.let(UUID::fromString) ?: return@LaunchedEffect
+        val existing = repository.getTransaction(id)?.transaction ?: return@LaunchedEffect
+        if (existing.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(existing.note)) {
+            mode = DebtMode.Forgive
+            entryMode = DebtEntryMode.Normal
+            forgivenessDirection = TransactionSemantics.debtForgivenessDirection(existing.note)
+                ?: DebtForgivenessDirection.ForgivenByOthers
+            selectedDebtAccount = accounts.firstOrNull { it.id == existing.accountId }
+            selectedCurrency = existing.currencyCode
+            amountInput = existing.amount.abs().toPlainString()
+            note = extractForgivenessBaseNote(existing.note)
+            date = existing.date
+        }
     }
 
     Column(
@@ -119,14 +164,14 @@ fun DebtEntryScreen(onDone: () -> Unit) {
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         ParityTopSection(
-            title = "借貸管理",
-            subtitle = "和 iOS 一樣，借貸會落成一組或多組轉帳分錄，方便之後繼續編輯與對帳。"
+            title = if (transactionId == null) "債務管理" else "編輯債務紀錄",
+            subtitle = "借入、還款與免除債務分開處理，不會再混成一般收入。"
         )
 
         SectionCard {
             ParitySectionHeader(
-                title = "借貸方式",
-                detail = "先選操作，再決定一般 / 分拆 / 合併模式"
+                title = "債務方式",
+                detail = "先選操作，再決定是否需要分拆或合併。"
             )
             ParitySegmentedControl(
                 options = DebtMode.values().toList(),
@@ -134,32 +179,55 @@ fun DebtEntryScreen(onDone: () -> Unit) {
                 label = { it.label },
                 onSelect = { mode = it }
             )
-            ParitySegmentedControl(
-                options = DebtEntryMode.values().toList(),
-                selected = entryMode,
-                label = { it.label },
-                onSelect = { entryMode = it }
-            )
+            if (mode == DebtMode.Forgive) {
+                ParitySegmentedControl(
+                    options = DebtForgivenessDirection.values().toList(),
+                    selected = forgivenessDirection,
+                    label = { it.label },
+                    onSelect = { forgivenessDirection = it }
+                )
+                Text(
+                    forgivenessDirection.detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                ParitySegmentedControl(
+                    options = DebtEntryMode.values().toList(),
+                    selected = entryMode,
+                    label = { it.label },
+                    onSelect = { entryMode = it }
+                )
+            }
         }
 
         if (debtAccounts.isEmpty()) {
             ParityEmptyState(
                 title = "還沒有借貸對象",
-                message = "先到帳戶頁建立類型為借貸的帳戶，之後才能記錄借入與還款流程。"
+                message = "先到帳戶頁建立類型為借貸的帳戶，之後才能記錄借入、還款或免除債務。"
             )
         } else {
             SectionCard {
                 ParitySectionHeader(
-                    title = "帳戶與對象",
-                    detail = "選擇借貸對象與你的實際資金帳戶"
+                    title = "對象與帳戶",
+                    detail = if (mode == DebtMode.Forgive) "免除債務只需要指定借貸對象。" else "借貸會同時影響你的帳戶與借貸對象。"
                 )
                 AccountMenuPicker(
-                    label = if (mode == DebtMode.Borrow) "跟誰借" else "還給誰",
+                    label = when (mode) {
+                        DebtMode.Borrow -> "跟誰借"
+                        DebtMode.Repay -> "還給誰"
+                        DebtMode.Forgive -> "借貸對象"
+                    },
                     options = debtAccounts,
                     selected = selectedDebtAccount,
-                    onSelect = { selectedDebtAccount = it }
+                    onSelect = {
+                        selectedDebtAccount = it
+                        if (mode == DebtMode.Forgive && it != null) {
+                            selectedCurrency = it.currency
+                        }
+                    }
                 )
-                if (entryMode != DebtEntryMode.Split) {
+                if (mode != DebtMode.Forgive && entryMode != DebtEntryMode.Split) {
                     AccountMenuPicker(
                         label = if (mode == DebtMode.Borrow) "存入帳戶" else "付款帳戶",
                         options = myAccounts,
@@ -178,23 +246,34 @@ fun DebtEntryScreen(onDone: () -> Unit) {
         SectionCard {
             ParitySectionHeader(
                 title = "金額與時間",
-                detail = "這裡的資料會直接影響之後產生的轉帳分錄"
+                detail = if (mode == DebtMode.Forgive) "免除債務只會調整借貸帳戶餘額，不會記成收入。" else "這裡的輸入會生成對應的借貸轉帳分錄。"
             )
-            when (entryMode) {
-                DebtEntryMode.Normal -> {
+            when {
+                mode == DebtMode.Forgive -> {
                     AmountCurrencyRow(
                         amount = amountInput,
                         onAmountChange = { amountInput = sanitizeAmount(it) },
                         currency = selectedCurrency,
-                        onCurrencyChange = { selectedCurrency = it }
+                        onCurrencyChange = { selectedCurrency = it },
+                        currencyService = currencyService
                     )
                 }
-                DebtEntryMode.Split -> {
+                entryMode == DebtEntryMode.Normal -> {
+                    AmountCurrencyRow(
+                        amount = amountInput,
+                        onAmountChange = { amountInput = sanitizeAmount(it) },
+                        currency = selectedCurrency,
+                        onCurrencyChange = { selectedCurrency = it },
+                        currencyService = currencyService
+                    )
+                }
+                entryMode == DebtEntryMode.Split -> {
                     splitLegs.forEachIndexed { index, leg ->
                         DebtSplitLegEditor(
                             index = index,
                             leg = leg,
                             accounts = myAccounts,
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 splitLegs = splitLegs.toMutableList().also { it[index] = updated }
                             },
@@ -207,11 +286,12 @@ fun DebtEntryScreen(onDone: () -> Unit) {
                         Text("新增分拆帳戶")
                     }
                 }
-                DebtEntryMode.Merge -> {
+                entryMode == DebtEntryMode.Merge -> {
                     mergeLegs.forEachIndexed { index, leg ->
                         DebtMergeLegEditor(
                             index = index,
                             leg = leg,
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 mergeLegs = mergeLegs.toMutableList().also { it[index] = updated }
                             },
@@ -253,10 +333,11 @@ fun DebtEntryScreen(onDone: () -> Unit) {
 
         ParitySummaryCard(
             title = "交易預覽",
-            value = totalAmountPreview(entryMode, amountInput, splitLegs, mergeLegs),
+            value = totalAmountPreview(mode, entryMode, amountInput, splitLegs, mergeLegs),
             supporting = when (mode) {
                 DebtMode.Borrow -> "借入會讓借貸帳戶出帳、你的帳戶入帳"
                 DebtMode.Repay -> "還款會讓你的帳戶出帳、借貸帳戶入帳"
+                DebtMode.Forgive -> forgivenessDirection.label
             }
         )
 
@@ -271,25 +352,52 @@ fun DebtEntryScreen(onDone: () -> Unit) {
                     validationMessage = "請先選擇借貸對象。"
                     return@Button
                 }
-                val transactions = buildDebtTransactions(
-                    mode = mode,
-                    entryMode = entryMode,
-                    debtAccount = debtAccount,
-                    myAccount = selectedMyAccount,
-                    date = date,
-                    note = note,
-                    currency = selectedCurrency,
-                    amountInput = amountInput,
-                    splitLegs = splitLegs,
-                    mergeLegs = mergeLegs
-                )
-                if (transactions == null) {
-                    validationMessage = "請輸入完整金額並選擇需要的帳戶。"
-                    return@Button
-                }
                 scope.launch {
-                    repository.upsertTransactions(transactions)
-                    onDone()
+                    if (mode == DebtMode.Forgive) {
+                        val amount = amountInput.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO }
+                        if (amount == null) {
+                            validationMessage = "請輸入有效金額。"
+                            return@launch
+                        }
+                        val id = transactionId?.let(UUID::fromString) ?: UUID.randomUUID()
+                        val transaction = TransactionEntity(
+                            id = id,
+                            amount = amount.multiply(forgivenessDirection.amountSign),
+                            currencyCode = selectedCurrency,
+                            date = date,
+                            note = TransactionSemantics.debtForgivenessNote(note, debtAccount.name, forgivenessDirection),
+                            photoPath = null,
+                            type = TransactionType.Transfer,
+                            linkedTransactionId = null,
+                            transferGroupId = null,
+                            transferSide = null,
+                            createdAt = Instant.now(),
+                            updatedAt = Instant.now(),
+                            accountId = debtAccount.id,
+                            categoryId = null
+                        )
+                        repository.upsertTransaction(transaction, emptyList())
+                        onDone()
+                    } else {
+                        val transactions = buildDebtTransactions(
+                            mode = mode,
+                            entryMode = entryMode,
+                            debtAccount = debtAccount,
+                            myAccount = selectedMyAccount,
+                            date = date,
+                            note = note,
+                            currency = selectedCurrency,
+                            amountInput = amountInput,
+                            splitLegs = splitLegs,
+                            mergeLegs = mergeLegs
+                        )
+                        if (transactions == null) {
+                            validationMessage = "請輸入完整金額並選擇需要的帳戶。"
+                            return@launch
+                        }
+                        repository.upsertTransactions(transactions)
+                        onDone()
+                    }
                 }
             },
             modifier = Modifier
@@ -297,9 +405,9 @@ fun DebtEntryScreen(onDone: () -> Unit) {
                 .height(50.dp),
             shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
             colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-            enabled = debtAccounts.isNotEmpty() && myAccounts.isNotEmpty()
+            enabled = debtAccounts.isNotEmpty() && (mode == DebtMode.Forgive || myAccounts.isNotEmpty())
         ) {
-            Text("確認")
+            Text(if (transactionId == null) "確認" else "儲存")
         }
     }
 }
@@ -316,6 +424,7 @@ private fun AccountMenuPicker(
         ParityMenuField(
             label = label,
             value = selected?.name.orEmpty(),
+            placeholder = "選擇帳戶",
             onClick = { expanded = true }
         )
         androidx.compose.material3.DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
@@ -337,18 +446,26 @@ private fun AmountCurrencyRow(
     amount: String,
     onAmountChange: (String) -> Unit,
     currency: String,
-    onCurrencyChange: (String) -> Unit
+    onCurrencyChange: (String) -> Unit,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.weight(1f)) {
-            OutlinedTextField(
-                value = amount,
-                onValueChange = onAmountChange,
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text("金額") }
-            )
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f)) {
+                OutlinedTextField(
+                    value = amount,
+                    onValueChange = onAmountChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("金額") }
+                )
+            }
+            CurrencyPicker(selected = currency, onSelect = onCurrencyChange, buttonStyle = CurrencyButtonStyle.Text)
         }
-        CurrencyPicker(selected = currency, onSelect = onCurrencyChange, buttonStyle = CurrencyButtonStyle.Text)
+        CurrencyRateHint(
+            currencyService = currencyService,
+            amount = amount.toBigDecimalOrNull(),
+            currencyCode = currency
+        )
     }
 }
 
@@ -357,6 +474,7 @@ private fun DebtSplitLegEditor(
     index: Int,
     leg: DebtSplitLeg,
     accounts: List<AccountEntity>,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     onUpdate: (DebtSplitLeg) -> Unit,
     onRemove: (() -> Unit)?
 ) {
@@ -373,7 +491,8 @@ private fun DebtSplitLegEditor(
             amount = leg.amount,
             onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
             currency = leg.currency,
-            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) },
+            currencyService = currencyService
         )
         if (onRemove != null) {
             TextButton(onClick = onRemove) { Text("移除此帳戶") }
@@ -385,6 +504,7 @@ private fun DebtSplitLegEditor(
 private fun DebtMergeLegEditor(
     index: Int,
     leg: DebtMergeLeg,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     onUpdate: (DebtMergeLeg) -> Unit,
     onRemove: (() -> Unit)?
 ) {
@@ -394,7 +514,8 @@ private fun DebtMergeLegEditor(
             amount = leg.amount,
             onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
             currency = leg.currency,
-            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) },
+            currencyService = currencyService
         )
         if (onRemove != null) {
             TextButton(onClick = onRemove) { Text("移除此金額項") }
@@ -530,15 +651,17 @@ private fun createDebtPair(
 }
 
 private fun totalAmountPreview(
+    mode: DebtMode,
     entryMode: DebtEntryMode,
     amountInput: String,
     splitLegs: List<DebtSplitLeg>,
     mergeLegs: List<DebtMergeLeg>
 ): String {
-    val total = when (entryMode) {
-        DebtEntryMode.Normal -> amountInput.toBigDecimalOrNull()
-        DebtEntryMode.Split -> splitLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == splitLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
-        DebtEntryMode.Merge -> mergeLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == mergeLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
+    val total = when {
+        mode == DebtMode.Forgive -> amountInput.toBigDecimalOrNull()
+        entryMode == DebtEntryMode.Normal -> amountInput.toBigDecimalOrNull()
+        entryMode == DebtEntryMode.Split -> splitLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == splitLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
+        else -> mergeLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == mergeLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
     }
     return total?.toPlainString() ?: "尚未完成輸入"
 }
@@ -566,4 +689,11 @@ private fun indexedMemo(base: String, mode: DebtEntryMode, index: Int, count: In
     }
     val trimmed = base.trim()
     return listOf(trimmed, suffix).filter { it.isNotBlank() }.joinToString(" ")
+}
+
+private fun extractForgivenessBaseNote(note: String): String {
+    return TransactionSemantics.debtForgivenessDisplayTitle(note)
+        .replace(Regex("\\(對方免除：.*\\)$"), "")
+        .replace(Regex("\\(我方免除：.*\\)$"), "")
+        .trim()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
@@ -46,10 +46,13 @@ import org.duckdns.lhfser.aiaccounting.core.ai.GeminiSettingsStore
 import org.duckdns.lhfser.aiaccounting.core.ai.ReceiptInfo
 import org.duckdns.lhfser.aiaccounting.core.ai.ReceiptScanService
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyRateHint
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
@@ -74,11 +77,12 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
     val repository = LocalRepository.current
     val scope = rememberCoroutineScope()
     val service = remember(context) { ReceiptScanService(GeminiSettingsStore(context)) }
+    val currencyService = LocalCurrencyService.current
     val scrollState = rememberScrollState()
 
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val categories by repository.categories.collectAsState(initial = emptyList())
-    val activeAccounts = remember(accounts) { accounts.filter { !it.isArchived } }
+    val activeAccounts = remember(accounts) { TransactionSemantics.ownAccounts(accounts) }
     val expenseCategories = remember(categories) { categories.filter { it.kind.supports(TransactionType.Expense) } }
 
     var imageBytes by remember { mutableStateOf<ByteArray?>(null) }
@@ -105,9 +109,13 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
     }
 
     LaunchedEffect(activeAccounts) {
-        if (selectedAccount == null) {
+        if (selectedAccount == null || activeAccounts.none { it.id == selectedAccount?.id }) {
             selectedAccount = activeAccounts.firstOrNull()
         }
+    }
+
+    LaunchedEffect(currencyService.mainCurrency) {
+        currencyService.fetchRates()
     }
 
     Column(
@@ -251,6 +259,11 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                     shape = RoundedCornerShape(18.dp)
                 )
                 CurrencyPicker(selected = currencyCode, onSelect = { currencyCode = it }, buttonStyle = CurrencyButtonStyle.Text)
+                CurrencyRateHint(
+                    currencyService = currencyService,
+                    amount = amountInput.toBigDecimalOrNull(),
+                    currencyCode = currencyCode
+                )
                 OutlinedTextField(
                     value = dateInput,
                     onValueChange = { dateInput = it },
@@ -277,7 +290,12 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                     options = activeAccounts,
                     selected = selectedAccount,
                     optionLabel = { it.name },
-                    onSelect = { selectedAccount = it }
+                    onSelect = {
+                        selectedAccount = it
+                        if (it != null && amountInput.isBlank()) {
+                            currencyCode = it.currency
+                        }
+                    }
                 )
                 EntityPicker(
                     label = "分類",

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ShortcutEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ShortcutEditorScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutEntity
@@ -48,14 +49,13 @@ fun ShortcutEditorScreen(shortcutId: String?, onDone: () -> Unit) {
     val tags by repository.tags.collectAsState(initial = emptyList())
     val scrollState = rememberScrollState()
 
-    val availableAccounts = accounts.filter { !it.isArchived }
-
     var name by remember { mutableStateOf("") }
     var icon by remember { mutableStateOf("⚡") }
     var amount by remember { mutableStateOf("") }
     var currency by remember { mutableStateOf("HKD") }
     var type by remember { mutableStateOf(TransactionType.Expense) }
     var note by remember { mutableStateOf("") }
+    val availableAccounts = TransactionSemantics.allowedAccounts(type, accounts)
     var selectedAccount by remember { mutableStateOf<AccountEntity?>(null) }
     var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
     var selectedTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
@@ -83,9 +83,13 @@ fun ShortcutEditorScreen(shortcutId: String?, onDone: () -> Unit) {
         }
     }
 
-    LaunchedEffect(type, filteredCategories) {
+    LaunchedEffect(type, filteredCategories, availableAccounts) {
         if (selectedCategory != null && filteredCategories.none { it.id == selectedCategory?.id }) {
             selectedCategory = null
+        }
+        if (selectedAccount != null && availableAccounts.none { it.id == selectedAccount?.id }) {
+            selectedAccount = availableAccounts.firstOrNull()
+            selectedAccount?.let { currency = it.currency }
         }
     }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
@@ -41,7 +41,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyRateHint
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
@@ -79,14 +82,17 @@ private data class MergeLeg(
 @Composable
 fun TransactionEditorScreen(
     transactionId: String? = null,
+    initialType: TransactionType = TransactionType.Expense,
+    locksTransactionType: Boolean = false,
     onDone: () -> Unit
 ) {
     val repository = LocalRepository.current
+    val currencyService = LocalCurrencyService.current
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
     var entryMode by remember { mutableStateOf(EntryMode.Normal) }
-    var transactionType by remember { mutableStateOf(TransactionType.Expense) }
+    var transactionType by remember { mutableStateOf(initialType) }
     var amountInput by remember { mutableStateOf("") }
     var note by remember { mutableStateOf("") }
     var selectedAccount by remember { mutableStateOf<AccountEntity?>(null) }
@@ -112,7 +118,11 @@ fun TransactionEditorScreen(
         selectedAccount?.id?.let(::add)
         splitLegs.mapNotNullTo(this) { it.account?.id }
     }
-    val selectableAccounts = accounts.filter { !it.isArchived || it.id in selectableAccountIds }
+    val selectableAccounts = remember(accounts, selectableAccountIds, transactionType) {
+        val allowed = TransactionSemantics.allowedAccounts(transactionType, accounts)
+        val preserved = accounts.filter { it.id in selectableAccountIds }
+        (allowed + preserved).distinctBy { it.id }
+    }
 
     LaunchedEffect(transactionId, accounts, categories, tags) {
         if (transactionId == null) return@LaunchedEffect
@@ -132,13 +142,30 @@ fun TransactionEditorScreen(
 
     val filteredCategories = categories.filter { it.kind.supports(transactionType) }
 
-    LaunchedEffect(transactionType, filteredCategories) {
+    LaunchedEffect(transactionType, filteredCategories, selectableAccounts) {
         if (selectedCategory != null && filteredCategories.none { it.id == selectedCategory?.id }) {
             selectedCategory = null
         }
         if (!newCategoryKind.supports(transactionType)) {
             newCategoryKind = defaultCategoryKindFor(transactionType)
         }
+        if (selectedAccount != null && selectableAccounts.none { it.id == selectedAccount?.id }) {
+            selectedAccount = selectableAccounts.firstOrNull()
+            selectedAccount?.let { selectedCurrency = it.currency }
+        }
+        if (entryMode == EntryMode.Split) {
+            splitLegs = splitLegs.map { leg ->
+                if (leg.account != null && selectableAccounts.none { it.id == leg.account?.id }) {
+                    leg.copy(account = null)
+                } else {
+                    leg
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(currencyService.mainCurrency) {
+        currencyService.fetchRates()
     }
 
     Column(
@@ -159,7 +186,15 @@ fun TransactionEditorScreen(
         )
         SectionCard {
             ModePicker(entryMode = entryMode, onModeChange = { entryMode = it })
-            TypePicker(type = transactionType, onChange = { transactionType = it })
+            if (locksTransactionType) {
+                Text(
+                    text = if (transactionType == TransactionType.Expense) "支出" else "收入",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
+                )
+            } else {
+                TypePicker(type = transactionType, onChange = { transactionType = it })
+            }
         }
 
         ParitySectionHeader(
@@ -174,7 +209,8 @@ fun TransactionEditorScreen(
                         amount = amountInput,
                         onAmountChange = { amountInput = sanitizeAmount(it) },
                         currency = selectedCurrency,
-                        onCurrencyChange = { selectedCurrency = it }
+                        onCurrencyChange = { selectedCurrency = it },
+                        currencyService = currencyService
                     )
                     AccountPicker(
                         label = "帳戶",
@@ -194,6 +230,7 @@ fun TransactionEditorScreen(
                             index = index,
                             leg = leg,
                             accounts = selectableAccounts,
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 splitLegs = splitLegs.toMutableList().also { it[index] = updated }
                             },
@@ -213,6 +250,7 @@ fun TransactionEditorScreen(
                         MergeLegEditor(
                             index = index,
                             leg = leg,
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 mergeLegs = mergeLegs.toMutableList().also { it[index] = updated }
                             },
@@ -449,7 +487,8 @@ private fun AmountRow(
     amount: String,
     onAmountChange: (String) -> Unit,
     currency: String,
-    onCurrencyChange: (String) -> Unit
+    onCurrencyChange: (String) -> Unit,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(label, style = MaterialTheme.typography.titleSmall)
@@ -462,6 +501,11 @@ private fun AmountRow(
                 modifier = Modifier.weight(1f)
             )
         }
+        CurrencyRateHint(
+            currencyService = currencyService,
+            amount = parsePositive(amount),
+            currencyCode = currency
+        )
     }
 }
 
@@ -571,6 +615,7 @@ private fun SplitLegEditor(
     index: Int,
     leg: SplitLeg,
     accounts: List<AccountEntity>,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     onUpdate: (SplitLeg) -> Unit,
     onRemove: (() -> Unit)?
 ) {
@@ -592,7 +637,8 @@ private fun SplitLegEditor(
             amount = leg.amount,
             onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
             currency = leg.currency,
-            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) },
+            currencyService = currencyService
         )
         if (onRemove != null) {
             TextButton(onClick = onRemove) { Text("移除") }
@@ -604,6 +650,7 @@ private fun SplitLegEditor(
 private fun MergeLegEditor(
     index: Int,
     leg: MergeLeg,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     onUpdate: (MergeLeg) -> Unit,
     onRemove: (() -> Unit)?
 ) {
@@ -617,7 +664,8 @@ private fun MergeLegEditor(
             amount = leg.amount,
             onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
             currency = leg.currency,
-            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) },
+            currencyService = currencyService
         )
         if (onRemove != null) {
             TextButton(onClick = onRemove) { Text("移除") }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -55,6 +55,7 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
@@ -98,6 +99,7 @@ private data class DailySection(val date: LocalDate, val items: List<LedgerItem>
 fun TransactionsScreen(
     onEdit: (String) -> Unit,
     onEditTransfer: (String) -> Unit,
+    onEditDebt: (String) -> Unit,
     onOpenAdvanceCase: (String) -> Unit,
     onAddShortcut: () -> Unit
 ) {
@@ -237,14 +239,15 @@ fun TransactionsScreen(
                         when (item) {
                             is LedgerItem.TransactionEntry -> {
                                 val groupId = item.item.transaction.transferGroupId?.toString()
+                                val isDebtForgiveness = TransactionSemantics.isDebtForgiveness(item.item.transaction.note)
                                 val isTransfer = item.item.transaction.type == TransactionType.Transfer && groupId != null
                                 TransactionRow(
                                     item = item.item,
                                     onClick = {
-                                        if (isTransfer) {
-                                            onEditTransfer(groupId!!)
-                                        } else {
-                                            onEdit(item.item.transaction.id.toString())
+                                        when {
+                                            isDebtForgiveness -> onEditDebt(item.item.transaction.id.toString())
+                                            isTransfer -> onEditTransfer(groupId!!)
+                                            else -> onEdit(item.item.transaction.id.toString())
                                         }
                                     },
                                     onLongClick = {
@@ -539,6 +542,12 @@ private fun TransactionRow(
     }
     val amountText = item.transaction.amount.asCurrencyText(item.transaction.currencyCode)
     val categoryText = item.category?.name ?: "未分類"
+    val isDebtForgiveness = item.transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(item.transaction.note)
+    val displayTitle = if (isDebtForgiveness) {
+        TransactionSemantics.debtForgivenessDisplayTitle(item.transaction.note)
+    } else {
+        item.transaction.note.ifBlank { categoryText }
+    }
     val accountText = item.account?.name ?: "未指定帳戶"
     val metaText = listOfNotNull(
         categoryText.takeIf { it.isNotBlank() },
@@ -556,11 +565,22 @@ private fun TransactionRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    item.transaction.note.ifBlank { categoryText },
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        displayTitle,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    if (isDebtForgiveness) {
+                        ParityStatusPill(
+                            text = "免除債務",
+                            tint = Color(0xFF8E24AA)
+                        )
+                    }
+                }
                 Text(
                     metaText,
                     style = MaterialTheme.typography.labelMedium,
@@ -583,7 +603,7 @@ private fun TransactionRow(
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    "${transactionTypeLabel(item.transaction.type)} · ${item.transaction.currencyCode}",
+                    "${transactionTypeLabel(item)} · ${item.transaction.currencyCode}",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -785,6 +805,7 @@ private fun ShortcutTile(
 private fun transferTintForNote(note: String): Color {
     val compact = note.replace(" ", "")
     return when {
+        TransactionSemantics.isDebtForgiveness(note) -> Color(0xFF8E24AA)
         compact.contains("(代墊給") || compact.contains("(代墊給我") -> Color(0xFFEF6C00)
         compact.contains("(還款至") || compact.contains("(還款給") -> Color(0xFF00897B)
         else -> MaterialTheme.colorScheme.onSurface
@@ -916,8 +937,9 @@ private fun formatHeaderDate(date: LocalDate): String {
     }
 }
 
-private fun transactionTypeLabel(type: TransactionType): String = when (type) {
-    TransactionType.Income -> "收入"
-    TransactionType.Expense -> "支出"
-    TransactionType.Transfer -> "轉帳"
+private fun transactionTypeLabel(item: TransactionWithDetails): String = when {
+    item.transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(item.transaction.note) -> "免除債務"
+    item.transaction.type == TransactionType.Income -> "收入"
+    item.transaction.type == TransactionType.Expense -> "支出"
+    else -> "轉帳"
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -33,10 +32,16 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.data.repository.TransferLeg
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyRateHint
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import org.duckdns.lhfser.aiaccounting.ui.components.TransferRateHint
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import java.math.BigDecimal
@@ -61,6 +66,7 @@ private data class TransferEditLegInput(
 @Composable
 fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
     val repository = LocalRepository.current
+    val currencyService = LocalCurrencyService.current
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val accounts by repository.accounts.collectAsState(initial = emptyList())
@@ -97,6 +103,10 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
         sourceLegs.mapNotNullTo(this) { it.account?.id }
     }
     val selectableAccounts = accounts.filter { !it.isArchived || it.id in selectableAccountIds }
+
+    LaunchedEffect(currencyService.mainCurrency) {
+        currencyService.fetchRates()
+    }
 
     LaunchedEffect(groupId, accounts) {
         val id = groupId?.let(UUID::fromString) ?: return@LaunchedEffect
@@ -158,21 +168,24 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Text("轉帳模式", style = MaterialTheme.typography.titleMedium)
         SectionCard {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                TransferEditMode.values().forEach { item ->
-                    FilterChip(
-                        selected = mode == item,
-                        onClick = { mode = item },
-                        label = { Text(item.label) }
-                    )
-                }
-            }
+            ParitySectionHeader(
+                title = "轉帳模式",
+                detail = "一般、分拆與合併都可以直接在這裡重新調整。"
+            )
+            ParitySegmentedControl(
+                options = TransferEditMode.values().toList(),
+                selected = mode,
+                label = { it.label },
+                onSelect = { mode = it }
+            )
         }
 
-        Text("轉帳內容", style = MaterialTheme.typography.titleMedium)
         SectionCard {
+            ParitySectionHeader(
+                title = "轉帳內容",
+                detail = "跨幣種時會顯示輸入匯率與目前可用的參考匯率。"
+            )
             when (mode) {
                 TransferEditMode.OneToOne -> {
                     AccountPicker(label = "轉出帳戶", accounts = selectableAccounts, selected = fromAccount) { acc ->
@@ -187,7 +200,8 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                             if (currencyOut == currencyIn) amountIn = amountOut
                         },
                         currency = currencyOut,
-                        onCurrencyChange = { currencyOut = it }
+                        onCurrencyChange = { currencyOut = it },
+                        currencyService = currencyService
                     )
                     AccountPicker(label = "轉入帳戶", accounts = selectableAccounts, selected = toAccount) { acc ->
                         toAccount = acc
@@ -198,7 +212,15 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                         amount = amountIn,
                         onAmountChange = { amountIn = sanitizeAmount(it) },
                         currency = currencyIn,
-                        onCurrencyChange = { currencyIn = it }
+                        onCurrencyChange = { currencyIn = it },
+                        currencyService = currencyService
+                    )
+                    TransferRateHint(
+                        currencyService = currencyService,
+                        outgoingAmount = parsePositive(amountOut),
+                        outgoingCurrency = currencyOut,
+                        incomingAmount = parsePositive(amountIn),
+                        incomingCurrency = currencyIn
                     )
                 }
                 TransferEditMode.OneToMany -> {
@@ -211,13 +233,15 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                         amount = sourceAmount,
                         onAmountChange = { sourceAmount = sanitizeAmount(it) },
                         currency = sourceCurrency,
-                        onCurrencyChange = { sourceCurrency = it }
+                        onCurrencyChange = { sourceCurrency = it },
+                        currencyService = currencyService
                     )
                     destinationLegs.forEachIndexed { index, leg ->
                         TransferLegEditor(
                             title = "轉入帳戶 ${index + 1}",
                             leg = leg,
                             accounts = selectableAccounts.filter { it.id != sourceAccount?.id },
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 destinationLegs = destinationLegs.toMutableList().also { it[index] = updated }
                             },
@@ -240,13 +264,15 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                         amount = destinationAmount,
                         onAmountChange = { destinationAmount = sanitizeAmount(it) },
                         currency = destinationCurrency,
-                        onCurrencyChange = { destinationCurrency = it }
+                        onCurrencyChange = { destinationCurrency = it },
+                        currencyService = currencyService
                     )
                     sourceLegs.forEachIndexed { index, leg ->
                         TransferLegEditor(
                             title = "轉出帳戶 ${index + 1}",
                             leg = leg,
                             accounts = selectableAccounts.filter { it.id != destinationAccount?.id },
+                            currencyService = currencyService,
                             onUpdate = { updated ->
                                 sourceLegs = sourceLegs.toMutableList().also { it[index] = updated }
                             },
@@ -262,8 +288,11 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
             }
         }
 
-        Text("日期", style = MaterialTheme.typography.titleMedium)
         SectionCard {
+            ParitySectionHeader(
+                title = "日期",
+                detail = "修改後會重新建立這組轉帳，日期與備註會一起套用。"
+            )
             TextButton(onClick = {
                 showDatePicker(context, date) { picked ->
                     date = picked
@@ -273,8 +302,11 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
             }
         }
 
-        Text("備註", style = MaterialTheme.typography.titleMedium)
         SectionCard {
+            ParitySectionHeader(
+                title = "備註",
+                detail = "可補充用途、手動匯率或這次修改的原因。"
+            )
             OutlinedTextField(
                 value = note,
                 onValueChange = { note = it },
@@ -386,10 +418,12 @@ private fun AccountPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.titleSmall)
-        TextButton(onClick = { expanded = true }) {
-            Text(selected?.name ?: "選擇帳戶")
-        }
+        ParityMenuField(
+            label = label,
+            value = selected?.name.orEmpty(),
+            placeholder = "選擇帳戶",
+            onClick = { expanded = true }
+        )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             accounts.forEach { account ->
                 DropdownMenuItem(
@@ -410,7 +444,8 @@ private fun AmountRow(
     amount: String,
     onAmountChange: (String) -> Unit,
     currency: String,
-    onCurrencyChange: (String) -> Unit
+    onCurrencyChange: (String) -> Unit,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(label, style = MaterialTheme.typography.titleSmall)
@@ -423,6 +458,11 @@ private fun AmountRow(
                 modifier = Modifier.weight(1f)
             )
         }
+        CurrencyRateHint(
+            currencyService = currencyService,
+            amount = parsePositive(amount),
+            currencyCode = currency
+        )
     }
 }
 
@@ -440,11 +480,15 @@ private fun TransferLegEditor(
     title: String,
     leg: TransferEditLegInput,
     accounts: List<AccountEntity>,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     onUpdate: (TransferEditLegInput) -> Unit,
     onRemove: (() -> Unit)?
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(title, style = MaterialTheme.typography.titleSmall)
+        ParitySectionHeader(
+            title = title,
+            detail = "每個分錄都會用自己的幣別與金額計算。"
+        )
         AccountPicker(label = "帳戶", accounts = accounts, selected = leg.account) { acc ->
             onUpdate(leg.copy(account = acc, currency = acc?.currency ?: leg.currency))
         }
@@ -453,7 +497,8 @@ private fun TransferLegEditor(
             amount = leg.amount,
             onAmountChange = { onUpdate(leg.copy(amount = sanitizeAmount(it))) },
             currency = leg.currency,
-            onCurrencyChange = { onUpdate(leg.copy(currency = it)) }
+            onCurrencyChange = { onUpdate(leg.copy(currency = it)) },
+            currencyService = currencyService
         )
         if (onRemove != null) {
             TextButton(onClick = onRemove) { Text("移除") }

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/DataHealthCheckerTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/DataHealthCheckerTest.kt
@@ -93,7 +93,8 @@ class DataHealthCheckerTest {
                     participantId = participantId,
                     receivedAccountId = receiveAccount.id
                 )
-            )
+            ),
+            shortcuts = emptyList()
         )
 
         val report = DataHealthChecker.run(snapshot, now)
@@ -149,7 +150,8 @@ class DataHealthCheckerTest {
                     debtAccountId = debtAccount.id
                 )
             ),
-            advanceRepayments = emptyList()
+            advanceRepayments = emptyList(),
+            shortcuts = emptyList()
         )
 
         val report = DataHealthChecker.run(snapshot, now)


### PR DESCRIPTION
## Summary
- split income entry from debt management so income only uses own accounts
- add debt forgiveness as a dedicated debt-management action on iOS and Android
- add live/cached exchange-rate hints for add/edit transaction and transfer flows
- add data-health cleanup tools for legacy income-on-debt records and shortcuts

## Testing
- xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
- cd '/Users/lhf/Documents/AI 記帳/android' && ./gradlew assembleDebug testDebugUnitTest
