### PR TITLE
Add budget carry-over settings and forecasts

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -194,6 +194,7 @@ struct AI___App: App {
             Shortcut.self,
             CategoryMonthlyBudget.self,
             BudgetMonthlyHistory.self,
+            BudgetSettings.self,
             AdvanceCase.self,
             AdvanceParticipant.self,
             AdvanceRepayment.self

--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -59,6 +59,36 @@ enum CategoryKind: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+enum BudgetCarryOverMode: String, Codable, CaseIterable, Identifiable {
+    case none = "None"
+    case unusedOnly = "UnusedOnly"
+    case overspendOnly = "OverspendOnly"
+    case netBalance = "NetBalance"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .none: return "不結轉"
+        case .unusedOnly: return "只結轉剩餘"
+        case .overspendOnly: return "只扣減超支"
+        case .netBalance: return "結轉淨額"
+        }
+    }
+}
+
+enum BudgetForecastMode: String, Codable, CaseIterable, Identifiable {
+    case spendingPace = "SpendingPace"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .spendingPace: return "按本月使用速度"
+        }
+    }
+}
+
 // MARK: - Models
 
 @Model
@@ -279,6 +309,45 @@ final class BudgetMonthlyHistory {
         self.isOverBudget = isOverBudget
         self.currencyCode = currencyCode
         self.updatedAt = updatedAt
+    }
+}
+
+@Model
+final class BudgetSettings {
+    @Attribute(.unique) var id: String
+    var carryOverModeRaw: String
+    var alertThresholdPercent: Decimal
+    var forecastModeRaw: String
+    var updatedAt: Date
+
+    init(
+        id: String = "global",
+        carryOverMode: BudgetCarryOverMode = .none,
+        alertThresholdPercent: Decimal = 85,
+        forecastMode: BudgetForecastMode = .spendingPace,
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.carryOverModeRaw = carryOverMode.rawValue
+        self.alertThresholdPercent = alertThresholdPercent
+        self.forecastModeRaw = forecastMode.rawValue
+        self.updatedAt = updatedAt
+    }
+
+    var carryOverMode: BudgetCarryOverMode {
+        get { BudgetCarryOverMode(rawValue: carryOverModeRaw) ?? .none }
+        set {
+            carryOverModeRaw = newValue.rawValue
+            updatedAt = Date()
+        }
+    }
+
+    var forecastMode: BudgetForecastMode {
+        get { BudgetForecastMode(rawValue: forecastModeRaw) ?? .spendingPace }
+        set {
+            forecastModeRaw = newValue.rawValue
+            updatedAt = Date()
+        }
     }
 }
 

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -15,6 +15,7 @@ struct FullBackupData: Codable {
     let shortcuts: [ShortcutCodable]
     let budgets: [BudgetCodable]?
     let budgetHistory: [BudgetHistoryCodable]?
+    let budgetSettings: [BudgetSettingsCodable]?
     let advanceCases: [AdvanceCaseCodable]?
     let advanceParticipants: [AdvanceParticipantCodable]?
     let advanceRepayments: [AdvanceRepaymentCodable]?
@@ -69,6 +70,13 @@ struct FullBackupData: Codable {
         let usageRatio: Decimal
         let isOverBudget: Bool
         let currencyCode: String
+        let updatedAt: Date?
+    }
+    struct BudgetSettingsCodable: Codable {
+        let id: String
+        let carryOverMode: String
+        let alertThresholdPercent: Decimal
+        let forecastMode: String
         let updatedAt: Date?
     }
     struct AdvanceCaseCodable: Codable {
@@ -174,11 +182,12 @@ class BackupManager: NSObject, ObservableObject {
         let shortcuts = (try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []
         let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
         let budgetHistory = (try? modelContext.fetch(FetchDescriptor<BudgetMonthlyHistory>())) ?? []
+        let budgetSettings = (try? modelContext.fetch(FetchDescriptor<BudgetSettings>())) ?? []
         let advanceCases = (try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []
         let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
         let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
         
-        return FullBackupData(version: "1.6", timestamp: Date(),
+        return FullBackupData(version: "1.7", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
             categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
@@ -227,6 +236,15 @@ class BackupManager: NSObject, ObservableObject {
                     usageRatio: $0.usageRatio,
                     isOverBudget: $0.isOverBudget,
                     currencyCode: $0.currencyCode,
+                    updatedAt: $0.updatedAt
+                )
+            },
+            budgetSettings: budgetSettings.map {
+                FullBackupData.BudgetSettingsCodable(
+                    id: $0.id,
+                    carryOverMode: $0.carryOverModeRaw,
+                    alertThresholdPercent: $0.alertThresholdPercent,
+                    forecastMode: $0.forecastModeRaw,
                     updatedAt: $0.updatedAt
                 )
             },
@@ -299,6 +317,7 @@ class BackupManager: NSObject, ObservableObject {
         var existingShortcutIDs = Set(((try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []).map(\.id))
         var existingBudgetIDs = Set(((try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []).map(\.id))
         var historyByKey = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<BudgetMonthlyHistory>())) ?? []).map { ($0.historyKey, $0) })
+        var budgetSettingsByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<BudgetSettings>())) ?? []).map { ($0.id, $0) })
         var advanceCaseByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<AdvanceCase>())) ?? []).map { ($0.id, $0) })
         var participantByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []).map { ($0.id, $0) })
         var existingRepaymentIDs = Set(((try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []).map(\.id))
@@ -426,6 +445,28 @@ class BackupManager: NSObject, ObservableObject {
                 )
                 modelContext.insert(history)
                 historyByKey[historyDTO.historyKey] = history
+            }
+        }
+
+        if let settingsDTOs = backup.budgetSettings {
+            for settingsDTO in settingsDTOs {
+                if let existing = budgetSettingsByID[settingsDTO.id] {
+                    existing.carryOverModeRaw = settingsDTO.carryOverMode
+                    existing.alertThresholdPercent = settingsDTO.alertThresholdPercent
+                    existing.forecastModeRaw = settingsDTO.forecastMode
+                    existing.updatedAt = settingsDTO.updatedAt ?? Date()
+                    continue
+                }
+
+                let settings = BudgetSettings(
+                    id: settingsDTO.id,
+                    carryOverMode: BudgetCarryOverMode(rawValue: settingsDTO.carryOverMode) ?? .none,
+                    alertThresholdPercent: settingsDTO.alertThresholdPercent,
+                    forecastMode: BudgetForecastMode(rawValue: settingsDTO.forecastMode) ?? .spendingPace,
+                    updatedAt: settingsDTO.updatedAt ?? Date()
+                )
+                modelContext.insert(settings)
+                budgetSettingsByID[settingsDTO.id] = settings
             }
         }
 

--- a/AI 記帳/Services/BudgetService.swift
+++ b/AI 記帳/Services/BudgetService.swift
@@ -10,6 +10,18 @@ struct BudgetStatus: Identifiable {
     var id: UUID { budget.id }
 }
 
+struct BudgetForecast {
+    let projectedSpent: Decimal
+    let projectedRemaining: Decimal
+    let projectedRatio: Decimal
+    let daysElapsed: Int
+    let daysInMonth: Int
+
+    var isProjectedOverBudget: Bool {
+        projectedRemaining < 0
+    }
+}
+
 enum BudgetService {
     static func monthKey(from date: Date) -> String {
         let components = Calendar.current.dateComponents([.year, .month], from: date)
@@ -30,6 +42,13 @@ enum BudgetService {
         components.month = month
         components.day = 1
         return Calendar.current.date(from: components)
+    }
+
+    static func previousMonthKey(from monthKey: String) -> String? {
+        guard let start = monthStart(from: monthKey),
+              let previous = Calendar.current.date(byAdding: .month, value: -1, to: start)
+        else { return nil }
+        return self.monthKey(from: previous)
     }
     
     static func statuses(
@@ -67,6 +86,61 @@ enum BudgetService {
                 return $0.isOverBudget && !$1.isOverBudget
             }
             return $0.ratio > $1.ratio
+        }
+    }
+
+    static func forecast(for status: BudgetStatus, today: Date = Date()) -> BudgetForecast {
+        guard let monthStart = monthStart(from: status.budget.monthKey),
+              let monthRange = Calendar.current.range(of: .day, in: .month, for: monthStart)
+        else {
+            return BudgetForecast(
+                projectedSpent: status.spent,
+                projectedRemaining: status.remaining,
+                projectedRatio: status.ratio,
+                daysElapsed: 1,
+                daysInMonth: 1
+            )
+        }
+
+        let daysInMonth = monthRange.count
+        let currentMonthKey = monthKey(from: today)
+        let projectedSpent: Decimal
+        let daysElapsed: Int
+
+        if status.budget.monthKey == currentMonthKey {
+            let day = Calendar.current.component(.day, from: today)
+            daysElapsed = max(1, min(day, daysInMonth))
+            projectedSpent = status.spent / Decimal(daysElapsed) * Decimal(daysInMonth)
+        } else {
+            daysElapsed = daysInMonth
+            projectedSpent = status.spent
+        }
+
+        let projectedRemaining = status.budget.amount - projectedSpent
+        let projectedRatio: Decimal = status.budget.amount > 0 ? projectedSpent / status.budget.amount : 0
+        return BudgetForecast(
+            projectedSpent: projectedSpent,
+            projectedRemaining: projectedRemaining,
+            projectedRatio: projectedRatio,
+            daysElapsed: daysElapsed,
+            daysInMonth: daysInMonth
+        )
+    }
+
+    static func carryOverAmount(
+        previousBudgetAmount: Decimal,
+        previousRemaining: Decimal,
+        mode: BudgetCarryOverMode
+    ) -> Decimal {
+        switch mode {
+        case .none:
+            return previousBudgetAmount
+        case .unusedOnly:
+            return previousBudgetAmount + max(previousRemaining, 0)
+        case .overspendOnly:
+            return max(previousBudgetAmount + min(previousRemaining, 0), 0)
+        case .netBalance:
+            return max(previousBudgetAmount + previousRemaining, 0)
         }
     }
 }

--- a/AI 記帳/Views/Budgets/BudgetsView.swift
+++ b/AI 記帳/Views/Budgets/BudgetsView.swift
@@ -5,6 +5,7 @@ struct BudgetsView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Category.name) private var categories: [Category]
     @Query(sort: \CategoryMonthlyBudget.monthKey, order: .reverse) private var budgets: [CategoryMonthlyBudget]
+    @Query(sort: \BudgetSettings.updatedAt, order: .reverse) private var budgetSettingsRecords: [BudgetSettings]
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
     @StateObject private var currencyService = CurrencyService.shared
     
@@ -16,6 +17,10 @@ struct BudgetsView: View {
     
     private var monthKey: String {
         BudgetService.monthKey(from: selectedMonthDate)
+    }
+
+    private var budgetSettings: BudgetSettings? {
+        budgetSettingsRecords.first
     }
     
     private var monthStatuses: [BudgetStatus] {
@@ -44,6 +49,43 @@ struct BudgetsView: View {
                 DatePicker("預算月份", selection: $selectedMonthDate, displayedComponents: [.date])
                     .datePickerStyle(.compact)
                 Toggle("只顯示提醒", isOn: $showingOnlyAlerts)
+            }
+
+            if let budgetSettings {
+                Section("預算規則") {
+                    Picker("結轉方式", selection: Binding(
+                        get: { budgetSettings.carryOverMode },
+                        set: { mode in
+                            budgetSettings.carryOverMode = mode
+                            persistBudgetSettings()
+                            applyCarryOverIfNeeded()
+                        }
+                    )) {
+                        ForEach(BudgetCarryOverMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+
+                    Stepper(
+                        value: Binding(
+                            get: { Int(truncating: NSDecimalNumber(decimal: budgetSettings.alertThresholdPercent)) },
+                            set: { value in
+                                budgetSettings.alertThresholdPercent = Decimal(value)
+                                budgetSettings.updatedAt = Date()
+                                persistBudgetSettings()
+                            }
+                        ),
+                        in: 50...100,
+                        step: 5
+                    ) {
+                        Text("提醒門檻：\(Int(truncating: NSDecimalNumber(decimal: budgetSettings.alertThresholdPercent)))%")
+                    }
+
+                    LabeledContent("預測方式", value: budgetSettings.forecastMode.displayName)
+                    Text(carryOverDescription(for: budgetSettings.carryOverMode))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             
             if visibleStatuses.isEmpty {
@@ -75,6 +117,13 @@ struct BudgetsView: View {
             }
         }
         .navigationTitle("預算與超支提醒")
+        .task {
+            ensureBudgetSettings()
+            applyCarryOverIfNeeded()
+        }
+        .onChange(of: selectedMonthDate) { _, _ in
+            applyCarryOverIfNeeded()
+        }
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
@@ -127,7 +176,9 @@ struct BudgetsView: View {
         let categoryName = budget.category?.name ?? "未分類"
         let progress = min(max(Double(NSDecimalNumber(decimal: status.ratio).doubleValue), 0), 1.5)
         let overBy = abs(status.remaining)
-        let color: Color = status.isOverBudget ? .red : (status.ratio >= 0.85 ? .orange : .green)
+        let threshold = (budgetSettings?.alertThresholdPercent ?? 85) / 100
+        let forecast = BudgetService.forecast(for: status)
+        let color: Color = status.isOverBudget ? .red : (status.ratio >= threshold ? .orange : .green)
         
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -159,8 +210,101 @@ struct BudgetsView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+
+            HStack {
+                Text("月底預測：\(forecast.projectedSpent.formatted(.currency(code: budget.currencyCode)))")
+                    .font(.caption2)
+                    .foregroundStyle(forecast.isProjectedOverBudget ? .red : .secondary)
+                Spacer()
+                if forecast.isProjectedOverBudget {
+                    Text("預計超支 \(abs(forecast.projectedRemaining).formatted(.currency(code: budget.currencyCode)))")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                } else {
+                    Text("預計剩餘 \(forecast.projectedRemaining.formatted(.currency(code: budget.currencyCode)))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
         .padding(.vertical, 4)
+    }
+
+    private func ensureBudgetSettings() {
+        guard budgetSettingsRecords.isEmpty else { return }
+        modelContext.insert(BudgetSettings())
+        persistBudgetSettings()
+    }
+
+    private func persistBudgetSettings() {
+        do {
+            try modelContext.save()
+        } catch {
+            print("儲存預算設定失敗: \(error)")
+        }
+    }
+
+    private func carryOverDescription(for mode: BudgetCarryOverMode) -> String {
+        switch mode {
+        case .none:
+            return "新月份不會自動建立預算。"
+        case .unusedOnly:
+            return "新月份會把上月剩餘金額加到同分類預算。"
+        case .overspendOnly:
+            return "新月份會扣減上月超支金額。"
+        case .netBalance:
+            return "新月份會把上月剩餘或超支都結轉。"
+        }
+    }
+
+    private func applyCarryOverIfNeeded() {
+        guard let settings = budgetSettings,
+              settings.carryOverMode != .none,
+              let previousMonthKey = BudgetService.previousMonthKey(from: monthKey)
+        else { return }
+
+        let currentCategoryIDs = Set(budgets.compactMap { budget -> UUID? in
+            guard budget.monthKey == monthKey else { return nil }
+            return budget.category?.id
+        })
+
+        let previousStatuses = BudgetService.statuses(
+            for: previousMonthKey,
+            budgets: budgets,
+            transactions: transactions,
+            currencyService: currencyService
+        )
+
+        var inserted = false
+        for status in previousStatuses {
+            guard let category = status.budget.category,
+                  !currentCategoryIDs.contains(category.id)
+            else { continue }
+
+            let amount = BudgetService.carryOverAmount(
+                previousBudgetAmount: status.budget.amount,
+                previousRemaining: status.remaining,
+                mode: settings.carryOverMode
+            )
+            guard amount > 0 else { continue }
+
+            modelContext.insert(CategoryMonthlyBudget(
+                monthKey: monthKey,
+                amount: amount,
+                currencyCode: status.budget.currencyCode,
+                isEnabled: status.budget.isEnabled,
+                category: category
+            ))
+            inserted = true
+        }
+
+        guard inserted else { return }
+        do {
+            try modelContext.save()
+            try BudgetHistoryService.shared.syncAll(modelContext: modelContext, currencyService: currencyService)
+        } catch {
+            print("套用預算結轉失敗: \(error)")
+        }
     }
     
     private func deleteBudget(_ budget: CategoryMonthlyBudget) {

--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -400,6 +400,7 @@ struct SettingsView: View {
             try modelContext.delete(model: Shortcut.self)
             try modelContext.delete(model: CategoryMonthlyBudget.self)
             try modelContext.delete(model: BudgetMonthlyHistory.self)
+            try modelContext.delete(model: BudgetSettings.self)
             try modelContext.delete(model: AdvanceRepayment.self)
             try modelContext.delete(model: AdvanceParticipant.self)
             try modelContext.delete(model: AdvanceCase.self)

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -93,6 +93,7 @@ final class BackupCompatibilityTests: XCTestCase {
             Shortcut.self,
             CategoryMonthlyBudget.self,
             BudgetMonthlyHistory.self,
+            BudgetSettings.self,
             AdvanceCase.self,
             AdvanceParticipant.self,
             AdvanceRepayment.self,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
@@ -13,6 +13,7 @@ class AppContainer(context: Context) {
     val database: AIAccountingDatabase by lazy {
         Room.databaseBuilder(appContext, AIAccountingDatabase::class.java, "ai_accounting.db")
             .addMigrations(AIAccountingDatabase.MIGRATION_1_2)
+            .addMigrations(AIAccountingDatabase.MIGRATION_2_3)
             .addCallback(SeedData.callback(appContext))
             .build()
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/backup/BackupModels.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/backup/BackupModels.kt
@@ -14,6 +14,7 @@ data class FullBackupData(
     val shortcuts: List<ShortcutCodable>,
     val budgets: List<BudgetCodable>?,
     val budgetHistory: List<BudgetHistoryCodable>?,
+    val budgetSettings: List<BudgetSettingsCodable>? = null,
     val advanceCases: List<AdvanceCaseCodable>?,
     val advanceParticipants: List<AdvanceParticipantCodable>?,
     val advanceRepayments: List<AdvanceRepaymentCodable>?
@@ -95,6 +96,14 @@ data class FullBackupData(
         val usageRatio: BigDecimal,
         val isOverBudget: Boolean,
         val currencyCode: String,
+        val updatedAt: Instant?
+    )
+
+    data class BudgetSettingsCodable(
+        val id: String,
+        val carryOverMode: String,
+        val alertThresholdPercent: BigDecimal,
+        val forecastMode: String,
         val updatedAt: Instant?
     )
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
@@ -17,11 +17,12 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ShortcutTagCrossRef::class,
         CategoryMonthlyBudgetEntity::class,
         BudgetMonthlyHistoryEntity::class,
+        BudgetSettingsEntity::class,
         AdvanceCaseEntity::class,
         AdvanceParticipantEntity::class,
         AdvanceRepaymentEntity::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -36,8 +37,8 @@ abstract class AIAccountingDatabase : RoomDatabase() {
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL(
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
                     """
                     CREATE TABLE IF NOT EXISTS `budget_monthly_history` (
                         `id` TEXT NOT NULL,
@@ -56,9 +57,26 @@ abstract class AIAccountingDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
-                database.execSQL("CREATE INDEX IF NOT EXISTS `index_budget_monthly_history_monthKey` ON `budget_monthly_history` (`monthKey`)")
-                database.execSQL("CREATE INDEX IF NOT EXISTS `index_budget_monthly_history_categoryId` ON `budget_monthly_history` (`categoryId`)")
-                database.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_monthly_history_historyKey` ON `budget_monthly_history` (`historyKey`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_budget_monthly_history_monthKey` ON `budget_monthly_history` (`monthKey`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_budget_monthly_history_categoryId` ON `budget_monthly_history` (`categoryId`)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_monthly_history_historyKey` ON `budget_monthly_history` (`historyKey`)")
+            }
+        }
+
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `budget_settings` (
+                        `id` TEXT NOT NULL,
+                        `carryOverMode` TEXT NOT NULL,
+                        `alertThresholdPercent` TEXT NOT NULL,
+                        `forecastMode` TEXT NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
@@ -168,11 +168,17 @@ interface BudgetDao {
     @Query("SELECT * FROM budget_monthly_history ORDER BY monthKey DESC, categoryNameSnapshot ASC")
     fun observeBudgetHistory(): Flow<List<BudgetMonthlyHistoryEntity>>
 
+    @Query("SELECT * FROM budget_settings WHERE id = 'global' LIMIT 1")
+    fun observeBudgetSettings(): Flow<BudgetSettingsEntity?>
+
     @Query("SELECT * FROM category_monthly_budgets")
     suspend fun getAll(): List<CategoryMonthlyBudgetEntity>
 
     @Query("SELECT * FROM budget_monthly_history")
     suspend fun getAllHistory(): List<BudgetMonthlyHistoryEntity>
+
+    @Query("SELECT * FROM budget_settings WHERE id = 'global' LIMIT 1")
+    suspend fun getSettings(): BudgetSettingsEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(budget: CategoryMonthlyBudgetEntity)
@@ -186,6 +192,9 @@ interface BudgetDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAllHistory(history: List<BudgetMonthlyHistoryEntity>)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertSettings(settings: BudgetSettingsEntity)
+
     @Delete
     suspend fun delete(budget: CategoryMonthlyBudgetEntity)
 
@@ -197,6 +206,9 @@ interface BudgetDao {
 
     @Query("DELETE FROM budget_monthly_history")
     suspend fun deleteAllHistory()
+
+    @Query("DELETE FROM budget_settings")
+    suspend fun deleteAllSettings()
 }
 
 @Dao

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
@@ -136,6 +136,15 @@ data class BudgetMonthlyHistoryEntity(
     val updatedAt: Instant
 )
 
+@Entity(tableName = "budget_settings")
+data class BudgetSettingsEntity(
+    @PrimaryKey val id: String = "global",
+    val carryOverMode: String = "None",
+    val alertThresholdPercent: BigDecimal = BigDecimal("85"),
+    val forecastMode: String = "SpendingPace",
+    val updatedAt: Instant = Instant.now()
+)
+
 @Entity(
     tableName = "advance_cases",
     indices = [Index("payerAccountId"), Index("expenseCategoryId")]

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -25,6 +25,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.BudgetDao
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.BudgetMonthlyHistoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.BudgetSettingsEntity
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutEntity
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutTagCrossRef
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
@@ -80,6 +81,7 @@ class AccountingRepository(
     val shortcuts: Flow<List<ShortcutWithDetails>> = shortcutDao.observeShortcuts()
     val budgets: Flow<List<CategoryMonthlyBudgetEntity>> = budgetDao.observeBudgets()
     val budgetHistories: Flow<List<BudgetMonthlyHistoryEntity>> = budgetDao.observeBudgetHistory()
+    val budgetSettings: Flow<BudgetSettingsEntity?> = budgetDao.observeBudgetSettings()
     val advanceCases: Flow<List<AdvanceCaseWithDetails>> = advanceDao.observeAdvanceCases()
 
     private data class AccountDeletionTargets(
@@ -348,6 +350,10 @@ class AccountingRepository(
             budgetDao.delete(budget)
             syncAllBudgetHistory()
         }
+    }
+
+    suspend fun upsertBudgetSettings(settings: BudgetSettingsEntity) {
+        budgetDao.upsertSettings(settings)
     }
 
     suspend fun createTransferOneToOne(
@@ -807,6 +813,7 @@ class AccountingRepository(
         val shortcutTags = shortcutDao.getShortcutTags()
         val budgets = budgetDao.getAll()
         val budgetHistories = budgetDao.getAllHistory()
+        val budgetSettings = budgetDao.getSettings()
         val advanceCases = advanceDao.getAllCases()
         val advanceParticipants = advanceDao.getAllParticipants()
         val advanceRepayments = advanceDao.getAllRepayments()
@@ -815,7 +822,7 @@ class AccountingRepository(
         val shortcutTagMap = shortcutTags.groupBy { it.shortcutId }
 
         return FullBackupData(
-            version = "1.6",
+            version = "1.7",
             timestamp = Instant.now(),
             accounts = accounts.map {
                 FullBackupData.AccountCodable(
@@ -897,6 +904,15 @@ class AccountingRepository(
                     isOverBudget = history.isOverBudget,
                     currencyCode = history.currencyCode,
                     updatedAt = history.updatedAt
+                )
+            },
+            budgetSettings = listOfNotNull(budgetSettings).map { settings ->
+                FullBackupData.BudgetSettingsCodable(
+                    id = settings.id,
+                    carryOverMode = settings.carryOverMode,
+                    alertThresholdPercent = settings.alertThresholdPercent,
+                    forecastMode = settings.forecastMode,
+                    updatedAt = settings.updatedAt
                 )
             },
             advanceCases = advanceCases.map { case ->
@@ -1057,6 +1073,16 @@ class AccountingRepository(
             )
         }.orEmpty()
 
+        val settingsEntities = data.budgetSettings?.map { settings ->
+            BudgetSettingsEntity(
+                id = settings.id,
+                carryOverMode = settings.carryOverMode,
+                alertThresholdPercent = settings.alertThresholdPercent,
+                forecastMode = settings.forecastMode,
+                updatedAt = settings.updatedAt ?: Instant.now()
+            )
+        }.orEmpty()
+
         val caseEntities = data.advanceCases?.map { case ->
             AdvanceCaseEntity(
                 id = case.id,
@@ -1127,6 +1153,7 @@ class AccountingRepository(
             if (historyEntities.isNotEmpty()) {
                 budgetDao.upsertAllHistory(historyEntities)
             }
+            settingsEntities.forEach { budgetDao.upsertSettings(it) }
             caseEntities.forEach { advanceDao.upsertCase(it) }
             if (participantEntities.isNotEmpty()) {
                 advanceDao.upsertParticipants(participantEntities)
@@ -1214,6 +1241,7 @@ class AccountingRepository(
         advanceDao.deleteAllRepayments()
         advanceDao.deleteAllParticipants()
         advanceDao.deleteAllCases()
+        budgetDao.deleteAllSettings()
         budgetDao.deleteAllHistory()
         budgetDao.deleteAll()
         shortcutDao.deleteAllShortcuts()

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/BudgetsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/BudgetsScreen.kt
@@ -60,6 +60,7 @@ import org.duckdns.lhfser.aiaccounting.data.backup.FullBackupData
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.BudgetMonthlyHistoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.BudgetSettingsEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
@@ -80,6 +81,14 @@ private data class BudgetStatus(
     val isOverBudget: Boolean = remaining < BigDecimal.ZERO
 }
 
+private data class BudgetForecast(
+    val projectedSpent: BigDecimal,
+    val projectedRemaining: BigDecimal,
+    val projectedRatio: BigDecimal
+) {
+    val isProjectedOverBudget: Boolean = projectedRemaining < BigDecimal.ZERO
+}
+
 @Composable
 fun BudgetsScreen() {
     val repository = LocalRepository.current
@@ -93,6 +102,7 @@ fun BudgetsScreen() {
 
     val budgets by repository.budgets.collectAsState(initial = emptyList())
     val budgetHistories by repository.budgetHistories.collectAsState(initial = emptyList())
+    val budgetSettings by repository.budgetSettings.collectAsState(initial = null)
     val categories by repository.categories.collectAsState(initial = emptyList())
     val transactions by repository.transactions.collectAsState(initial = emptyList())
 
@@ -139,12 +149,31 @@ fun BudgetsScreen() {
     }
 
     val monthKey = monthKeyFromDate(selectedMonthDate)
+    val effectiveBudgetSettings = budgetSettings ?: BudgetSettingsEntity()
     val statuses = remember(budgets, transactions, categories, currencyService, monthKey) {
         buildBudgetStatuses(budgets, transactions, categories, currencyService, monthKey)
     }
     val visibleStatuses = if (showingOnlyAlerts) {
         statuses.filter { it.ratio >= BigDecimal.ONE }
     } else statuses
+
+    LaunchedEffect(budgetSettings) {
+        if (budgetSettings == null) {
+            repository.upsertBudgetSettings(BudgetSettingsEntity())
+        }
+    }
+
+    LaunchedEffect(monthKey, effectiveBudgetSettings.carryOverMode, budgets, transactions, categories) {
+        applyBudgetCarryOverIfNeeded(
+            repository = repository,
+            settings = effectiveBudgetSettings,
+            selectedMonthDate = selectedMonthDate,
+            budgets = budgets,
+            transactions = transactions,
+            categories = categories,
+            currencyService = currencyService
+        )
+    }
 
     LaunchedEffect(editingBudget, expenseCategories) {
         if (editingBudget == null) {
@@ -194,6 +223,65 @@ fun BudgetsScreen() {
                         }
                         Switch(checked = showingOnlyAlerts, onCheckedChange = { showingOnlyAlerts = it })
                     }
+                }
+            }
+        }
+
+        item {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(AppSpacing.card),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text("預算規則", style = MaterialTheme.typography.titleSmall)
+                    TextButton(onClick = {
+                        scope.launch {
+                            repository.upsertBudgetSettings(
+                                effectiveBudgetSettings.copy(
+                                    carryOverMode = nextCarryOverMode(effectiveBudgetSettings.carryOverMode),
+                                    updatedAt = Instant.now()
+                                )
+                            )
+                        }
+                    }) {
+                        Text("結轉方式：${carryOverModeLabel(effectiveBudgetSettings.carryOverMode)}")
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            "提醒門檻：${effectiveBudgetSettings.alertThresholdPercent.toPlainString()}%",
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        TextButton(onClick = {
+                            scope.launch {
+                                repository.upsertBudgetSettings(
+                                    effectiveBudgetSettings.copy(
+                                        alertThresholdPercent = (effectiveBudgetSettings.alertThresholdPercent - BigDecimal("5")).coerceAtLeast(BigDecimal("50")),
+                                        updatedAt = Instant.now()
+                                    )
+                                )
+                            }
+                        }) { Text("-5") }
+                        TextButton(onClick = {
+                            scope.launch {
+                                repository.upsertBudgetSettings(
+                                    effectiveBudgetSettings.copy(
+                                        alertThresholdPercent = (effectiveBudgetSettings.alertThresholdPercent + BigDecimal("5")).coerceAtMost(BigDecimal("100")),
+                                        updatedAt = Instant.now()
+                                    )
+                                )
+                            }
+                        }) { Text("+5") }
+                    }
+                    Text(
+                        "預測方式：按本月使用速度。${carryOverModeDescription(effectiveBudgetSettings.carryOverMode)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
         }
@@ -511,6 +599,7 @@ fun BudgetsScreen() {
             items(visibleStatuses) { status ->
                 BudgetRow(
                     status = status,
+                    alertThresholdPercent = effectiveBudgetSettings.alertThresholdPercent,
                     onClick = { editingBudget = status.budget },
                     onLongClick = {
                         budgetToDelete = status.budget
@@ -543,14 +632,21 @@ fun BudgetsScreen() {
 }
 
 @Composable
-private fun BudgetRow(status: BudgetStatus, onClick: () -> Unit, onLongClick: () -> Unit) {
+private fun BudgetRow(
+    status: BudgetStatus,
+    alertThresholdPercent: BigDecimal,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
     val progress = status.ratio
         .coerceIn(BigDecimal.ZERO, BigDecimal("1.5"))
         .toFloat()
         .coerceIn(0f, 1.5f)
+    val alertRatio = alertThresholdPercent.divide(BigDecimal("100"), 4, RoundingMode.HALF_UP)
+    val forecast = buildBudgetForecast(status)
     val color = when {
         status.isOverBudget -> MaterialTheme.colorScheme.error
-        status.ratio >= BigDecimal("0.85") -> Color(0xFFFF9800)
+        status.ratio >= alertRatio -> Color(0xFFFF9800)
         else -> Color(0xFF2E7D32)
     }
 
@@ -599,6 +695,23 @@ private fun BudgetRow(status: BudgetStatus, onClick: () -> Unit, onLongClick: ()
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "月底預測：${forecast.projectedSpent.asCurrencyText(status.budget.currencyCode)}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (forecast.isProjectedOverBudget) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    if (forecast.isProjectedOverBudget) {
+                        "預計超支 ${forecast.projectedRemaining.abs().asCurrencyText(status.budget.currencyCode)}"
+                    } else {
+                        "預計剩餘 ${forecast.projectedRemaining.asCurrencyText(status.budget.currencyCode)}"
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (forecast.isProjectedOverBudget) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }
@@ -673,6 +786,117 @@ private fun buildBudgetStatuses(
             categoryName = categoryName
         )
     }.sortedByDescending { it.ratio }
+}
+
+private suspend fun applyBudgetCarryOverIfNeeded(
+    repository: org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository,
+    settings: BudgetSettingsEntity,
+    selectedMonthDate: LocalDate,
+    budgets: List<CategoryMonthlyBudgetEntity>,
+    transactions: List<TransactionWithDetails>,
+    categories: List<CategoryEntity>,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+) {
+    if (settings.carryOverMode == "None") return
+
+    val monthKey = monthKeyFromDate(selectedMonthDate)
+    val previousMonthDate = selectedMonthDate.minusMonths(1).withDayOfMonth(1)
+    val previousMonthKey = monthKeyFromDate(previousMonthDate)
+    val existingCategoryIds = budgets
+        .filter { it.monthKey == monthKey }
+        .mapNotNull { it.categoryId }
+        .toSet()
+
+    val previousStatuses = buildBudgetStatuses(
+        budgets = budgets,
+        transactions = transactions,
+        categories = categories,
+        currencyService = currencyService,
+        monthKey = previousMonthKey
+    )
+    val now = Instant.now()
+
+    previousStatuses.forEach { status ->
+        val categoryId = status.budget.categoryId ?: return@forEach
+        if (categoryId in existingCategoryIds) return@forEach
+
+        val amount = carryOverAmount(
+            previousBudgetAmount = status.budget.amount,
+            previousRemaining = status.remaining,
+            mode = settings.carryOverMode
+        )
+        if (amount <= BigDecimal.ZERO) return@forEach
+
+        repository.upsertBudget(
+            CategoryMonthlyBudgetEntity(
+                id = UUID.randomUUID(),
+                monthKey = monthKey,
+                amount = amount,
+                currencyCode = status.budget.currencyCode,
+                isEnabled = status.budget.isEnabled,
+                createdAt = now,
+                updatedAt = now,
+                categoryId = categoryId
+            )
+        )
+    }
+}
+
+private fun carryOverAmount(
+    previousBudgetAmount: BigDecimal,
+    previousRemaining: BigDecimal,
+    mode: String
+): BigDecimal {
+    return when (mode) {
+        "UnusedOnly" -> previousBudgetAmount + previousRemaining.max(BigDecimal.ZERO)
+        "OverspendOnly" -> (previousBudgetAmount + previousRemaining.min(BigDecimal.ZERO)).max(BigDecimal.ZERO)
+        "NetBalance" -> (previousBudgetAmount + previousRemaining).max(BigDecimal.ZERO)
+        else -> previousBudgetAmount
+    }
+}
+
+private fun buildBudgetForecast(status: BudgetStatus, today: LocalDate = LocalDate.now()): BudgetForecast {
+    val monthStart = monthStartFromKey(status.budget.monthKey)
+    val daysInMonth = monthStart.lengthOfMonth()
+    val projectedSpent = if (monthKeyFromDate(today) == status.budget.monthKey) {
+        val elapsed = today.dayOfMonth.coerceIn(1, daysInMonth)
+        status.spent
+            .divide(BigDecimal(elapsed), 6, RoundingMode.HALF_UP)
+            .multiply(BigDecimal(daysInMonth))
+    } else {
+        status.spent
+    }
+    val projectedRemaining = status.budget.amount - projectedSpent
+    val projectedRatio = if (status.budget.amount > BigDecimal.ZERO) {
+        projectedSpent.divide(status.budget.amount, 6, RoundingMode.HALF_UP)
+    } else {
+        BigDecimal.ZERO
+    }
+    return BudgetForecast(projectedSpent, projectedRemaining, projectedRatio)
+}
+
+private fun nextCarryOverMode(current: String): String {
+    val modes = listOf("None", "UnusedOnly", "OverspendOnly", "NetBalance")
+    val index = modes.indexOf(current).takeIf { it >= 0 } ?: 0
+    return modes[(index + 1) % modes.size]
+}
+
+private fun carryOverModeLabel(mode: String): String {
+    return when (mode) {
+        "UnusedOnly" -> "只結轉剩餘"
+        "OverspendOnly" -> "只扣減超支"
+        "NetBalance" -> "結轉淨額"
+        else -> "不結轉"
+    }
+}
+
+private fun carryOverModeDescription(mode: String): String {
+    return when (mode) {
+        "UnusedOnly" -> "新月份會把上月剩餘金額加到同分類預算。"
+        "OverspendOnly" -> "新月份會扣減上月超支金額。"
+        "NetBalance" -> "新月份會把上月剩餘或超支都結轉。"
+        else -> "新月份不會自動建立預算。"
+    }
 }
 
 private fun monthKeyFromDate(date: LocalDate): String {


### PR DESCRIPTION
## Summary
- add cross-platform budget settings for carry-over mode, alert threshold, and forecast mode
- add month-end budget forecast display and carry-over generation for missing monthly category budgets
- include budget settings in JSON backup/restore with backward-compatible Android decoding

## Testing
- xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO test
- ./gradlew assembleDebug testDebugUnitTest

Closes #38