### PR TITLE
Allow same-account transfers across currencies

### DIFF
--- a/AI 記帳/Views/Transactions/AddTransferView.swift
+++ b/AI 記帳/Views/Transactions/AddTransferView.swift
@@ -158,9 +158,6 @@ struct AddTransferView: View {
             .onChange(of: fromAccount) { _, _ in
                 if let acc = fromAccount {
                     currencyOut = acc.currency
-                    if toAccount?.id == acc.id {
-                        toAccount = nil
-                    }
                 }
             }
 
@@ -199,7 +196,7 @@ struct AddTransferView: View {
         Section("轉入方 (收入)") {
             Picker("到帳戶", selection: $toAccount) {
                 Text("選擇帳戶").tag(nil as Account?)
-                ForEach(activeAccounts.filter { $0.id != fromAccount?.id }) { acc in
+                ForEach(activeAccounts) { acc in
                     Text(acc.name).tag(acc as Account?)
                 }
             }
@@ -265,11 +262,6 @@ struct AddTransferView: View {
             .onChange(of: sourceAccount) { _, _ in
                 if let acc = sourceAccount {
                     sourceCurrency = acc.currency
-                    for index in destinationLegs.indices {
-                        if destinationLegs[index].account?.id == acc.id {
-                            destinationLegs[index].account = nil
-                        }
-                    }
                 }
             }
 
@@ -302,7 +294,7 @@ struct AddTransferView: View {
                 VStack(spacing: 10) {
                     Picker("到帳戶", selection: $leg.account) {
                         Text("選擇帳戶").tag(nil as Account?)
-                        ForEach(activeAccounts.filter { $0.id != sourceAccount?.id }) { acc in
+                        ForEach(activeAccounts) { acc in
                             Text(acc.name).tag(acc as Account?)
                         }
                     }
@@ -361,7 +353,7 @@ struct AddTransferView: View {
                 VStack(spacing: 10) {
                     Picker("從帳戶", selection: $leg.account) {
                         Text("選擇帳戶").tag(nil as Account?)
-                        ForEach(activeAccounts.filter { $0.id != destinationAccount?.id }) { acc in
+                        ForEach(activeAccounts) { acc in
                             Text(acc.name).tag(acc as Account?)
                         }
                     }
@@ -422,11 +414,6 @@ struct AddTransferView: View {
             .onChange(of: destinationAccount) { _, _ in
                 if let acc = destinationAccount {
                     destinationCurrency = acc.currency
-                    for index in sourceLegs.indices {
-                        if sourceLegs[index].account?.id == acc.id {
-                            sourceLegs[index].account = nil
-                        }
-                    }
                 }
             }
 
@@ -468,10 +455,6 @@ struct AddTransferView: View {
 
     private func saveOneToOneTransfer() {
         guard let from = fromAccount, let to = toAccount else { return }
-        guard from.id != to.id else {
-            showValidation("轉出與轉入帳戶不可相同。")
-            return
-        }
         guard let amountOut = positiveDecimal(from: amountOutString) else {
             showValidation("請輸入大於 0 的轉出金額。")
             return
@@ -547,10 +530,6 @@ struct AddTransferView: View {
 
         var accountIDs = Set<UUID>()
         for leg in parsedLegs {
-            if leg.account.id == source.id {
-                showValidation("轉入帳戶不可與轉出帳戶相同。")
-                return
-            }
             if accountIDs.contains(leg.account.id) {
                 showValidation("分拆轉入帳戶不可重複，請合併該帳戶的金額。")
                 return
@@ -624,10 +603,6 @@ struct AddTransferView: View {
 
         var accountIDs = Set<UUID>()
         for leg in parsedLegs {
-            if leg.account.id == destination.id {
-                showValidation("轉出帳戶不可與轉入帳戶相同。")
-                return
-            }
             if accountIDs.contains(leg.account.id) {
                 showValidation("轉出帳戶不可重複，請合併該帳戶的金額。")
                 return

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -300,10 +300,6 @@ struct EditTransferView: View {
                 showValidation("轉入帳戶不可重複，請合併金額。")
                 return
             }
-            if !outgoingIDs.isDisjoint(with: incomingIDs) {
-                showValidation("同一帳戶不可同時出現在轉出與轉入。")
-                return
-            }
 
             var existing = try fetchGroupTransactions(for: originalTransaction)
                 .filter { $0.type == .transfer }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
@@ -174,7 +174,7 @@ fun AddTransferScreen(onDone: () -> Unit) {
                         TransferLegEditor(
                             title = "轉入帳戶 ${index + 1}",
                             leg = leg,
-                            accounts = activeAccounts.filter { it.id != sourceAccount?.id },
+                            accounts = activeAccounts,
                             currencyService = currencyService,
                             onUpdate = { updated ->
                                 destinationLegs = destinationLegs.toMutableList().also { it[index] = updated }
@@ -205,7 +205,7 @@ fun AddTransferScreen(onDone: () -> Unit) {
                         TransferLegEditor(
                             title = "轉出帳戶 ${index + 1}",
                             leg = leg,
-                            accounts = activeAccounts.filter { it.id != destinationAccount?.id },
+                            accounts = activeAccounts,
                             currencyService = currencyService,
                             onUpdate = { updated ->
                                 sourceLegs = sourceLegs.toMutableList().also { it[index] = updated }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
@@ -240,7 +240,7 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                         TransferLegEditor(
                             title = "轉入帳戶 ${index + 1}",
                             leg = leg,
-                            accounts = selectableAccounts.filter { it.id != sourceAccount?.id },
+                            accounts = selectableAccounts,
                             currencyService = currencyService,
                             onUpdate = { updated ->
                                 destinationLegs = destinationLegs.toMutableList().also { it[index] = updated }
@@ -271,7 +271,7 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                         TransferLegEditor(
                             title = "轉出帳戶 ${index + 1}",
                             leg = leg,
-                            accounts = selectableAccounts.filter { it.id != destinationAccount?.id },
+                            accounts = selectableAccounts,
                             currencyService = currencyService,
                             onUpdate = { updated ->
                                 sourceLegs = sourceLegs.toMutableList().also { it[index] = updated }


### PR DESCRIPTION
## Summary
- allow transfers to and from the same account when users are moving value between different currencies in one bank account
- remove UI filtering and validation that blocked same-account transfers on iOS and Android
- keep duplicate protection within the same transfer side so split legs still have to be merged per account

## Testing
- xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
- cd '/Users/lhf/Documents/AI 記帳/android' && ./gradlew assembleDebug testDebugUnitTest