### PR TITLE
Add data safety regression fixtures

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: macos-latest
     timeout-minutes: 30
 
@@ -38,9 +38,20 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             build | tee xcodebuild.log
 
+      - name: Run Unit Tests (iOS Simulator)
+        run: |
+          xcodebuild \
+            -project 'AI 記帳.xcodeproj' \
+            -scheme 'AI 記帳' \
+            -destination 'platform=iOS Simulator,name=iPhone 13' \
+            CODE_SIGNING_ALLOWED=NO \
+            test | tee xcodebuild-test.log
+
       - name: Upload Build Log on Failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: xcodebuild-log
-          path: xcodebuild.log
+          name: xcodebuild-logs
+          path: |
+            xcodebuild.log
+            xcodebuild-test.log

--- a/AI 記帳.xcodeproj/project.pbxproj
+++ b/AI 記帳.xcodeproj/project.pbxproj
@@ -7,12 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		FFA001000000000000000004 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFA001000000000000000002 /* XCTest.framework */; };
 		FFE186662F067E15007E709F /* GoogleGenerativeAI in Frameworks */ = {isa = PBXBuildFile; productRef = FFE186652F067E15007E709F /* GoogleGenerativeAI */; };
 		FFE186742F06A5DB007E709F /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = FFE186732F06A5DB007E709F /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		FFA00100000000000000000D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FF5082152F057AD70012E7D0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF50821C2F057AD70012E7D0;
+			remoteInfo = "AI 記帳";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		FF50821D2F057AD70012E7D0 /* AI 記帳.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AI 記帳.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFA001000000000000000001 /* AI 記帳Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AI 記帳Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFA001000000000000000002 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		FFE186732F06A5DB007E709F /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -20,6 +33,11 @@
 		FF50821F2F057AD70012E7D0 /* AI 記帳 */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "AI 記帳";
+			sourceTree = "<group>";
+		};
+		FFA001000000000000000003 /* AI 記帳Tests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "AI 記帳Tests";
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -33,6 +51,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FFA001000000000000000005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FFA001000000000000000004 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -41,7 +67,9 @@
 			children = (
 				FFE186732F06A5DB007E709F /* Localizable.xcstrings */,
 				FF50821D2F057AD70012E7D0 /* AI 記帳.app */,
+				FFA001000000000000000001 /* AI 記帳Tests.xctest */,
 				FF50821F2F057AD70012E7D0 /* AI 記帳 */,
+				FFA001000000000000000003 /* AI 記帳Tests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -71,6 +99,29 @@
 			productReference = FF50821D2F057AD70012E7D0 /* AI 記帳.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FFA001000000000000000008 /* AI 記帳Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FFA00100000000000000000B /* Build configuration list for PBXNativeTarget "AI 記帳Tests" */;
+			buildPhases = (
+				FFA001000000000000000006 /* Sources */,
+				FFA001000000000000000005 /* Frameworks */,
+				FFA001000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FFA00100000000000000000E /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				FFA001000000000000000003 /* AI 記帳Tests */,
+			);
+			name = "AI 記帳Tests";
+			packageProductDependencies = (
+			);
+			productName = "AI 記帳Tests";
+			productReference = FFA001000000000000000001 /* AI 記帳Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -83,6 +134,10 @@
 				TargetAttributes = {
 					FF50821C2F057AD70012E7D0 = {
 						CreatedOnToolsVersion = 26.2;
+					};
+					FFA001000000000000000008 = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = FF50821C2F057AD70012E7D0;
 					};
 				};
 			};
@@ -109,6 +164,7 @@
 			projectRoot = "";
 			targets = (
 				FF50821C2F057AD70012E7D0 /* AI 記帳 */,
+				FFA001000000000000000008 /* AI 記帳Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -122,6 +178,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FFA001000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -132,7 +195,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FFA001000000000000000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FFA00100000000000000000E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FF50821C2F057AD70012E7D0 /* AI 記帳 */;
+			targetProxy = FFA00100000000000000000D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		FF5082282F057AD80012E7D0 /* Debug */ = {
@@ -330,6 +408,62 @@
 			};
 			name = Release;
 		};
+		FFA001000000000000000009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+				buildSettings = {
+					BUNDLE_LOADER = "$(TEST_HOST)";
+					CODE_SIGN_ENTITLEMENTS = "";
+					CODE_SIGN_IDENTITY = "Apple Development";
+					CODE_SIGN_STYLE = Automatic;
+					CURRENT_PROJECT_VERSION = 1;
+					DEVELOPMENT_TEAM = N8999ZB8MC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					);
+					MARKETING_VERSION = 1.0;
+					PRODUCT_BUNDLE_IDENTIFIER = org.duckdns.lhfser.AIMoneyTests;
+					PRODUCT_NAME = "$(TARGET_NAME)";
+					SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+					SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+					SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+					SWIFT_VERSION = 5.0;
+					TARGETED_DEVICE_FAMILY = "1,2";
+					TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AI 記帳.app/AI 記帳";
+					TEST_TARGET_NAME = "AI 記帳";
+				};
+				name = Debug;
+			};
+			FFA00100000000000000000A /* Release */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
+					BUNDLE_LOADER = "$(TEST_HOST)";
+					CODE_SIGN_ENTITLEMENTS = "";
+					CODE_SIGN_IDENTITY = "Apple Development";
+					CODE_SIGN_STYLE = Automatic;
+					CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8999ZB8MC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					);
+					MARKETING_VERSION = 1.0;
+					PRODUCT_BUNDLE_IDENTIFIER = org.duckdns.lhfser.AIMoneyTests;
+					PRODUCT_NAME = "$(TARGET_NAME)";
+					SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+					SWIFT_VERSION = 5.0;
+					TARGETED_DEVICE_FAMILY = "1,2";
+					TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AI 記帳.app/AI 記帳";
+					TEST_TARGET_NAME = "AI 記帳";
+				};
+				name = Release;
+			};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -347,6 +481,15 @@
 			buildConfigurations = (
 				FF50822B2F057AD80012E7D0 /* Debug */,
 				FF50822C2F057AD80012E7D0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FFA00100000000000000000B /* Build configuration list for PBXNativeTarget "AI 記帳Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FFA001000000000000000009 /* Debug */,
+				FFA00100000000000000000A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AI 記帳.xcodeproj/xcshareddata/xcschemes/AI 記帳.xcscheme
+++ b/AI 記帳.xcodeproj/xcshareddata/xcschemes/AI 記帳.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FF50821C2F057AD70012E7D0"
+               BuildableName = "AI 記帳.app"
+               BlueprintName = "AI 記帳"
+               ReferencedContainer = "container:AI 記帳.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FFA001000000000000000008"
+               BuildableName = "AI 記帳Tests.xctest"
+               BlueprintName = "AI 記帳Tests"
+               ReferencedContainer = "container:AI 記帳.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FFA001000000000000000008"
+               BuildableName = "AI 記帳Tests.xctest"
+               BlueprintName = "AI 記帳Tests"
+               ReferencedContainer = "container:AI 記帳.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF50821C2F057AD70012E7D0"
+            BuildableName = "AI 記帳.app"
+            BlueprintName = "AI 記帳"
+            ReferencedContainer = "container:AI 記帳.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF50821C2F057AD70012E7D0"
+            BuildableName = "AI 記帳.app"
+            BlueprintName = "AI 記帳"
+            ReferencedContainer = "container:AI 記帳.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -2,6 +2,12 @@ import SwiftUI
 import SwiftData
 import SQLite3
 
+private extension ProcessInfo {
+    static var isRunningXCTest: Bool {
+        processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+}
+
 @main
 struct AI___App: App {
     private static func repairLegacyCategoryKindsIfNeeded(storeURL: URL) {
@@ -192,6 +198,15 @@ struct AI___App: App {
             AdvanceParticipant.self,
             AdvanceRepayment.self
         ])
+
+        if ProcessInfo.isRunningXCTest {
+            let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+            do {
+                return try ModelContainer(for: schema, configurations: [configuration])
+            } catch {
+                fatalError("Could not create in-memory ModelContainer for tests: \(error)")
+            }
+        }
         
         // 1. 獲取 Documents 資料夾
         let fileManager = FileManager.default

--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -59,6 +59,10 @@ struct ContentView: View {
         return hasher.finalize()
     }
 
+    private var isRunningXCTest: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     var body: some View {
         GeometryReader { proxy in
             ZStack(alignment: .bottomTrailing) {
@@ -148,6 +152,7 @@ struct ContentView: View {
             showingAddAdvanceCase = false
         }
         .onChange(of: scenePhase, initial: true) { _, newPhase in
+            guard !isRunningXCTest else { return }
             switch newPhase {
             case .active:
                 idleBackupTask?.cancel()
@@ -159,6 +164,7 @@ struct ContentView: View {
             }
         }
         .onAppear {
+            guard !isRunningXCTest else { return }
             guard !initialGuideChecked else { return }
             initialGuideChecked = true
             selectedTab = hasSeenUserGuide ? .ledger : .home
@@ -167,6 +173,7 @@ struct ContentView: View {
             }
         }
         .task(id: budgetHistorySyncToken) {
+            guard !isRunningXCTest else { return }
             do {
                 try BudgetHistoryService.shared.syncAll(
                     modelContext: modelContext,

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+import SwiftData
+@testable import AI_記帳
+
+@MainActor
+final class BackupCompatibilityTests: XCTestCase {
+    func testLegacyAdvanceFixture_roundTripsWithoutHealthIssues() async throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+
+        let fixtureURL = fixtureURL(named: "legacy_bidirectional_advances.json")
+        try await BackupManager.shared.restoreFromJSON(url: fixtureURL, modelContext: modelContext)
+
+        let initialReport = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertEqual(0, initialReport.errorCount)
+        XCTAssertEqual(0, initialReport.warningCount)
+
+        let exported = BackupManager.shared.createBackupData(modelContext: modelContext)
+        XCTAssertEqual(5, exported.accounts.count)
+        XCTAssertEqual(2, exported.categories.count)
+        XCTAssertEqual(16, exported.transactions.count)
+        XCTAssertEqual(2, exported.advanceCases?.count)
+        XCTAssertEqual(3, exported.advanceParticipants?.count)
+        XCTAssertEqual(4, exported.advanceRepayments?.count)
+        XCTAssertEqual("Both", exported.categories.first(where: { $0.name == "Salary" })?.kind)
+
+        let secondContainer = try makeInMemoryContainer()
+        let secondContext = ModelContext(secondContainer)
+        let exportedURL = try writeBackup(exported, named: "legacy-advance-roundtrip.json")
+        try await BackupManager.shared.restoreFromJSON(url: exportedURL, modelContext: secondContext)
+
+        let secondReport = DataHealthCheckService.run(modelContext: secondContext)
+        XCTAssertEqual(0, secondReport.errorCount)
+        XCTAssertEqual(0, secondReport.warningCount)
+
+        let cases = try secondContext.fetch(FetchDescriptor<AdvanceCase>())
+        XCTAssertEqual(2, cases.count)
+    }
+
+    func testLegacyDebtIncomeFixture_canRepairAndReimportCleanly() async throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+
+        let fixtureURL = fixtureURL(named: "legacy_debt_income_repair.json")
+        try await BackupManager.shared.restoreFromJSON(url: fixtureURL, modelContext: modelContext)
+
+        let initialReport = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertTrue(initialReport.issues.contains(where: { $0.title == "收入記到了借貸帳戶" }))
+        XCTAssertTrue(initialReport.issues.contains(where: { $0.title == "收入捷徑綁到了借貸帳戶" }))
+
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let shortcuts = try modelContext.fetch(FetchDescriptor<Shortcut>())
+        let convertedCount = try LegacyDebtIncomeRepairService.convertLegacyDebtIncomeTransactions(
+            LegacyDebtIncomeRepairService.legacyDebtIncomeTransactions(from: transactions),
+            modelContext: modelContext
+        )
+        let detachedCount = try LegacyDebtIncomeRepairService.detachLegacyDebtIncomeShortcuts(
+            LegacyDebtIncomeRepairService.legacyDebtIncomeShortcuts(from: shortcuts),
+            modelContext: modelContext
+        )
+
+        XCTAssertEqual(1, convertedCount)
+        XCTAssertEqual(1, detachedCount)
+
+        let repairedReport = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertFalse(repairedReport.issues.contains(where: { $0.title == "收入記到了借貸帳戶" }))
+        XCTAssertFalse(repairedReport.issues.contains(where: { $0.title == "收入捷徑綁到了借貸帳戶" }))
+
+        let exported = BackupManager.shared.createBackupData(modelContext: modelContext)
+        XCTAssertEqual("Both", exported.categories.first(where: { $0.name == "Salary" })?.kind)
+        XCTAssertEqual(1, exported.budgetHistory?.count)
+        XCTAssertNil(exported.shortcuts.first?.accountID)
+        XCTAssertEqual("Transfer", exported.transactions.first(where: { $0.id == UUID(uuidString: "34343434-3434-3434-3434-343434343431") })?.type)
+        XCTAssertTrue((exported.transactions.first(where: { $0.id == UUID(uuidString: "34343434-3434-3434-3434-343434343431") })?.note ?? "").contains("[免除債務]"))
+
+        let secondContainer = try makeInMemoryContainer()
+        let secondContext = ModelContext(secondContainer)
+        let exportedURL = try writeBackup(exported, named: "legacy-debt-income-roundtrip.json")
+        try await BackupManager.shared.restoreFromJSON(url: exportedURL, modelContext: secondContext)
+
+        let secondReport = DataHealthCheckService.run(modelContext: secondContext)
+        XCTAssertFalse(secondReport.issues.contains(where: { $0.title == "收入記到了借貸帳戶" }))
+        XCTAssertFalse(secondReport.issues.contains(where: { $0.title == "收入捷徑綁到了借貸帳戶" }))
+        XCTAssertEqual(0, secondReport.errorCount)
+    }
+
+    private func makeInMemoryContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Account.self,
+            FinancialTransaction.self,
+            Category.self,
+            Tag.self,
+            Shortcut.self,
+            CategoryMonthlyBudget.self,
+            BudgetMonthlyHistory.self,
+            AdvanceCase.self,
+            AdvanceParticipant.self,
+            AdvanceRepayment.self,
+        ])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: configuration)
+    }
+
+    private func fixtureURL(named name: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures", isDirectory: true)
+            .appendingPathComponent(name)
+    }
+
+    private func writeBackup(_ backup: FullBackupData, named name: String) throws -> URL {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(backup).write(to: tempURL, options: .atomic)
+        return tempURL
+    }
+}

--- a/AI 記帳Tests/Fixtures/legacy_bidirectional_advances.json
+++ b/AI 記帳Tests/Fixtures/legacy_bidirectional_advances.json
@@ -1,0 +1,491 @@
+{
+  "version": "1.5",
+  "timestamp": "2026-03-01T00:00:00Z",
+  "accounts": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "name": "Cash Wallet",
+      "currency": "HKD",
+      "type": "Cash",
+      "baseBalance": 500,
+      "sortOrder": 0,
+      "isArchived": false
+    },
+    {
+      "id": "22222222-2222-2222-2222-222222222221",
+      "name": "Friend A",
+      "currency": "HKD",
+      "type": "Debt",
+      "baseBalance": 0,
+      "sortOrder": 1,
+      "isArchived": false
+    },
+    {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "name": "Friend B",
+      "currency": "HKD",
+      "type": "Debt",
+      "baseBalance": 0,
+      "sortOrder": 2,
+      "isArchived": false
+    },
+    {
+      "id": "33333333-3333-3333-3333-333333333333",
+      "name": "HSBC",
+      "currency": "HKD",
+      "type": "Bank",
+      "baseBalance": 1200,
+      "sortOrder": 3,
+      "isArchived": false
+    },
+    {
+      "id": "44444444-4444-4444-4444-444444444444",
+      "name": "Pocket Cash",
+      "currency": "HKD",
+      "type": "Cash",
+      "baseBalance": 150,
+      "sortOrder": 4,
+      "isArchived": false
+    }
+  ],
+  "categories": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "name": "Food",
+      "icon": "fork.knife",
+      "colorHex": "#F97316",
+      "kind": "Expense"
+    },
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+      "name": "Salary",
+      "icon": "banknote",
+      "colorHex": "#10B981",
+      "kind": null
+    }
+  ],
+  "tags": [
+    {
+      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+      "name": "shared"
+    },
+    {
+      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2",
+      "name": "reimbursement"
+    }
+  ],
+  "transactions": [
+    {
+      "id": "55555555-5555-5555-5555-555555555551",
+      "amount": 1000,
+      "currencyCode": "HKD",
+      "date": "2026-02-01T09:00:00Z",
+      "note": "February salary",
+      "type": "Income",
+      "linkedTransactionID": null,
+      "transferGroupID": null,
+      "transferSide": null,
+      "photoPath": null,
+      "createdAt": "2026-02-01T09:00:00Z",
+      "updatedAt": "2026-02-01T09:00:00Z",
+      "accountID": "33333333-3333-3333-3333-333333333333",
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555552",
+      "amount": -50,
+      "currencyCode": "HKD",
+      "date": "2026-02-10T12:00:00Z",
+      "note": "Dinner split (自己份額)",
+      "type": "Expense",
+      "linkedTransactionID": null,
+      "transferGroupID": null,
+      "transferSide": null,
+      "photoPath": null,
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-10T12:00:00Z",
+      "accountID": "11111111-1111-1111-1111-111111111111",
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "tagIDs": [
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1"
+      ]
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555553",
+      "amount": -50,
+      "currencyCode": "HKD",
+      "date": "2026-02-10T12:00:00Z",
+      "note": "Dinner split (代墊給 Friend A)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555554",
+      "transferGroupID": "66666666-6666-6666-6666-666666666661",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-10T12:00:00Z",
+      "accountID": "11111111-1111-1111-1111-111111111111",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555554",
+      "amount": 50,
+      "currencyCode": "HKD",
+      "date": "2026-02-10T12:00:00Z",
+      "note": "Dinner split (來自 Cash Wallet)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555553",
+      "transferGroupID": "66666666-6666-6666-6666-666666666661",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-10T12:00:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222221",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555555",
+      "amount": -50,
+      "currencyCode": "HKD",
+      "date": "2026-02-10T12:00:00Z",
+      "note": "Dinner split (代墊給 Friend B)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555556",
+      "transferGroupID": "66666666-6666-6666-6666-666666666662",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-10T12:00:00Z",
+      "accountID": "11111111-1111-1111-1111-111111111111",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555556",
+      "amount": 50,
+      "currencyCode": "HKD",
+      "date": "2026-02-10T12:00:00Z",
+      "note": "Dinner split (來自 Cash Wallet)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555555",
+      "transferGroupID": "66666666-6666-6666-6666-666666666662",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-10T12:00:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222222",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555557",
+      "amount": -40,
+      "currencyCode": "HKD",
+      "date": "2026-02-15T08:30:00Z",
+      "note": "Taxi (代墊給我 Cash Wallet)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555558",
+      "transferGroupID": "66666666-6666-6666-6666-666666666663",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-15T08:30:00Z",
+      "updatedAt": "2026-02-15T08:30:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222221",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555558",
+      "amount": 40,
+      "currencyCode": "HKD",
+      "date": "2026-02-15T08:30:00Z",
+      "note": "Taxi (來自 Friend A)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555557",
+      "transferGroupID": "66666666-6666-6666-6666-666666666663",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-15T08:30:00Z",
+      "updatedAt": "2026-02-15T08:30:00Z",
+      "accountID": "11111111-1111-1111-1111-111111111111",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555559",
+      "amount": -20,
+      "currencyCode": "HKD",
+      "date": "2026-02-18T19:00:00Z",
+      "note": "Dinner split (還款至 Pocket Cash)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555560",
+      "transferGroupID": "66666666-6666-6666-6666-666666666664",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-18T19:00:00Z",
+      "updatedAt": "2026-02-18T19:00:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222221",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555560",
+      "amount": 20,
+      "currencyCode": "HKD",
+      "date": "2026-02-18T19:00:00Z",
+      "note": "Dinner split (來自 Friend A)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555559",
+      "transferGroupID": "66666666-6666-6666-6666-666666666664",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-18T19:00:00Z",
+      "updatedAt": "2026-02-18T19:00:00Z",
+      "accountID": "44444444-4444-4444-4444-444444444444",
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "tagIDs": [
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2"
+      ]
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555561",
+      "amount": -30,
+      "currencyCode": "HKD",
+      "date": "2026-02-20T10:00:00Z",
+      "note": "Dinner split (還款至 HSBC)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555562",
+      "transferGroupID": "66666666-6666-6666-6666-666666666665",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-20T10:00:00Z",
+      "updatedAt": "2026-02-20T10:00:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222221",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555562",
+      "amount": 30,
+      "currencyCode": "HKD",
+      "date": "2026-02-20T10:00:00Z",
+      "note": "Dinner split (來自 Friend A)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555561",
+      "transferGroupID": "66666666-6666-6666-6666-666666666665",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-20T10:00:00Z",
+      "updatedAt": "2026-02-20T10:00:00Z",
+      "accountID": "33333333-3333-3333-3333-333333333333",
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "tagIDs": [
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2"
+      ]
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555563",
+      "amount": -20,
+      "currencyCode": "HKD",
+      "date": "2026-02-22T21:00:00Z",
+      "note": "Taxi (還款給 Friend A)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555564",
+      "transferGroupID": "66666666-6666-6666-6666-666666666666",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-22T21:00:00Z",
+      "updatedAt": "2026-02-22T21:00:00Z",
+      "accountID": "44444444-4444-4444-4444-444444444444",
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "tagIDs": [
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2"
+      ]
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555564",
+      "amount": 20,
+      "currencyCode": "HKD",
+      "date": "2026-02-22T21:00:00Z",
+      "note": "Taxi (來自 Pocket Cash)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555563",
+      "transferGroupID": "66666666-6666-6666-6666-666666666666",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-22T21:00:00Z",
+      "updatedAt": "2026-02-22T21:00:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222221",
+      "categoryID": null,
+      "tagIDs": []
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555565",
+      "amount": -20,
+      "currencyCode": "HKD",
+      "date": "2026-02-23T21:00:00Z",
+      "note": "Taxi (還款給 Friend A)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555566",
+      "transferGroupID": "66666666-6666-6666-6666-666666666667",
+      "transferSide": "Outgoing",
+      "photoPath": null,
+      "createdAt": "2026-02-23T21:00:00Z",
+      "updatedAt": "2026-02-23T21:00:00Z",
+      "accountID": "33333333-3333-3333-3333-333333333333",
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "tagIDs": [
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2"
+      ]
+    },
+    {
+      "id": "55555555-5555-5555-5555-555555555566",
+      "amount": 20,
+      "currencyCode": "HKD",
+      "date": "2026-02-23T21:00:00Z",
+      "note": "Taxi (來自 HSBC)",
+      "type": "Transfer",
+      "linkedTransactionID": "55555555-5555-5555-5555-555555555565",
+      "transferGroupID": "66666666-6666-6666-6666-666666666667",
+      "transferSide": "Incoming",
+      "photoPath": null,
+      "createdAt": "2026-02-23T21:00:00Z",
+      "updatedAt": "2026-02-23T21:00:00Z",
+      "accountID": "22222222-2222-2222-2222-222222222221",
+      "categoryID": null,
+      "tagIDs": []
+    }
+  ],
+  "shortcuts": [],
+  "budgets": [
+    {
+      "id": "77777777-7777-7777-7777-777777777771",
+      "monthKey": "2026-02",
+      "amount": 800,
+      "currencyCode": "HKD",
+      "isEnabled": null,
+      "categoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "createdAt": "2026-02-01T00:00:00Z",
+      "updatedAt": "2026-02-01T00:00:00Z"
+    }
+  ],
+  "advanceCases": [
+    {
+      "id": "88888888-8888-8888-8888-888888888881",
+      "title": "Dinner split",
+      "date": "2026-02-10T12:00:00Z",
+      "currencyCode": "HKD",
+      "myShareAmount": 50,
+      "note": "Shared dinner",
+      "selfExpenseTransactionID": "55555555-5555-5555-5555-555555555552",
+      "payerAccountID": "11111111-1111-1111-1111-111111111111",
+      "expenseCategoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-20T10:00:00Z"
+    },
+    {
+      "id": "88888888-8888-8888-8888-888888888882",
+      "title": "Taxi",
+      "date": "2026-02-15T08:30:00Z",
+      "currencyCode": "HKD",
+      "myShareAmount": null,
+      "note": "Friend paid first",
+      "selfExpenseTransactionID": null,
+      "payerAccountID": "11111111-1111-1111-1111-111111111111",
+      "expenseCategoryID": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+      "createdAt": "2026-02-15T08:30:00Z",
+      "updatedAt": "2026-02-23T21:00:00Z"
+    }
+  ],
+  "advanceParticipants": [
+    {
+      "id": "99999999-9999-9999-9999-999999999991",
+      "name": "Friend A",
+      "owedAmount": 50,
+      "repaidAmount": 50,
+      "initialTransferGroupID": "66666666-6666-6666-6666-666666666661",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888881",
+      "debtAccountID": "22222222-2222-2222-2222-222222222221",
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-20T10:00:00Z"
+    },
+    {
+      "id": "99999999-9999-9999-9999-999999999992",
+      "name": "Friend B",
+      "owedAmount": 50,
+      "repaidAmount": null,
+      "initialTransferGroupID": "66666666-6666-6666-6666-666666666662",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888881",
+      "debtAccountID": "22222222-2222-2222-2222-222222222222",
+      "createdAt": "2026-02-10T12:00:00Z",
+      "updatedAt": "2026-02-10T12:00:00Z"
+    },
+    {
+      "id": "99999999-9999-9999-9999-999999999993",
+      "name": "Friend A",
+      "owedAmount": 40,
+      "repaidAmount": 40,
+      "initialTransferGroupID": "66666666-6666-6666-6666-666666666663",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888882",
+      "debtAccountID": "22222222-2222-2222-2222-222222222221",
+      "createdAt": "2026-02-15T08:30:00Z",
+      "updatedAt": "2026-02-23T21:00:00Z"
+    }
+  ],
+  "advanceRepayments": [
+    {
+      "id": "10101010-1010-1010-1010-101010101011",
+      "amount": 20,
+      "currencyCode": "HKD",
+      "normalizedAmount": null,
+      "date": "2026-02-18T19:00:00Z",
+      "note": "Part 1",
+      "linkedTransferGroupID": "66666666-6666-6666-6666-666666666664",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888881",
+      "participantID": "99999999-9999-9999-9999-999999999991",
+      "receivedAccountID": "44444444-4444-4444-4444-444444444444",
+      "createdAt": "2026-02-18T19:00:00Z"
+    },
+    {
+      "id": "10101010-1010-1010-1010-101010101012",
+      "amount": 30,
+      "currencyCode": "HKD",
+      "normalizedAmount": 30,
+      "date": "2026-02-20T10:00:00Z",
+      "note": "Part 2",
+      "linkedTransferGroupID": "66666666-6666-6666-6666-666666666665",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888881",
+      "participantID": "99999999-9999-9999-9999-999999999991",
+      "receivedAccountID": "33333333-3333-3333-3333-333333333333",
+      "createdAt": "2026-02-20T10:00:00Z"
+    },
+    {
+      "id": "10101010-1010-1010-1010-101010101013",
+      "amount": 20,
+      "currencyCode": "HKD",
+      "normalizedAmount": 20,
+      "date": "2026-02-22T21:00:00Z",
+      "note": "Pocket leg",
+      "linkedTransferGroupID": "66666666-6666-6666-6666-666666666666",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888882",
+      "participantID": "99999999-9999-9999-9999-999999999993",
+      "receivedAccountID": "44444444-4444-4444-4444-444444444444",
+      "createdAt": "2026-02-22T21:00:00Z"
+    },
+    {
+      "id": "10101010-1010-1010-1010-101010101014",
+      "amount": 20,
+      "currencyCode": "HKD",
+      "normalizedAmount": 20,
+      "date": "2026-02-23T21:00:00Z",
+      "note": "Bank leg",
+      "linkedTransferGroupID": "66666666-6666-6666-6666-666666666667",
+      "advanceCaseID": "88888888-8888-8888-8888-888888888882",
+      "participantID": "99999999-9999-9999-9999-999999999993",
+      "receivedAccountID": "33333333-3333-3333-3333-333333333333",
+      "createdAt": "2026-02-23T21:00:00Z"
+    }
+  ]
+}

--- a/AI 記帳Tests/Fixtures/legacy_debt_income_repair.json
+++ b/AI 記帳Tests/Fixtures/legacy_debt_income_repair.json
@@ -1,0 +1,115 @@
+{
+  "version": "1.4",
+  "timestamp": "2026-02-01T00:00:00Z",
+  "accounts": [
+    {
+      "id": "12121212-1212-1212-1212-121212121211",
+      "name": "Cash Wallet",
+      "currency": "HKD",
+      "type": "Cash",
+      "baseBalance": 300,
+      "sortOrder": 0,
+      "isArchived": false
+    },
+    {
+      "id": "12121212-1212-1212-1212-121212121212",
+      "name": "Friend Loan",
+      "currency": "HKD",
+      "type": "Debt",
+      "baseBalance": 0,
+      "sortOrder": 1,
+      "isArchived": false
+    },
+    {
+      "id": "12121212-1212-1212-1212-121212121213",
+      "name": "HSBC",
+      "currency": "HKD",
+      "type": "Bank",
+      "baseBalance": 900,
+      "sortOrder": 2,
+      "isArchived": false
+    }
+  ],
+  "categories": [
+    {
+      "id": "abababab-abab-abab-abab-ababababab11",
+      "name": "Salary",
+      "icon": "banknote",
+      "colorHex": "#10B981",
+      "kind": null
+    },
+    {
+      "id": "abababab-abab-abab-abab-ababababab12",
+      "name": "Groceries",
+      "icon": "cart",
+      "colorHex": "#F97316",
+      "kind": "Expense"
+    }
+  ],
+  "tags": [],
+  "transactions": [
+    {
+      "id": "34343434-3434-3434-3434-343434343431",
+      "amount": 150,
+      "currencyCode": "HKD",
+      "date": "2026-01-05T09:00:00Z",
+      "note": "Legacy debt income",
+      "type": "Income",
+      "linkedTransactionID": null,
+      "transferGroupID": null,
+      "transferSide": null,
+      "photoPath": null,
+      "createdAt": "2026-01-05T09:00:00Z",
+      "updatedAt": "2026-01-05T09:00:00Z",
+      "accountID": "12121212-1212-1212-1212-121212121212",
+      "categoryID": "abababab-abab-abab-abab-ababababab11",
+      "tagIDs": []
+    },
+    {
+      "id": "34343434-3434-3434-3434-343434343432",
+      "amount": -45,
+      "currencyCode": "HKD",
+      "date": "2026-01-08T18:30:00Z",
+      "note": "Weekly groceries",
+      "type": "Expense",
+      "linkedTransactionID": null,
+      "transferGroupID": null,
+      "transferSide": null,
+      "photoPath": null,
+      "createdAt": "2026-01-08T18:30:00Z",
+      "updatedAt": "2026-01-08T18:30:00Z",
+      "accountID": "12121212-1212-1212-1212-121212121211",
+      "categoryID": "abababab-abab-abab-abab-ababababab12",
+      "tagIDs": []
+    }
+  ],
+  "shortcuts": [
+    {
+      "id": "56565656-5656-5656-5656-565656565651",
+      "name": "Legacy salary shortcut",
+      "icon": "banknote",
+      "amount": 60,
+      "type": "Income",
+      "note": "Shortcut still points to debt account",
+      "currencyCode": null,
+      "accountID": "12121212-1212-1212-1212-121212121212",
+      "categoryID": "abababab-abab-abab-abab-ababababab11",
+      "tagIDs": []
+    }
+  ],
+  "budgets": [
+    {
+      "id": "78787878-7878-7878-7878-787878787871",
+      "monthKey": "2026-01",
+      "amount": 100,
+      "currencyCode": "HKD",
+      "isEnabled": null,
+      "categoryID": "abababab-abab-abab-abab-ababababab12",
+      "createdAt": "2026-01-01T00:00:00Z",
+      "updatedAt": "2026-01-01T00:00:00Z"
+    }
+  ],
+  "advanceCases": null,
+  "advanceParticipants": null,
+  "advanceRepayments": null
+}

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -11,7 +11,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -85,6 +88,55 @@ class BackupRoundTripTest {
             assertEquals(2, dinnerCase?.repayments?.size)
             assertEquals(1, taxiCase?.participants?.size)
             assertEquals(2, taxiCase?.repayments?.size)
+        } finally {
+            secondDatabase.close()
+        }
+    }
+
+    @Test
+    fun legacyDebtIncomeFixture_importRepairExport_reimportsCleanly() = runBlocking {
+        val fixtureJson = loadFixture("fixtures/legacy_debt_income_repair.json")
+
+        repository.importBackupJson(fixtureJson, replaceExisting = true)
+
+        val initialReport = repository.buildDataHealthReport()
+        assertTrue(initialReport.issues.any { it.title == "收入交易記到了借貸帳戶" })
+        assertTrue(initialReport.issues.any { it.title == "收入捷徑綁到了借貸帳戶" })
+
+        assertEquals(1, repository.convertAllLegacyDebtIncomeTransactions())
+        assertEquals(1, repository.detachAllLegacyDebtIncomeShortcuts())
+
+        val repairedReport = repository.buildDataHealthReport()
+        assertFalse(repairedReport.issues.any { it.title == "收入交易記到了借貸帳戶" })
+        assertFalse(repairedReport.issues.any { it.title == "收入捷徑綁到了借貸帳戶" })
+        assertEquals(0, repairedReport.errorCount)
+
+        val exportedJson = repository.exportBackupJson()
+        val exported = BackupJsonAdapter.gson.fromJson(exportedJson, FullBackupData::class.java)
+
+        assertEquals("Both", exported.categories.first { it.name == "Salary" }.kind)
+        assertEquals(1, exported.budgetHistory?.size)
+        assertNull(exported.shortcuts.first().accountID)
+        assertEquals(
+            "Transfer",
+            exported.transactions.first { it.id == UUID.fromString("34343434-3434-3434-3434-343434343431") }.type
+        )
+        assertTrue(
+            exported.transactions
+                .first { it.id == UUID.fromString("34343434-3434-3434-3434-343434343431") }
+                .note
+                .contains("[免除債務]")
+        )
+
+        val secondDatabase = buildDatabase()
+        try {
+            val secondRepository = AccountingRepository(secondDatabase, currencyService)
+            secondRepository.importBackupJson(exportedJson, replaceExisting = true)
+
+            val secondReport = secondRepository.buildDataHealthReport()
+            assertFalse(secondReport.issues.any { it.title == "收入交易記到了借貸帳戶" })
+            assertFalse(secondReport.issues.any { it.title == "收入捷徑綁到了借貸帳戶" })
+            assertEquals(0, secondReport.errorCount)
         } finally {
             secondDatabase.close()
         }

--- a/android/app/src/test/resources/fixtures/legacy_debt_income_repair.json
+++ b/android/app/src/test/resources/fixtures/legacy_debt_income_repair.json
@@ -1,0 +1,115 @@
+{
+  "version": "1.4",
+  "timestamp": "2026-02-01T00:00:00Z",
+  "accounts": [
+    {
+      "id": "12121212-1212-1212-1212-121212121211",
+      "name": "Cash Wallet",
+      "currency": "HKD",
+      "type": "Cash",
+      "baseBalance": 300,
+      "sortOrder": 0,
+      "isArchived": false
+    },
+    {
+      "id": "12121212-1212-1212-1212-121212121212",
+      "name": "Friend Loan",
+      "currency": "HKD",
+      "type": "Debt",
+      "baseBalance": 0,
+      "sortOrder": 1,
+      "isArchived": false
+    },
+    {
+      "id": "12121212-1212-1212-1212-121212121213",
+      "name": "HSBC",
+      "currency": "HKD",
+      "type": "Bank",
+      "baseBalance": 900,
+      "sortOrder": 2,
+      "isArchived": false
+    }
+  ],
+  "categories": [
+    {
+      "id": "abababab-abab-abab-abab-ababababab11",
+      "name": "Salary",
+      "icon": "banknote",
+      "colorHex": "#10B981",
+      "kind": null
+    },
+    {
+      "id": "abababab-abab-abab-abab-ababababab12",
+      "name": "Groceries",
+      "icon": "cart",
+      "colorHex": "#F97316",
+      "kind": "Expense"
+    }
+  ],
+  "tags": [],
+  "transactions": [
+    {
+      "id": "34343434-3434-3434-3434-343434343431",
+      "amount": 150,
+      "currencyCode": "HKD",
+      "date": "2026-01-05T09:00:00Z",
+      "note": "Legacy debt income",
+      "type": "Income",
+      "linkedTransactionID": null,
+      "transferGroupID": null,
+      "transferSide": null,
+      "photoPath": null,
+      "createdAt": "2026-01-05T09:00:00Z",
+      "updatedAt": "2026-01-05T09:00:00Z",
+      "accountID": "12121212-1212-1212-1212-121212121212",
+      "categoryID": "abababab-abab-abab-abab-ababababab11",
+      "tagIDs": []
+    },
+    {
+      "id": "34343434-3434-3434-3434-343434343432",
+      "amount": -45,
+      "currencyCode": "HKD",
+      "date": "2026-01-08T18:30:00Z",
+      "note": "Weekly groceries",
+      "type": "Expense",
+      "linkedTransactionID": null,
+      "transferGroupID": null,
+      "transferSide": null,
+      "photoPath": null,
+      "createdAt": "2026-01-08T18:30:00Z",
+      "updatedAt": "2026-01-08T18:30:00Z",
+      "accountID": "12121212-1212-1212-1212-121212121211",
+      "categoryID": "abababab-abab-abab-abab-ababababab12",
+      "tagIDs": []
+    }
+  ],
+  "shortcuts": [
+    {
+      "id": "56565656-5656-5656-5656-565656565651",
+      "name": "Legacy salary shortcut",
+      "icon": "banknote",
+      "amount": 60,
+      "type": "Income",
+      "note": "Shortcut still points to debt account",
+      "currencyCode": null,
+      "accountID": "12121212-1212-1212-1212-121212121212",
+      "categoryID": "abababab-abab-abab-abab-ababababab11",
+      "tagIDs": []
+    }
+  ],
+  "budgets": [
+    {
+      "id": "78787878-7878-7878-7878-787878787871",
+      "monthKey": "2026-01",
+      "amount": 100,
+      "currencyCode": "HKD",
+      "isEnabled": null,
+      "categoryID": "abababab-abab-abab-abab-ababababab12",
+      "createdAt": "2026-01-01T00:00:00Z",
+      "updatedAt": "2026-01-01T00:00:00Z"
+    }
+  ],
+  "advanceCases": null,
+  "advanceParticipants": null,
+  "advanceRepayments": null
+}

--- a/docs/CI_CHECKLIST.md
+++ b/docs/CI_CHECKLIST.md
@@ -1,7 +1,7 @@
 # CI Checklist (iOS + Android)
 
 Status: Active  
-Last updated: 2026-03-23
+Last updated: 2026-04-18
 
 This checklist is the baseline for PR quality gates for dual-platform delivery.
 
@@ -29,6 +29,14 @@ xcodebuild -project 'AI 記帳.xcodeproj' \
   build
 ```
 
+```bash
+xcodebuild -project 'AI 記帳.xcodeproj' \
+  -scheme 'AI 記帳' \
+  -destination 'platform=iOS Simulator,name=iPhone 13' \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
 ### String catalog sanity
 ```bash
 python3 -m json.tool Localizable.xcstrings > /dev/null
@@ -47,10 +55,20 @@ cd android
 - Add transaction (income/expense) and verify report totals.
 - Transfer flow (including grouped transfer) and verify it does not affect income/expense totals.
 - Backup export/import with `android/app/src/test/resources/fixtures/legacy_bidirectional_advances.json`.
+- Legacy repair regression with:
+  - `android/app/src/test/resources/fixtures/legacy_bidirectional_advances.json`
+  - `android/app/src/test/resources/fixtures/legacy_debt_income_repair.json`
 - Advance tracking flow (create case, repayment, remaining amount).
 - Follow the cross-platform matrix in `docs/VALIDATION_MATRIX.md`.
 
-## 5. Release Gate
+## 5. Data Regression Guard
+
+When a PR changes backup format, repair rules, or model semantics:
+- Add or update at least one legacy fixture.
+- Run `restore -> health check -> repair -> re-check -> export` on the affected fixture set.
+- Confirm iOS and Android both accept the supported legacy backups.
+
+## 6. Release Gate
 
 Before creating a release tag:
 - Confirm all required checks are green.


### PR DESCRIPTION
## Summary
- add shared iOS and Android legacy fixtures for backup compatibility coverage
- add iOS backup compatibility tests and wire them into the shared scheme/CI
- extend Android round-trip coverage for legacy debt-income repair flows

## Testing
- xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO test\n- cd android && ./gradlew assembleDebug testDebugUnitTest\n\nCloses #35