### PR TITLE
Add settlement center for advances and debts

### DIFF
--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -224,6 +224,9 @@ struct SettingsView: View {
                     NavigationLink(destination: AdvancesView()) {
                         Label("代墊追蹤", systemImage: "person.2.fill")
                     }
+                    NavigationLink(destination: SettlementCenterView()) {
+                        Label("結算中心", systemImage: "person.line.dotted.person")
+                    }
                     NavigationLink(destination: BudgetsView()) {
                         Label("預算與超支提醒", systemImage: "chart.bar.doc.horizontal")
                     }

--- a/AI 記帳/Views/Settlements/SettlementCenterView.swift
+++ b/AI 記帳/Views/Settlements/SettlementCenterView.swift
@@ -1,0 +1,391 @@
+import SwiftUI
+import SwiftData
+
+private enum SettlementCenterMode: String, CaseIterable, Identifiable {
+    case people = "按對象"
+    case cases = "按案件"
+    case timeline = "時間線"
+
+    var id: String { rawValue }
+}
+
+private struct SettlementPersonSummary: Identifiable {
+    let id: UUID
+    let name: String
+    let balances: [SettlementCurrencyBalance]
+    let netBalanceInMainCurrency: Decimal
+    let advanceCaseCount: Int
+    let repaymentCount: Int
+    let forgivenessCount: Int
+}
+
+private struct SettlementCurrencyBalance: Identifiable {
+    let currencyCode: String
+    let amount: Decimal
+
+    var id: String { currencyCode }
+}
+
+private struct SettlementTimelineItem: Identifiable {
+    let id: String
+    let date: Date
+    let title: String
+    let subtitle: String
+    let amount: Decimal?
+    let currencyCode: String
+    let tint: Color
+}
+
+struct SettlementCenterView: View {
+    @Query(sort: \Account.sortOrder) private var accounts: [Account]
+    @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
+    @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
+    @StateObject private var currencyService = CurrencyService.shared
+    @AppStorage("mainCurrency") private var mainCurrency: String = "HKD"
+    @State private var mode: SettlementCenterMode = .people
+
+    private var activeDebtAccounts: [Account] {
+        accounts.filter { $0.type == .debt && !$0.isArchived }
+    }
+
+    private var personSummaries: [SettlementPersonSummary] {
+        activeDebtAccounts.map { account in
+            let participants = advanceCases.flatMap(\.participants).filter { $0.debtAccount?.id == account.id }
+            let repayments = advanceCases.flatMap(\.repayments).filter { $0.participant?.debtAccount?.id == account.id }
+            let forgiveness = transactions.filter {
+                $0.account?.id == account.id && TransactionSemantics.isDebtForgiveness(note: $0.note)
+            }
+            let caseCount = Set(participants.compactMap { $0.advanceCase?.id }).count
+            let balances = balances(for: account)
+            let netInMainCurrency = balances.reduce(Decimal.zero) { partial, balance in
+                partial + currencyService.convert(
+                    amount: balance.amount,
+                    from: balance.currencyCode,
+                    to: mainCurrency
+                )
+            }
+
+            return SettlementPersonSummary(
+                id: account.id,
+                name: account.name,
+                balances: balances,
+                netBalanceInMainCurrency: netInMainCurrency,
+                advanceCaseCount: caseCount,
+                repaymentCount: repayments.count,
+                forgivenessCount: forgiveness.count
+            )
+        }
+        .filter { !$0.balances.isEmpty || $0.advanceCaseCount > 0 || $0.repaymentCount > 0 || $0.forgivenessCount > 0 }
+        .sorted { abs($0.netBalanceInMainCurrency) > abs($1.netBalanceInMainCurrency) }
+    }
+
+    private var activeCaseSummaries: [AdvanceCase] {
+        advanceCases.sorted {
+            let lhsOutstanding = AdvanceService.outstandingAmount(for: $0)
+            let rhsOutstanding = AdvanceService.outstandingAmount(for: $1)
+            if lhsOutstanding == rhsOutstanding {
+                return $0.date > $1.date
+            }
+            return lhsOutstanding > rhsOutstanding
+        }
+    }
+
+    private var timelineItems: [SettlementTimelineItem] {
+        let advanceInitialGroupIDs = Set(advanceCases.flatMap(\.participants).compactMap(\.initialTransferGroupID))
+        let repaymentGroupIDs = Set(advanceCases.flatMap(\.repayments).compactMap(\.linkedTransferGroupID))
+        let advanceGroupIDs = advanceInitialGroupIDs.union(repaymentGroupIDs)
+
+        var items: [SettlementTimelineItem] = advanceCases.map { advanceCase in
+            SettlementTimelineItem(
+                id: "case-\(advanceCase.id.uuidString)",
+                date: advanceCase.date,
+                title: "建立代墊：\(advanceCase.title)",
+                subtitle: "\(advanceCase.participants.count) 位對象，未清 \(AdvanceService.outstandingAmount(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode)))",
+                amount: AdvanceService.totalAdvanced(for: advanceCase),
+                currencyCode: advanceCase.currencyCode,
+                tint: .orange
+            )
+        }
+
+        items += advanceCases.flatMap(\.repayments).map { repayment in
+            SettlementTimelineItem(
+                id: "repayment-\(repayment.id.uuidString)",
+                date: repayment.date,
+                title: "代墊還款：\(repayment.participant?.name ?? "未命名對象")",
+                subtitle: repayment.advanceCase?.title ?? "未連結代墊單",
+                amount: repayment.amount,
+                currencyCode: repayment.currencyCode,
+                tint: .green
+            )
+        }
+
+        items += transactions.compactMap { transaction in
+            guard transaction.account?.type == .debt, transaction.type == .transfer else { return nil }
+            let isForgiveness = TransactionSemantics.isDebtForgiveness(note: transaction.note)
+            if !isForgiveness, let groupID = transaction.transferGroupID, advanceGroupIDs.contains(groupID) {
+                return nil
+            }
+
+            let title: String
+            let tint: Color
+            if isForgiveness {
+                title = TransactionSemantics.debtForgivenessDisplayTitle(note: transaction.note)
+                tint = .purple
+            } else if transaction.amount < 0 {
+                title = "債務增加"
+                tint = .red
+            } else {
+                title = "債務減少"
+                tint = .blue
+            }
+
+            return SettlementTimelineItem(
+                id: "debt-\(transaction.id.uuidString)",
+                date: transaction.date,
+                title: title,
+                subtitle: transaction.account?.name ?? "借貸帳戶",
+                amount: transaction.amount,
+                currencyCode: transaction.currencyCode,
+                tint: tint
+            )
+        }
+
+        return items.sorted { $0.date > $1.date }
+    }
+
+    private var totalNetInMainCurrency: Decimal {
+        personSummaries.reduce(Decimal.zero) { $0 + $1.netBalanceInMainCurrency }
+    }
+
+    private var settlementSummaryText: String {
+        var lines: [String] = [
+            "結算中心摘要",
+            "淨額：\(totalNetInMainCurrency.formatted(.currency(code: mainCurrency)))",
+            ""
+        ]
+        lines += personSummaries.map { summary in
+            let primaryBalance = summary.balances.first
+            let balanceText = primaryBalance.map {
+                $0.amount.formatted(.currency(code: $0.currencyCode))
+            } ?? Decimal.zero.formatted(.currency(code: mainCurrency))
+            return "\(summary.name), \(directionText(for: summary.netBalanceInMainCurrency)), \(balanceText), 代墊案件 \(summary.advanceCaseCount), 還款 \(summary.repaymentCount), 免除 \(summary.forgivenessCount)"
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("整體淨額 (\(mainCurrency))")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(totalNetInMainCurrency.formatted(.currency(code: mainCurrency)))
+                        .font(.system(size: 32, weight: .bold))
+                        .foregroundStyle(totalNetInMainCurrency >= 0 ? .green : .red)
+                    Text("正數代表你待收；負數代表你待還。")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 8)
+            }
+
+            Section {
+                Picker("視角", selection: $mode) {
+                    ForEach(SettlementCenterMode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            switch mode {
+            case .people:
+                peopleSection
+            case .cases:
+                casesSection
+            case .timeline:
+                timelineSection
+            }
+
+            Section("快速動作") {
+                NavigationLink(destination: AdvancesView()) {
+                    Label("前往代墊追蹤", systemImage: "person.2.fill")
+                }
+                NavigationLink(destination: AddDebtView()) {
+                    Label("新增借貸 / 還款 / 免除債務", systemImage: "arrow.left.arrow.right")
+                }
+            }
+        }
+        .prominentInlineTitle("結算中心")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ShareLink(item: settlementSummaryText) {
+                    Label("分享摘要", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
+        .task {
+            await currencyService.fetchRates()
+        }
+    }
+
+    @ViewBuilder
+    private var peopleSection: some View {
+        if personSummaries.isEmpty {
+            Section {
+                ContentUnavailableView(
+                    "沒有待結算對象",
+                    systemImage: "checkmark.circle",
+                    description: Text("代墊、借貸、還款和免除債務都清空後，這裡會保持空白。")
+                )
+            }
+        } else {
+            Section("按對象") {
+                ForEach(personSummaries) { summary in
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(summary.name)
+                                    .font(.headline)
+                                Text(directionText(for: summary.netBalanceInMainCurrency))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            VStack(alignment: .trailing, spacing: 3) {
+                                if let primaryBalance = summary.balances.first {
+                                    Text(primaryBalance.amount.formatted(.currency(code: primaryBalance.currencyCode)))
+                                        .font(.headline)
+                                        .foregroundStyle(primaryBalance.amount >= 0 ? .green : .red)
+                                }
+                                Text(summary.netBalanceInMainCurrency.formatted(.currency(code: mainCurrency)))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        HStack(spacing: 8) {
+                            settlementPill("代墊 \(summary.advanceCaseCount)")
+                            settlementPill("還款 \(summary.repaymentCount)")
+                            settlementPill("免除 \(summary.forgivenessCount)")
+                        }
+
+                        ForEach(summary.balances.dropFirst()) { balance in
+                            Text("\(balance.currencyCode): \(balance.amount.formatted(.currency(code: balance.currencyCode)))")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var casesSection: some View {
+        if activeCaseSummaries.isEmpty {
+            Section {
+                ContentUnavailableView(
+                    "沒有代墊案件",
+                    systemImage: "tray",
+                    description: Text("新增代墊後，案件級結算會出現在這裡。")
+                )
+            }
+        } else {
+            Section("按案件") {
+                ForEach(activeCaseSummaries) { advanceCase in
+                    NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text(advanceCase.title)
+                                    .font(.headline)
+                                Spacer()
+                                Text(AdvanceService.outstandingAmount(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode)))
+                                    .font(.headline)
+                                    .foregroundStyle(AdvanceService.outstandingAmount(for: advanceCase) > 0 ? .orange : .secondary)
+                            }
+                            Text("\(advanceCase.participants.count) 位對象，總額 \(AdvanceService.totalAdvanced(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode)))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(advanceCase.date.formatted(date: .abbreviated, time: .omitted))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var timelineSection: some View {
+        if timelineItems.isEmpty {
+            Section {
+                ContentUnavailableView(
+                    "沒有結算時間線",
+                    systemImage: "clock",
+                    description: Text("代墊、還款、借貸與免除債務紀錄會按時間排列。")
+                )
+            }
+        } else {
+            Section("時間線") {
+                ForEach(timelineItems) { item in
+                    HStack(alignment: .top, spacing: 12) {
+                        Circle()
+                            .fill(item.tint)
+                            .frame(width: 10, height: 10)
+                            .padding(.top, 6)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.title)
+                                .font(.headline)
+                            Text(item.subtitle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(item.date.formatted(date: .abbreviated, time: .shortened))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if let amount = item.amount {
+                            Text(amount.formatted(.currency(code: item.currencyCode)))
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(amount >= 0 ? .green : .red)
+                        }
+                    }
+                    .padding(.vertical, 3)
+                }
+            }
+        }
+    }
+
+    private func directionText(for amount: Decimal) -> String {
+        if amount > 0 { return "對方欠你" }
+        if amount < 0 { return "你欠對方" }
+        return "已結清"
+    }
+
+    private func balances(for account: Account) -> [SettlementCurrencyBalance] {
+        var totals: [String: Decimal] = [:]
+        if account.baseBalance != 0 {
+            totals[account.currency, default: 0] += account.baseBalance
+        }
+        for transaction in transactions where transaction.account?.id == account.id {
+            totals[transaction.currencyCode, default: 0] += transaction.amount
+        }
+        return totals
+            .filter { $0.value != 0 }
+            .sorted { $0.key < $1.key }
+            .map { SettlementCurrencyBalance(currencyCode: $0.key, amount: $0.value) }
+    }
+
+    private func settlementPill(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(uiColor: .secondarySystemBackground), in: Capsule())
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -66,6 +66,7 @@ import org.duckdns.lhfser.aiaccounting.ui.screens.OverviewScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReceiptScanScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReportsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.SettingsScreen
+import org.duckdns.lhfser.aiaccounting.ui.screens.SettlementCenterScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ShortcutEditorScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.TagEditorScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.TagsScreen
@@ -104,6 +105,7 @@ private sealed class AppDestination(
     data object TagEdit : AppDestination("tags/edit/{tagId}", "編輯標籤")
     data object Budgets : AppDestination("budgets", "預算與提醒")
     data object DataHealth : AppDestination("data-health", "資料健康檢查")
+    data object Settlements : AppDestination("settlements", "結算中心")
     data object AccountEdit : AppDestination("accounts/edit/{accountId}", "編輯帳戶")
     data object ShortcutEdit : AppDestination("shortcuts/edit/{shortcutId}", "捷徑")
 }
@@ -257,6 +259,7 @@ fun AIAccountingRoot(
                     onOpenTags = { navController.navigate(AppDestination.Tags.route) },
                     onOpenBudgets = { navController.navigate(AppDestination.Budgets.route) },
                     onOpenAdvances = { navController.navigate("advances") },
+                    onOpenSettlements = { navController.navigate(AppDestination.Settlements.route) },
                     onOpenHealth = { navController.navigate(AppDestination.DataHealth.route) }
                 )
             }
@@ -316,6 +319,12 @@ fun AIAccountingRoot(
             }
             composable("advances") {
                 AdvancesScreen(onOpenCase = { caseId -> navController.navigate("advance/$caseId") })
+            }
+            composable(AppDestination.Settlements.route) {
+                SettlementCenterScreen(
+                    onOpenAdvanceCase = { caseId -> navController.navigate("advance/$caseId") },
+                    onOpenDebt = { navController.navigate(AppDestination.DebtAdd.route) }
+                )
             }
             composable(
                 AppDestination.AdvanceDetail.route,
@@ -499,6 +508,7 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
         route.startsWith("tags/edit") -> "編輯標籤"
         route == AppDestination.Budgets.route -> "預算與提醒"
         route == AppDestination.DataHealth.route -> "資料健康檢查"
+        route == AppDestination.Settlements.route -> "結算中心"
         route.startsWith("accounts/edit") -> "編輯帳戶"
         route.startsWith("accounts/") -> "帳戶明細"
         route.startsWith("shortcuts/edit") -> "捷徑"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -53,6 +53,7 @@ fun SettingsScreen(
     onOpenTags: () -> Unit,
     onOpenBudgets: () -> Unit,
     onOpenAdvances: () -> Unit,
+    onOpenSettlements: () -> Unit,
     onOpenHealth: () -> Unit
 ) {
     val repository = LocalRepository.current
@@ -188,6 +189,7 @@ fun SettingsScreen(
                 ParitySettingRow("分類管理", "支援收入 / 支出 / 兩者", onClick = onOpenCategories)
                 ParitySettingRow("標籤管理", "用於快速篩選與統計", onClick = onOpenTags)
                 ParitySettingRow("代墊追蹤", "查看待還款與還款紀錄", onClick = onOpenAdvances)
+                ParitySettingRow("結算中心", "集中查看代墊、借貸、還款與免除債務", onClick = onOpenSettlements)
                 ParitySettingRow("預算與超支提醒", "設定每月分類預算與 AI 建議", onClick = onOpenBudgets)
                 ParitySettingRow("資料健康檢查", "檢查缺失分類、帳戶與歷史異常", onClick = onOpenHealth)
             }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
@@ -1,0 +1,501 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Timeline
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+private enum class SettlementMode(val label: String) {
+    People("按對象"),
+    Cases("按案件"),
+    Timeline("時間線")
+}
+
+private data class SettlementPersonSummary(
+    val account: AccountEntity,
+    val balances: List<SettlementCurrencyBalance>,
+    val netInMainCurrency: BigDecimal,
+    val advanceCaseCount: Int,
+    val repaymentCount: Int,
+    val forgivenessCount: Int
+)
+
+private data class SettlementCurrencyBalance(
+    val currency: String,
+    val amount: BigDecimal
+)
+
+private data class TimelineItem(
+    val id: String,
+    val date: Instant,
+    val title: String,
+    val subtitle: String,
+    val amount: BigDecimal?,
+    val currencyCode: String,
+    val tint: Color
+)
+
+@Composable
+fun SettlementCenterScreen(
+    onOpenAdvanceCase: (String) -> Unit,
+    onOpenDebt: () -> Unit
+) {
+    val repository = LocalRepository.current
+    val currencyService = LocalCurrencyService.current
+    val context = LocalContext.current
+
+    val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val transactions by repository.transactions.collectAsState(initial = emptyList())
+    val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
+    val mainCurrency = currencyService.mainCurrency
+    val rateSnapshot = currencyService.rates
+    var mode by rememberSaveable { mutableStateOf(SettlementMode.People) }
+
+    val personSummaries = remember(accounts, transactions, advanceCases, mainCurrency, rateSnapshot) {
+        buildPersonSummaries(accounts, transactions, advanceCases, currencyService, mainCurrency)
+    }
+    val totalNet = remember(personSummaries) {
+        personSummaries.fold(BigDecimal.ZERO) { acc, summary -> acc + summary.netInMainCurrency }
+    }
+    val caseSummaries = remember(advanceCases) {
+        advanceCases.sortedWith(
+            compareByDescending<AdvanceCaseWithDetails> { outstandingAmount(it) }
+                .thenByDescending { it.advanceCase.date }
+        )
+    }
+    val timelineItems = remember(transactions, advanceCases) {
+        buildTimelineItems(transactions, advanceCases)
+    }
+    val shareText = remember(personSummaries, totalNet, mainCurrency) {
+        buildShareText(personSummaries, totalNet, mainCurrency)
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+            start = AppSpacing.screenHorizontal,
+            end = AppSpacing.screenHorizontal,
+            top = AppSpacing.screenVertical,
+            bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+        ),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        item {
+            ParityTopSection(
+                title = "結算中心",
+                subtitle = "集中查看代墊、借貸、還款與免除債務。",
+                accessory = {
+                    TextButton(onClick = {
+                        val intent = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, shareText)
+                        }
+                        context.startActivity(Intent.createChooser(intent, "分享結算摘要"))
+                    }) {
+                        Text("分享")
+                    }
+                }
+            )
+        }
+
+        item {
+            ParitySummaryCard(
+                title = "整體淨額 ($mainCurrency)",
+                value = totalNet.asCurrencyText(mainCurrency),
+                supporting = "正數代表你待收；負數代表你待還。"
+            )
+        }
+
+        item {
+            ParitySegmentedControl(
+                options = SettlementMode.values().toList(),
+                selected = mode,
+                label = { it.label },
+                onSelect = { mode = it }
+            )
+        }
+
+        when (mode) {
+            SettlementMode.People -> {
+                if (personSummaries.isEmpty()) {
+                    item {
+                        ParityEmptyState(
+                            title = "沒有待結算對象",
+                            message = "代墊、借貸、還款和免除債務都清空後，這裡會保持空白。",
+                            icon = Icons.Default.CheckCircle
+                        )
+                    }
+                } else {
+                    items(personSummaries, key = { it.account.id }) { summary ->
+                        PersonSummaryCard(summary = summary, mainCurrency = mainCurrency)
+                    }
+                }
+            }
+            SettlementMode.Cases -> {
+                if (caseSummaries.isEmpty()) {
+                    item {
+                        ParityEmptyState(
+                            title = "沒有代墊案件",
+                            message = "新增代墊後，案件級結算會出現在這裡。",
+                            icon = Icons.Default.Groups
+                        )
+                    }
+                } else {
+                    items(caseSummaries, key = { it.advanceCase.id }) { advanceCase ->
+                        CaseSummaryCard(
+                            advanceCase = advanceCase,
+                            onClick = { onOpenAdvanceCase(advanceCase.advanceCase.id.toString()) }
+                        )
+                    }
+                }
+            }
+            SettlementMode.Timeline -> {
+                if (timelineItems.isEmpty()) {
+                    item {
+                        ParityEmptyState(
+                            title = "沒有結算時間線",
+                            message = "代墊、還款、借貸與免除債務紀錄會按時間排列。",
+                            icon = Icons.Default.Timeline
+                        )
+                    }
+                } else {
+                    items(timelineItems, key = { it.id }) { item ->
+                        TimelineCard(item = item)
+                    }
+                }
+            }
+        }
+
+        item {
+            PressableCard(modifier = Modifier.fillMaxWidth(), onClick = onOpenDebt) {
+                Row(
+                    modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text("新增借貸 / 還款 / 免除債務", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                        Text("快速跳轉到債務管理流程。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PersonSummaryCard(summary: SettlementPersonSummary, mainCurrency: String) {
+    val primaryBalance = summary.balances.firstOrNull()
+    PressableCard(modifier = Modifier.fillMaxWidth(), onClick = {}) {
+        Column(
+            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 15.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(summary.account.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(directionText(summary.netInMainCurrency), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    if (primaryBalance != null) {
+                        Text(
+                            primaryBalance.amount.asCurrencyText(primaryBalance.currency),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = amountColor(primaryBalance.amount)
+                        )
+                    }
+                    Text(
+                        summary.netInMainCurrency.asCurrencyText(mainCurrency),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ParityStatusPill("代墊 ${summary.advanceCaseCount}", tint = MaterialTheme.colorScheme.tertiary)
+                ParityStatusPill("還款 ${summary.repaymentCount}", tint = MaterialTheme.colorScheme.primary)
+                ParityStatusPill("免除 ${summary.forgivenessCount}", tint = MaterialTheme.colorScheme.secondary)
+            }
+            summary.balances.drop(1).forEach { balance ->
+                Text(
+                    "${balance.currency}: ${balance.amount.asCurrencyText(balance.currency)}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CaseSummaryCard(advanceCase: AdvanceCaseWithDetails, onClick: () -> Unit) {
+    val outstanding = outstandingAmount(advanceCase)
+    val total = totalAdvanced(advanceCase)
+    PressableCard(modifier = Modifier.fillMaxWidth(), onClick = onClick) {
+        Column(
+            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 15.dp),
+            verticalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(advanceCase.advanceCase.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text("${advanceCase.participants.size} 位對象 · ${advanceCase.advanceCase.date.toDateText()}", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text("未清", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(outstanding.asCurrencyText(advanceCase.advanceCase.currencyCode), style = MaterialTheme.typography.titleSmall, color = amountColor(outstanding))
+                }
+            }
+            Text("總額 ${total.asCurrencyText(advanceCase.advanceCase.currencyCode)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun TimelineCard(item: TimelineItem) {
+    PressableCard(modifier = Modifier.fillMaxWidth(), onClick = {}) {
+        Row(
+            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("●", color = item.tint, style = MaterialTheme.typography.titleMedium)
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(item.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(item.subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(item.date.toDateText(), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (item.amount != null) {
+                Text(
+                    item.amount.asCurrencyText(item.currencyCode),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = amountColor(item.amount)
+                )
+            }
+        }
+    }
+}
+
+private fun buildPersonSummaries(
+    accounts: List<AccountEntity>,
+    transactions: List<TransactionWithDetails>,
+    advanceCases: List<AdvanceCaseWithDetails>,
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
+    mainCurrency: String
+): List<SettlementPersonSummary> {
+    val debtAccounts = accounts.filter { it.type == AccountType.Debt && !it.isArchived }
+    val balancesByAccount = calculateDebtBalances(debtAccounts, transactions)
+    val forgivenessByAccount = transactions
+        .filter { it.account?.type == AccountType.Debt && TransactionSemantics.isDebtForgiveness(it.transaction.note) }
+        .groupingBy { it.account?.id }
+        .eachCount()
+    val participantsByAccount = advanceCases
+        .flatMap { advanceCase -> advanceCase.participants.map { participant -> advanceCase to participant } }
+        .groupBy { it.second.debtAccountId }
+    val repaymentsByAccount = advanceCases
+        .flatMap { advanceCase -> advanceCase.repayments.mapNotNull { repayment ->
+            val participant = advanceCase.participants.firstOrNull { it.id == repayment.participantId }
+            val debtAccountId = participant?.debtAccountId ?: return@mapNotNull null
+            debtAccountId to repayment
+        } }
+        .groupBy { it.first }
+
+    return debtAccounts.map { account ->
+        val balances = balancesByAccount[account.id].orEmpty()
+        val netInMain = balances.fold(BigDecimal.ZERO) { acc, balance ->
+            acc + currencyService.convert(balance.amount, balance.currency, mainCurrency)
+        }
+        val caseCount = participantsByAccount[account.id].orEmpty().map { it.first.advanceCase.id }.toSet().size
+        val repaymentCount = repaymentsByAccount[account.id].orEmpty().size
+        SettlementPersonSummary(
+            account = account,
+            balances = balances,
+            netInMainCurrency = netInMain,
+            advanceCaseCount = caseCount,
+            repaymentCount = repaymentCount,
+            forgivenessCount = forgivenessByAccount[account.id] ?: 0
+        )
+    }
+        .filter { it.netInMainCurrency != BigDecimal.ZERO || it.advanceCaseCount > 0 || it.repaymentCount > 0 || it.forgivenessCount > 0 }
+        .sortedByDescending { it.netInMainCurrency.abs() }
+}
+
+private fun calculateDebtBalances(
+    accounts: List<AccountEntity>,
+    transactions: List<TransactionWithDetails>
+): Map<UUID, List<SettlementCurrencyBalance>> {
+    val grouped = transactions.groupBy { it.transaction.accountId }
+    return accounts.associate { account ->
+        val totals = linkedMapOf<String, BigDecimal>()
+        if (account.baseBalance != BigDecimal.ZERO) {
+            totals[account.currency] = account.baseBalance
+        }
+        grouped[account.id].orEmpty().forEach { tx ->
+            val currency = tx.transaction.currencyCode
+            totals[currency] = totals.getOrDefault(currency, BigDecimal.ZERO) + tx.transaction.amount
+        }
+        account.id to totals.entries
+            .filter { it.value != BigDecimal.ZERO }
+            .sortedBy { it.key }
+            .map { SettlementCurrencyBalance(it.key, it.value) }
+    }
+}
+
+private fun buildTimelineItems(
+    transactions: List<TransactionWithDetails>,
+    advanceCases: List<AdvanceCaseWithDetails>
+): List<TimelineItem> {
+    val advanceGroupIds = advanceCases
+        .flatMap { advanceCase ->
+            advanceCase.participants.mapNotNull { it.initialTransferGroupId } +
+                advanceCase.repayments.mapNotNull { it.linkedTransferGroupId }
+        }
+        .toSet()
+
+    val items = mutableListOf<TimelineItem>()
+    advanceCases.forEach { advanceCase ->
+        items += TimelineItem(
+            id = "case-${advanceCase.advanceCase.id}",
+            date = advanceCase.advanceCase.date,
+            title = "建立代墊：${advanceCase.advanceCase.title}",
+            subtitle = "${advanceCase.participants.size} 位對象，未清 ${outstandingAmount(advanceCase).asCurrencyText(advanceCase.advanceCase.currencyCode)}",
+            amount = totalAdvanced(advanceCase),
+            currencyCode = advanceCase.advanceCase.currencyCode,
+            tint = Color(0xFFFF9800)
+        )
+        advanceCase.repayments.forEach { repayment ->
+            val participant = advanceCase.participants.firstOrNull { it.id == repayment.participantId }
+            items += TimelineItem(
+                id = "repayment-${repayment.id}",
+                date = repayment.date,
+                title = "代墊還款：${participant?.name ?: "未命名對象"}",
+                subtitle = advanceCase.advanceCase.title,
+                amount = repayment.amount,
+                currencyCode = repayment.currencyCode,
+                tint = Color(0xFF2E7D32)
+            )
+        }
+    }
+
+    transactions.forEach { tx ->
+        val transaction = tx.transaction
+        if (tx.account?.type != AccountType.Debt || transaction.type != TransactionType.Transfer) return@forEach
+        val isForgiveness = TransactionSemantics.isDebtForgiveness(transaction.note)
+        if (!isForgiveness && transaction.transferGroupId != null && transaction.transferGroupId in advanceGroupIds) return@forEach
+        items += TimelineItem(
+            id = "debt-${transaction.id}",
+            date = transaction.date,
+            title = when {
+                isForgiveness -> TransactionSemantics.debtForgivenessDisplayTitle(transaction.note)
+                transaction.amount.signum() < 0 -> "債務增加"
+                else -> "債務減少"
+            },
+            subtitle = tx.account.name,
+            amount = transaction.amount,
+            currencyCode = transaction.currencyCode,
+            tint = when {
+                isForgiveness -> Color(0xFF8E24AA)
+                transaction.amount.signum() < 0 -> Color(0xFFD32F2F)
+                else -> Color(0xFF1976D2)
+            }
+        )
+    }
+
+    return items.sortedByDescending { it.date }
+}
+
+private fun outstandingAmount(advanceCase: AdvanceCaseWithDetails): BigDecimal {
+    return advanceCase.participants.fold(BigDecimal.ZERO) { acc, participant ->
+        acc + (participant.owedAmount - participant.repaidAmount).max(BigDecimal.ZERO)
+    }
+}
+
+private fun totalAdvanced(advanceCase: AdvanceCaseWithDetails): BigDecimal {
+    return advanceCase.advanceCase.myShareAmount + advanceCase.participants.fold(BigDecimal.ZERO) { acc, participant ->
+        acc + participant.owedAmount
+    }
+}
+
+private fun buildShareText(
+    summaries: List<SettlementPersonSummary>,
+    totalNet: BigDecimal,
+    mainCurrency: String
+): String {
+    return buildString {
+        appendLine("結算中心摘要")
+        appendLine("淨額：${totalNet.asCurrencyText(mainCurrency)}")
+        appendLine()
+        summaries.forEach { summary ->
+            val firstBalance = summary.balances.firstOrNull()
+            appendLine(
+                "${summary.account.name}, ${directionText(summary.netInMainCurrency)}, " +
+                    "${firstBalance?.amount?.asCurrencyText(firstBalance.currency) ?: BigDecimal.ZERO.asCurrencyText(summary.account.currency)}, " +
+                    "代墊 ${summary.advanceCaseCount}, 還款 ${summary.repaymentCount}, 免除 ${summary.forgivenessCount}"
+            )
+        }
+    }
+}
+
+private fun directionText(amount: BigDecimal): String {
+    return when {
+        amount.signum() > 0 -> "對方欠你"
+        amount.signum() < 0 -> "你欠對方"
+        else -> "已結清"
+    }
+}
+
+@Composable
+private fun amountColor(amount: BigDecimal): Color {
+    return when {
+        amount.signum() > 0 -> Color(0xFF2E7D32)
+        amount.signum() < 0 -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+}


### PR DESCRIPTION
## Summary
- add a cross-platform settlement center for advances, debts, repayments, and debt forgiveness
- support person, case, and timeline views with outstanding/net summaries
- add share/export text summary and quick jump into existing settlement flows
- keep this as a display/navigation layer without database schema changes

## Testing
- xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
- ./gradlew assembleDebug testDebugUnitTest

Closes #39