### PR TITLE
[codex] Add recurring transaction rules

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -192,6 +192,8 @@ struct AI___App: App {
             Category.self,
             Tag.self,
             Shortcut.self,
+            RecurringRule.self,
+            RecurringOccurrence.self,
             CategoryMonthlyBudget.self,
             BudgetMonthlyHistory.self,
             BudgetSettings.self,

--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -15,6 +15,8 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Query(sort: \CategoryMonthlyBudget.updatedAt, order: .reverse) private var budgets: [CategoryMonthlyBudget]
     @Query(sort: \FinancialTransaction.updatedAt, order: .reverse) private var transactions: [FinancialTransaction]
+    @Query(sort: \RecurringRule.updatedAt, order: .reverse) private var recurringRules: [RecurringRule]
+    @Query(sort: \RecurringOccurrence.updatedAt, order: .reverse) private var recurringOccurrences: [RecurringOccurrence]
 
     @State private var selectedTab: RootTab = .ledger
     @State private var showingAddOptions = false
@@ -56,6 +58,22 @@ struct ContentView: View {
             hasher.combine(transaction.category?.id)
         }
 
+        return hasher.finalize()
+    }
+
+    private var recurringSyncToken: Int {
+        var hasher = Hasher()
+        for rule in recurringRules {
+            hasher.combine(rule.id)
+            hasher.combine(rule.nextDueDate.timeIntervalSince1970)
+            hasher.combine(rule.isPaused)
+            hasher.combine(rule.updatedAt.timeIntervalSince1970)
+        }
+        for occurrence in recurringOccurrences {
+            hasher.combine(occurrence.id)
+            hasher.combine(occurrence.statusRaw)
+            hasher.combine(occurrence.updatedAt.timeIntervalSince1970)
+        }
         return hasher.finalize()
     }
 
@@ -157,6 +175,7 @@ struct ContentView: View {
             case .active:
                 idleBackupTask?.cancel()
                 idleBackupTask = nil
+                syncRecurringOccurrences()
             case .inactive, .background:
                 scheduleIdleAutoBackup()
             @unknown default:
@@ -184,6 +203,10 @@ struct ContentView: View {
             } catch {
                 print("⚠️ 預算歷史同步失敗: \(error)")
             }
+        }
+        .task(id: recurringSyncToken) {
+            guard !isRunningXCTest else { return }
+            syncRecurringOccurrences()
         }
     }
 
@@ -221,6 +244,18 @@ struct ContentView: View {
             guard !Task.isCancelled, scenePhase != .active else { return }
             BackupManager.shared.performAutoBackup(modelContext: modelContext)
             idleBackupTask = nil
+        }
+    }
+
+    private func syncRecurringOccurrences() {
+        do {
+            try RecurringTransactionService.syncDueOccurrences(
+                rules: recurringRules,
+                occurrences: recurringOccurrences,
+                modelContext: modelContext
+            )
+        } catch {
+            print("⚠️ 定期記帳同步失敗: \(error)")
         }
     }
 }

--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -89,6 +89,38 @@ enum BudgetForecastMode: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+enum RecurringFrequency: String, Codable, CaseIterable, Identifiable {
+    case daily = "Daily"
+    case weekly = "Weekly"
+    case monthly = "Monthly"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .daily: return "每日"
+        case .weekly: return "每週"
+        case .monthly: return "每月"
+        }
+    }
+}
+
+enum RecurringOccurrenceStatus: String, Codable, CaseIterable, Identifiable {
+    case pending = "Pending"
+    case confirmed = "Confirmed"
+    case skipped = "Skipped"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .pending: return "待確認"
+        case .confirmed: return "已建立"
+        case .skipped: return "已跳過"
+        }
+    }
+}
+
 // MARK: - Models
 
 @Model
@@ -232,6 +264,108 @@ final class Shortcut {
         self.account = account
         self.category = category
         self.tags = tags
+    }
+}
+
+@Model
+final class RecurringRule {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var amount: Decimal
+    var currencyCode: String
+    var type: TransactionType
+    var note: String
+    var frequencyRaw: String
+    var intervalCount: Int
+    var nextDueDate: Date
+    var isPaused: Bool
+    var createdAt: Date
+    var updatedAt: Date
+
+    var account: Account?
+    var category: Category?
+    var tags: [Tag] = []
+    @Relationship(deleteRule: .cascade, inverse: \RecurringOccurrence.rule)
+    var occurrences: [RecurringOccurrence] = []
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        amount: Decimal,
+        currencyCode: String = "HKD",
+        type: TransactionType,
+        note: String = "",
+        frequency: RecurringFrequency = .monthly,
+        intervalCount: Int = 1,
+        nextDueDate: Date = Date(),
+        isPaused: Bool = false,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        account: Account? = nil,
+        category: Category? = nil,
+        tags: [Tag] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.amount = amount
+        self.currencyCode = currencyCode
+        self.type = type
+        self.note = note
+        self.frequencyRaw = frequency.rawValue
+        self.intervalCount = max(1, intervalCount)
+        self.nextDueDate = nextDueDate
+        self.isPaused = isPaused
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.account = account
+        self.category = category
+        self.tags = tags
+    }
+
+    var frequency: RecurringFrequency {
+        get { RecurringFrequency(rawValue: frequencyRaw) ?? .monthly }
+        set {
+            frequencyRaw = newValue.rawValue
+            updatedAt = Date()
+        }
+    }
+}
+
+@Model
+final class RecurringOccurrence {
+    @Attribute(.unique) var id: UUID
+    var dueDate: Date
+    var statusRaw: String
+    var createdTransactionID: UUID?
+    var createdAt: Date
+    var updatedAt: Date
+
+    var rule: RecurringRule?
+
+    init(
+        id: UUID = UUID(),
+        dueDate: Date,
+        status: RecurringOccurrenceStatus = .pending,
+        createdTransactionID: UUID? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        rule: RecurringRule? = nil
+    ) {
+        self.id = id
+        self.dueDate = dueDate
+        self.statusRaw = status.rawValue
+        self.createdTransactionID = createdTransactionID
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.rule = rule
+    }
+
+    var status: RecurringOccurrenceStatus {
+        get { RecurringOccurrenceStatus(rawValue: statusRaw) ?? .pending }
+        set {
+            statusRaw = newValue.rawValue
+            updatedAt = Date()
+        }
     }
 }
 

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -13,6 +13,8 @@ struct FullBackupData: Codable {
     let tags: [TagCodable]
     let transactions: [TransactionCodable]
     let shortcuts: [ShortcutCodable]
+    let recurringRules: [RecurringRuleCodable]?
+    let recurringOccurrences: [RecurringOccurrenceCodable]?
     let budgets: [BudgetCodable]?
     let budgetHistory: [BudgetHistoryCodable]?
     let budgetSettings: [BudgetSettingsCodable]?
@@ -47,6 +49,32 @@ struct FullBackupData: Codable {
         // 🔥 新增 Optional，兼容舊 JSON
         let currencyCode: String?
         let accountID: UUID?; let categoryID: UUID?; let tagIDs: [UUID]
+    }
+    struct RecurringRuleCodable: Codable {
+        let id: UUID
+        let title: String
+        let amount: Decimal
+        let currencyCode: String
+        let type: String
+        let note: String
+        let frequency: String
+        let intervalCount: Int
+        let nextDueDate: Date
+        let isPaused: Bool
+        let accountID: UUID?
+        let categoryID: UUID?
+        let tagIDs: [UUID]
+        let createdAt: Date?
+        let updatedAt: Date?
+    }
+    struct RecurringOccurrenceCodable: Codable {
+        let id: UUID
+        let dueDate: Date
+        let status: String
+        let createdTransactionID: UUID?
+        let ruleID: UUID?
+        let createdAt: Date?
+        let updatedAt: Date?
     }
     struct BudgetCodable: Codable {
         let id: UUID
@@ -180,6 +208,8 @@ class BackupManager: NSObject, ObservableObject {
         let tags = (try? modelContext.fetch(FetchDescriptor<Tag>())) ?? []
         let transactions = (try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []
         let shortcuts = (try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []
+        let recurringRules = (try? modelContext.fetch(FetchDescriptor<RecurringRule>())) ?? []
+        let recurringOccurrences = (try? modelContext.fetch(FetchDescriptor<RecurringOccurrence>())) ?? []
         let budgets = (try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []
         let budgetHistory = (try? modelContext.fetch(FetchDescriptor<BudgetMonthlyHistory>())) ?? []
         let budgetSettings = (try? modelContext.fetch(FetchDescriptor<BudgetSettings>())) ?? []
@@ -187,7 +217,7 @@ class BackupManager: NSObject, ObservableObject {
         let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
         let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
         
-        return FullBackupData(version: "1.7", timestamp: Date(),
+        return FullBackupData(version: "1.8", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
             categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
@@ -211,6 +241,36 @@ class BackupManager: NSObject, ObservableObject {
                 )
             },
             shortcuts: shortcuts.map { FullBackupData.ShortcutCodable(id: $0.id, name: $0.name, icon: $0.icon, amount: $0.amount, type: $0.type.rawValue, note: $0.note, currencyCode: $0.currencyCode, accountID: $0.account?.id, categoryID: $0.category?.id, tagIDs: $0.tags.map { $0.id }) },
+            recurringRules: recurringRules.map {
+                FullBackupData.RecurringRuleCodable(
+                    id: $0.id,
+                    title: $0.title,
+                    amount: $0.amount,
+                    currencyCode: $0.currencyCode,
+                    type: $0.type.rawValue,
+                    note: $0.note,
+                    frequency: $0.frequencyRaw,
+                    intervalCount: $0.intervalCount,
+                    nextDueDate: $0.nextDueDate,
+                    isPaused: $0.isPaused,
+                    accountID: $0.account?.id,
+                    categoryID: $0.category?.id,
+                    tagIDs: $0.tags.map(\.id),
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            },
+            recurringOccurrences: recurringOccurrences.map {
+                FullBackupData.RecurringOccurrenceCodable(
+                    id: $0.id,
+                    dueDate: $0.dueDate,
+                    status: $0.statusRaw,
+                    createdTransactionID: $0.createdTransactionID,
+                    ruleID: $0.rule?.id,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            },
             budgets: budgets.map {
                 FullBackupData.BudgetCodable(
                     id: $0.id,
@@ -315,6 +375,8 @@ class BackupManager: NSObject, ObservableObject {
         var tagByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<Tag>())) ?? []).map { ($0.id, $0) })
         var existingTransactionIDs = Set(((try? modelContext.fetch(FetchDescriptor<FinancialTransaction>())) ?? []).map(\.id))
         var existingShortcutIDs = Set(((try? modelContext.fetch(FetchDescriptor<Shortcut>())) ?? []).map(\.id))
+        var recurringRuleByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<RecurringRule>())) ?? []).map { ($0.id, $0) })
+        var recurringOccurrenceByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<RecurringOccurrence>())) ?? []).map { ($0.id, $0) })
         var existingBudgetIDs = Set(((try? modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())) ?? []).map(\.id))
         var historyByKey = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<BudgetMonthlyHistory>())) ?? []).map { ($0.historyKey, $0) })
         var budgetSettingsByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<BudgetSettings>())) ?? []).map { ($0.id, $0) })
@@ -394,6 +456,73 @@ class BackupManager: NSObject, ObservableObject {
             )
             modelContext.insert(shortcut)
             existingShortcutIDs.insert(scDTO.id)
+        }
+
+        if let ruleDTOs = backup.recurringRules {
+            for ruleDTO in ruleDTOs {
+                let tagIDs = Set(ruleDTO.tagIDs)
+                if let existing = recurringRuleByID[ruleDTO.id] {
+                    existing.title = ruleDTO.title
+                    existing.amount = ruleDTO.amount
+                    existing.currencyCode = ruleDTO.currencyCode
+                    existing.type = TransactionType(rawValue: ruleDTO.type) ?? .expense
+                    existing.note = ruleDTO.note
+                    existing.frequencyRaw = ruleDTO.frequency
+                    existing.intervalCount = max(1, ruleDTO.intervalCount)
+                    existing.nextDueDate = ruleDTO.nextDueDate
+                    existing.isPaused = ruleDTO.isPaused
+                    existing.account = ruleDTO.accountID.flatMap { accountByID[$0] }
+                    existing.category = ruleDTO.categoryID.flatMap { categoryByID[$0] }
+                    existing.tags = tagByID.values.filter { tagIDs.contains($0.id) }
+                    existing.updatedAt = ruleDTO.updatedAt ?? Date()
+                    continue
+                }
+
+                let rule = RecurringRule(
+                    id: ruleDTO.id,
+                    title: ruleDTO.title,
+                    amount: ruleDTO.amount,
+                    currencyCode: ruleDTO.currencyCode,
+                    type: TransactionType(rawValue: ruleDTO.type) ?? .expense,
+                    note: ruleDTO.note,
+                    frequency: RecurringFrequency(rawValue: ruleDTO.frequency) ?? .monthly,
+                    intervalCount: max(1, ruleDTO.intervalCount),
+                    nextDueDate: ruleDTO.nextDueDate,
+                    isPaused: ruleDTO.isPaused,
+                    createdAt: ruleDTO.createdAt ?? Date(),
+                    updatedAt: ruleDTO.updatedAt ?? (ruleDTO.createdAt ?? Date()),
+                    account: ruleDTO.accountID.flatMap { accountByID[$0] },
+                    category: ruleDTO.categoryID.flatMap { categoryByID[$0] },
+                    tags: tagByID.values.filter { tagIDs.contains($0.id) }
+                )
+                modelContext.insert(rule)
+                recurringRuleByID[ruleDTO.id] = rule
+            }
+        }
+
+        if let occurrenceDTOs = backup.recurringOccurrences {
+            for occurrenceDTO in occurrenceDTOs {
+                if let existing = recurringOccurrenceByID[occurrenceDTO.id] {
+                    existing.dueDate = occurrenceDTO.dueDate
+                    existing.statusRaw = occurrenceDTO.status
+                    existing.createdTransactionID = occurrenceDTO.createdTransactionID
+                    existing.rule = occurrenceDTO.ruleID.flatMap { recurringRuleByID[$0] }
+                    existing.updatedAt = occurrenceDTO.updatedAt ?? Date()
+                    continue
+                }
+
+                let occurrence = RecurringOccurrence(
+                    id: occurrenceDTO.id,
+                    dueDate: occurrenceDTO.dueDate,
+                    status: RecurringOccurrenceStatus(rawValue: occurrenceDTO.status) ?? .pending,
+                    createdTransactionID: occurrenceDTO.createdTransactionID,
+                    createdAt: occurrenceDTO.createdAt ?? Date(),
+                    updatedAt: occurrenceDTO.updatedAt ?? (occurrenceDTO.createdAt ?? Date()),
+                    rule: occurrenceDTO.ruleID.flatMap { recurringRuleByID[$0] }
+                )
+                modelContext.insert(occurrence)
+                recurringOccurrenceByID[occurrenceDTO.id] = occurrence
+            }
         }
 
         if let budgetDTOs = backup.budgets {

--- a/AI 記帳/Services/RecurringTransactionService.swift
+++ b/AI 記帳/Services/RecurringTransactionService.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftData
+
+enum RecurringTransactionError: LocalizedError {
+    case missingRule
+    case missingAccount
+    case invalidType
+
+    var errorDescription: String? {
+        switch self {
+        case .missingRule:
+            return "找不到對應的定期規則。"
+        case .missingAccount:
+            return "此規則缺少帳戶，請先編輯規則。"
+        case .invalidType:
+            return "定期記帳 v1 只支援收入與支出。"
+        }
+    }
+}
+
+enum RecurringTransactionService {
+    static func syncDueOccurrences(
+        rules: [RecurringRule],
+        occurrences: [RecurringOccurrence],
+        now: Date = Date(),
+        modelContext: ModelContext
+    ) throws {
+        for rule in rules where !rule.isPaused {
+            guard rule.type == .income || rule.type == .expense else { continue }
+
+            var dueDate = rule.nextDueDate
+            var generatedCount = 0
+            let existingDueDates = occurrences
+                .filter { $0.rule?.id == rule.id }
+                .map(\.dueDate)
+
+            while dueDate <= now, generatedCount < 24 {
+                let alreadyExists = existingDueDates.contains { Calendar.current.isDate($0, equalTo: dueDate, toGranularity: .minute) }
+                if !alreadyExists {
+                    let occurrence = RecurringOccurrence(dueDate: dueDate, rule: rule)
+                    modelContext.insert(occurrence)
+                }
+
+                dueDate = nextDate(after: dueDate, frequency: rule.frequency, intervalCount: rule.intervalCount)
+                generatedCount += 1
+            }
+
+            if dueDate != rule.nextDueDate {
+                rule.nextDueDate = dueDate
+                rule.updatedAt = now
+            }
+        }
+
+        try modelContext.save()
+    }
+
+    @discardableResult
+    static func confirm(
+        occurrence: RecurringOccurrence,
+        modelContext: ModelContext
+    ) throws -> FinancialTransaction {
+        guard let rule = occurrence.rule else { throw RecurringTransactionError.missingRule }
+        guard rule.type == .income || rule.type == .expense else { throw RecurringTransactionError.invalidType }
+        guard let account = rule.account else { throw RecurringTransactionError.missingAccount }
+
+        if let createdID = occurrence.createdTransactionID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.id == createdID }
+            )
+            if let existing = try modelContext.fetch(descriptor).first {
+                occurrence.status = .confirmed
+                try modelContext.save()
+                return existing
+            }
+        }
+
+        let signedAmount = rule.type == .expense ? -abs(rule.amount) : abs(rule.amount)
+        let transaction = FinancialTransaction(
+            amount: signedAmount,
+            currencyCode: rule.currencyCode,
+            date: occurrence.dueDate,
+            note: rule.note.isEmpty ? rule.title : rule.note,
+            type: rule.type,
+            account: account,
+            category: rule.category,
+            tags: rule.tags
+        )
+        modelContext.insert(transaction)
+        occurrence.createdTransactionID = transaction.id
+        occurrence.status = .confirmed
+        rule.updatedAt = Date()
+        try modelContext.save()
+        return transaction
+    }
+
+    static func skip(
+        occurrence: RecurringOccurrence,
+        modelContext: ModelContext
+    ) throws {
+        occurrence.status = .skipped
+        occurrence.updatedAt = Date()
+        try modelContext.save()
+    }
+
+    static func nextDate(after date: Date, frequency: RecurringFrequency, intervalCount: Int) -> Date {
+        let value = max(1, intervalCount)
+        let component: Calendar.Component
+        switch frequency {
+        case .daily:
+            component = .day
+        case .weekly:
+            component = .weekOfYear
+        case .monthly:
+            component = .month
+        }
+        return Calendar.current.date(byAdding: component, value: value, to: date) ?? date
+    }
+}

--- a/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
+++ b/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
@@ -1,0 +1,368 @@
+import SwiftUI
+import SwiftData
+
+struct RecurringTransactionsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \RecurringOccurrence.dueDate) private var occurrences: [RecurringOccurrence]
+    @Query(sort: \RecurringRule.nextDueDate) private var rules: [RecurringRule]
+    @State private var showingAddRule = false
+    @State private var editingRule: RecurringRule?
+    @State private var alertMessage: String?
+
+    private var pendingOccurrences: [RecurringOccurrence] {
+        occurrences.filter { $0.status == .pending }
+    }
+
+    var body: some View {
+        List {
+            if pendingOccurrences.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "沒有待確認項目",
+                        systemImage: "checkmark.circle",
+                        description: Text("定期記帳到期後會先出現在這裡，確認後才會建立正式帳目。")
+                    )
+                }
+            } else {
+                Section("待確認") {
+                    ForEach(pendingOccurrences) { occurrence in
+                        pendingOccurrenceRow(occurrence)
+                    }
+                }
+            }
+
+            Section("規則") {
+                if rules.isEmpty {
+                    Text("尚未建立定期記帳規則。")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(rules) { rule in
+                        Button {
+                            editingRule = rule
+                        } label: {
+                            recurringRuleRow(rule)
+                        }
+                    }
+                }
+            }
+        }
+        .prominentInlineTitle("定期記帳")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingAddRule = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingAddRule, onDismiss: syncDueOccurrences) {
+            AddRecurringRuleView()
+        }
+        .sheet(item: $editingRule, onDismiss: syncDueOccurrences) { rule in
+            AddRecurringRuleView(rule: rule)
+        }
+        .alert("提示", isPresented: Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )) {
+            Button("好") {}
+        } message: {
+            Text(alertMessage ?? "")
+        }
+        .task {
+            syncDueOccurrences()
+        }
+    }
+
+    private func pendingOccurrenceRow(_ occurrence: RecurringOccurrence) -> some View {
+        let rule = occurrence.rule
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(rule?.title ?? "未知規則")
+                        .font(.headline)
+                    Text(occurrence.dueDate.formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption)
+                        .foregroundStyle(occurrence.dueDate < Date() ? .red : .secondary)
+                }
+                Spacer()
+                if let rule {
+                    Text(signedAmountText(for: rule))
+                        .font(.headline)
+                        .foregroundStyle(rule.type == .income ? .green : .red)
+                }
+            }
+
+            HStack {
+                Button("跳過") {
+                    updateOccurrence(occurrence) {
+                        try RecurringTransactionService.skip(occurrence: occurrence, modelContext: modelContext)
+                    }
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("確認建立") {
+                    updateOccurrence(occurrence) {
+                        _ = try RecurringTransactionService.confirm(occurrence: occurrence, modelContext: modelContext)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(rule?.account == nil)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func recurringRuleRow(_ rule: RecurringRule) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(rule.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text("\(rule.frequency.displayName) · 每 \(rule.intervalCount) 次 · 下次 \(rule.nextDueDate.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if rule.isPaused {
+                    Text("已暫停")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.orange)
+                }
+            }
+            Spacer()
+            Text(signedAmountText(for: rule))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(rule.type == .income ? .green : .red)
+        }
+        .contentShape(Rectangle())
+    }
+
+    private func signedAmountText(for rule: RecurringRule) -> String {
+        let amount = rule.type == .expense ? -abs(rule.amount) : abs(rule.amount)
+        return amount.formatted(.currency(code: rule.currencyCode))
+    }
+
+    private func syncDueOccurrences() {
+        do {
+            try RecurringTransactionService.syncDueOccurrences(
+                rules: rules,
+                occurrences: occurrences,
+                modelContext: modelContext
+            )
+        } catch {
+            alertMessage = error.localizedDescription
+        }
+    }
+
+    private func updateOccurrence(_ occurrence: RecurringOccurrence, action: () throws -> Void) {
+        do {
+            try action()
+        } catch {
+            alertMessage = error.localizedDescription
+        }
+    }
+}
+
+struct AddRecurringRuleView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \Account.sortOrder) private var accounts: [Account]
+    @Query(sort: \Category.name) private var categories: [Category]
+
+    let rule: RecurringRule?
+
+    @State private var title = ""
+    @State private var type: TransactionType = .expense
+    @State private var amountString = ""
+    @State private var currencyCode = "HKD"
+    @State private var frequency: RecurringFrequency = .monthly
+    @State private var intervalCount = 1
+    @State private var nextDueDate = Date()
+    @State private var note = ""
+    @State private var isPaused = false
+    @State private var selectedAccount: Account?
+    @State private var selectedCategory: Category?
+    @State private var validationMessage: String?
+
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+
+    init(rule: RecurringRule? = nil) {
+        self.rule = rule
+    }
+
+    private var ownAccounts: [Account] {
+        accounts.filter { $0.type != .debt && !$0.isArchived }
+    }
+
+    private var availableCategories: [Category] {
+        categories.filter { category in
+            switch type {
+            case .income:
+                return category.kind == .income || category.kind == .both
+            case .expense:
+                return category.kind == .expense || category.kind == .both
+            case .transfer:
+                return false
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("基本資料") {
+                    TextField("名稱", text: $title)
+                    Picker("類型", selection: $type) {
+                        Text("支出").tag(TransactionType.expense)
+                        Text("收入").tag(TransactionType.income)
+                    }
+                    .pickerStyle(.segmented)
+                    TextField("金額", text: $amountString)
+                        .keyboardType(.decimalPad)
+                    Picker("幣種", selection: $currencyCode) {
+                        ForEach(currencies, id: \.self) { code in
+                            Text(code).tag(code)
+                        }
+                    }
+                    DatePicker("下次日期", selection: $nextDueDate, displayedComponents: [.date, .hourAndMinute])
+                }
+
+                Section("重複規則") {
+                    Picker("頻率", selection: $frequency) {
+                        ForEach(RecurringFrequency.allCases) { frequency in
+                            Text(frequency.displayName).tag(frequency)
+                        }
+                    }
+                    Stepper("間隔：每 \(intervalCount) 次", value: $intervalCount, in: 1...24)
+                    Toggle("暫停此規則", isOn: $isPaused)
+                }
+
+                Section("分類與帳戶") {
+                    Picker("帳戶", selection: $selectedAccount) {
+                        Text("請選擇").tag(nil as Account?)
+                        ForEach(ownAccounts) { account in
+                            Text(account.name).tag(account as Account?)
+                        }
+                    }
+
+                    Picker("分類", selection: $selectedCategory) {
+                        Text("未分類").tag(nil as Category?)
+                        ForEach(availableCategories) { category in
+                            Text("\(category.icon) \(category.name)").tag(category as Category?)
+                        }
+                    }
+                }
+
+                Section("備註") {
+                    TextField("備註（可選）", text: $note, axis: .vertical)
+                }
+            }
+            .navigationTitle(rule == nil ? "新增定期記帳" : "編輯定期記帳")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("儲存") { save() }
+                }
+            }
+            .alert("無法儲存", isPresented: Binding(
+                get: { validationMessage != nil },
+                set: { if !$0 { validationMessage = nil } }
+            )) {
+                Button("好") {}
+            } message: {
+                Text(validationMessage ?? "")
+            }
+            .onAppear(perform: loadExistingRule)
+            .onChange(of: selectedAccount) { _, newValue in
+                if let newValue {
+                    currencyCode = newValue.currency
+                }
+            }
+            .onChange(of: type) { _, _ in
+                if let selectedCategory, !availableCategories.contains(where: { $0.id == selectedCategory.id }) {
+                    self.selectedCategory = nil
+                }
+            }
+        }
+    }
+
+    private func loadExistingRule() {
+        guard let rule, title.isEmpty else {
+            selectedAccount = selectedAccount ?? ownAccounts.first
+            if let selectedAccount {
+                currencyCode = selectedAccount.currency
+            }
+            return
+        }
+
+        title = rule.title
+        type = rule.type == .income ? .income : .expense
+        amountString = NSDecimalNumber(decimal: abs(rule.amount)).stringValue
+        currencyCode = rule.currencyCode
+        frequency = rule.frequency
+        intervalCount = max(1, rule.intervalCount)
+        nextDueDate = rule.nextDueDate
+        note = rule.note
+        isPaused = rule.isPaused
+        selectedAccount = rule.account
+        selectedCategory = rule.category
+    }
+
+    private func save() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            validationMessage = "請輸入名稱。"
+            return
+        }
+        guard let amount = Decimal(string: amountString), amount > 0 else {
+            validationMessage = "請輸入大於 0 的金額。"
+            return
+        }
+        guard let selectedAccount else {
+            validationMessage = "請選擇帳戶。"
+            return
+        }
+
+        if let rule {
+            rule.title = trimmedTitle
+            rule.amount = amount
+            rule.currencyCode = currencyCode
+            rule.type = type
+            rule.note = note.trimmingCharacters(in: .whitespacesAndNewlines)
+            rule.frequency = frequency
+            rule.intervalCount = max(1, intervalCount)
+            rule.nextDueDate = nextDueDate
+            rule.isPaused = isPaused
+            rule.account = selectedAccount
+            rule.category = selectedCategory
+            rule.updatedAt = Date()
+        } else {
+            modelContext.insert(
+                RecurringRule(
+                    title: trimmedTitle,
+                    amount: amount,
+                    currencyCode: currencyCode,
+                    type: type,
+                    note: note.trimmingCharacters(in: .whitespacesAndNewlines),
+                    frequency: frequency,
+                    intervalCount: max(1, intervalCount),
+                    nextDueDate: nextDueDate,
+                    isPaused: isPaused,
+                    account: selectedAccount,
+                    category: selectedCategory
+                )
+            )
+        }
+
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            validationMessage = error.localizedDescription
+        }
+    }
+}

--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -227,6 +227,9 @@ struct SettingsView: View {
                     NavigationLink(destination: SettlementCenterView()) {
                         Label("結算中心", systemImage: "person.line.dotted.person")
                     }
+                    NavigationLink(destination: RecurringTransactionsView()) {
+                        Label("定期記帳", systemImage: "calendar.badge.clock")
+                    }
                     NavigationLink(destination: BudgetsView()) {
                         Label("預算與超支提醒", systemImage: "chart.bar.doc.horizontal")
                     }
@@ -401,6 +404,8 @@ struct SettingsView: View {
             try modelContext.delete(model: Category.self)
             try modelContext.delete(model: Tag.self)
             try modelContext.delete(model: Shortcut.self)
+            try modelContext.delete(model: RecurringOccurrence.self)
+            try modelContext.delete(model: RecurringRule.self)
             try modelContext.delete(model: CategoryMonthlyBudget.self)
             try modelContext.delete(model: BudgetMonthlyHistory.self)
             try modelContext.delete(model: BudgetSettings.self)

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -91,6 +91,8 @@ final class BackupCompatibilityTests: XCTestCase {
             Category.self,
             Tag.self,
             Shortcut.self,
+            RecurringRule.self,
+            RecurringOccurrence.self,
             CategoryMonthlyBudget.self,
             BudgetMonthlyHistory.self,
             BudgetSettings.self,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
@@ -14,6 +14,7 @@ class AppContainer(context: Context) {
         Room.databaseBuilder(appContext, AIAccountingDatabase::class.java, "ai_accounting.db")
             .addMigrations(AIAccountingDatabase.MIGRATION_1_2)
             .addMigrations(AIAccountingDatabase.MIGRATION_2_3)
+            .addMigrations(AIAccountingDatabase.MIGRATION_3_4)
             .addCallback(SeedData.callback(appContext))
             .build()
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/backup/BackupModels.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/backup/BackupModels.kt
@@ -12,6 +12,8 @@ data class FullBackupData(
     val tags: List<TagCodable>,
     val transactions: List<TransactionCodable>,
     val shortcuts: List<ShortcutCodable>,
+    val recurringRules: List<RecurringRuleCodable>? = null,
+    val recurringOccurrences: List<RecurringOccurrenceCodable>? = null,
     val budgets: List<BudgetCodable>?,
     val budgetHistory: List<BudgetHistoryCodable>?,
     val budgetSettings: List<BudgetSettingsCodable>? = null,
@@ -71,6 +73,34 @@ data class FullBackupData(
         val accountID: UUID?,
         val categoryID: UUID?,
         val tagIDs: List<UUID>
+    )
+
+    data class RecurringRuleCodable(
+        val id: UUID,
+        val title: String,
+        val amount: BigDecimal,
+        val currencyCode: String,
+        val type: String,
+        val note: String,
+        val frequency: String,
+        val intervalCount: Int,
+        val nextDueDate: Instant,
+        val isPaused: Boolean,
+        val accountID: UUID?,
+        val categoryID: UUID?,
+        val tagIDs: List<UUID>,
+        val createdAt: Instant?,
+        val updatedAt: Instant?
+    )
+
+    data class RecurringOccurrenceCodable(
+        val id: UUID,
+        val dueDate: Instant,
+        val status: String,
+        val createdTransactionID: UUID?,
+        val ruleID: UUID?,
+        val createdAt: Instant?,
+        val updatedAt: Instant?
     )
 
     data class BudgetCodable(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
@@ -15,6 +15,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         TransactionTagCrossRef::class,
         ShortcutEntity::class,
         ShortcutTagCrossRef::class,
+        RecurringRuleEntity::class,
+        RecurringOccurrenceEntity::class,
         CategoryMonthlyBudgetEntity::class,
         BudgetMonthlyHistoryEntity::class,
         BudgetSettingsEntity::class,
@@ -22,7 +24,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AdvanceParticipantEntity::class,
         AdvanceRepaymentEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -32,6 +34,7 @@ abstract class AIAccountingDatabase : RoomDatabase() {
     abstract fun tagDao(): TagDao
     abstract fun transactionDao(): TransactionDao
     abstract fun shortcutDao(): ShortcutDao
+    abstract fun recurringDao(): RecurringDao
     abstract fun budgetDao(): BudgetDao
     abstract fun advanceDao(): AdvanceDao
 
@@ -77,6 +80,52 @@ abstract class AIAccountingDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `recurring_rules` (
+                        `id` TEXT NOT NULL,
+                        `title` TEXT NOT NULL,
+                        `amount` TEXT NOT NULL,
+                        `currencyCode` TEXT NOT NULL,
+                        `type` TEXT NOT NULL,
+                        `note` TEXT NOT NULL,
+                        `frequency` TEXT NOT NULL,
+                        `intervalCount` INTEGER NOT NULL,
+                        `nextDueDate` INTEGER NOT NULL,
+                        `isPaused` INTEGER NOT NULL,
+                        `createdAt` INTEGER NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        `accountId` TEXT,
+                        `categoryId` TEXT,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_rules_accountId` ON `recurring_rules` (`accountId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_rules_categoryId` ON `recurring_rules` (`categoryId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_rules_nextDueDate` ON `recurring_rules` (`nextDueDate`)")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `recurring_occurrences` (
+                        `id` TEXT NOT NULL,
+                        `dueDate` INTEGER NOT NULL,
+                        `status` TEXT NOT NULL,
+                        `createdTransactionId` TEXT,
+                        `createdAt` INTEGER NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        `ruleId` TEXT,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_occurrences_ruleId` ON `recurring_occurrences` (`ruleId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_occurrences_dueDate` ON `recurring_occurrences` (`dueDate`)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_recurring_occurrences_ruleId_dueDate` ON `recurring_occurrences` (`ruleId`, `dueDate`)")
             }
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
@@ -161,6 +161,51 @@ interface ShortcutDao {
 }
 
 @Dao
+interface RecurringDao {
+    @Query("SELECT * FROM recurring_rules ORDER BY nextDueDate ASC")
+    fun observeRules(): Flow<List<RecurringRuleEntity>>
+
+    @Query("SELECT * FROM recurring_occurrences ORDER BY dueDate ASC")
+    fun observeOccurrences(): Flow<List<RecurringOccurrenceEntity>>
+
+    @Query("SELECT * FROM recurring_rules")
+    suspend fun getAllRules(): List<RecurringRuleEntity>
+
+    @Query("SELECT * FROM recurring_occurrences")
+    suspend fun getAllOccurrences(): List<RecurringOccurrenceEntity>
+
+    @Query("SELECT * FROM recurring_occurrences WHERE id = :occurrenceId")
+    suspend fun getOccurrence(occurrenceId: UUID): RecurringOccurrenceEntity?
+
+    @Query("SELECT * FROM recurring_rules WHERE id = :ruleId")
+    suspend fun getRule(ruleId: UUID): RecurringRuleEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertRule(rule: RecurringRuleEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertRules(rules: List<RecurringRuleEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertOccurrence(occurrence: RecurringOccurrenceEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertOccurrences(occurrences: List<RecurringOccurrenceEntity>)
+
+    @Delete
+    suspend fun deleteRule(rule: RecurringRuleEntity)
+
+    @Query("DELETE FROM recurring_occurrences WHERE ruleId = :ruleId")
+    suspend fun deleteOccurrencesForRule(ruleId: UUID)
+
+    @Query("DELETE FROM recurring_occurrences")
+    suspend fun deleteAllOccurrences()
+
+    @Query("DELETE FROM recurring_rules")
+    suspend fun deleteAllRules()
+}
+
+@Dao
 interface BudgetDao {
     @Query("SELECT * FROM category_monthly_budgets ORDER BY monthKey DESC")
     fun observeBudgets(): Flow<List<CategoryMonthlyBudgetEntity>>

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
@@ -99,6 +99,45 @@ data class ShortcutTagCrossRef(
 )
 
 @Entity(
+    tableName = "recurring_rules",
+    indices = [Index("accountId"), Index("categoryId"), Index("nextDueDate")]
+)
+data class RecurringRuleEntity(
+    @PrimaryKey val id: UUID,
+    val title: String,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val type: TransactionType,
+    val note: String,
+    val frequency: String,
+    val intervalCount: Int,
+    val nextDueDate: Instant,
+    val isPaused: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val accountId: UUID?,
+    val categoryId: UUID?
+)
+
+@Entity(
+    tableName = "recurring_occurrences",
+    indices = [
+        Index("ruleId"),
+        Index("dueDate"),
+        Index(value = ["ruleId", "dueDate"], unique = true)
+    ]
+)
+data class RecurringOccurrenceEntity(
+    @PrimaryKey val id: UUID,
+    val dueDate: Instant,
+    val status: String,
+    val createdTransactionId: UUID?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val ruleId: UUID?
+)
+
+@Entity(
     tableName = "category_monthly_budgets",
     indices = [Index("monthKey"), Index("categoryId")]
 )

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -26,6 +26,8 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.BudgetMonthlyHistoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.BudgetSettingsEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringOccurrenceEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutEntity
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutTagCrossRef
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
@@ -62,6 +64,10 @@ data class AccountDeletionImpact(
         get() = !counts.hasBookkeeping
 }
 
+private const val RECURRING_STATUS_PENDING = "Pending"
+private const val RECURRING_STATUS_CONFIRMED = "Confirmed"
+private const val RECURRING_STATUS_SKIPPED = "Skipped"
+
 class AccountingRepository(
     private val database: AIAccountingDatabase,
     private val currencyService: CurrencyService
@@ -71,6 +77,7 @@ class AccountingRepository(
     private val tagDao = database.tagDao()
     private val transactionDao = database.transactionDao()
     private val shortcutDao = database.shortcutDao()
+    private val recurringDao = database.recurringDao()
     private val budgetDao: BudgetDao = database.budgetDao()
     private val advanceDao = database.advanceDao()
 
@@ -79,6 +86,8 @@ class AccountingRepository(
     val tags: Flow<List<TagEntity>> = tagDao.observeTags()
     val transactions: Flow<List<TransactionWithDetails>> = transactionDao.observeTransactions()
     val shortcuts: Flow<List<ShortcutWithDetails>> = shortcutDao.observeShortcuts()
+    val recurringRules: Flow<List<RecurringRuleEntity>> = recurringDao.observeRules()
+    val recurringOccurrences: Flow<List<RecurringOccurrenceEntity>> = recurringDao.observeOccurrences()
     val budgets: Flow<List<CategoryMonthlyBudgetEntity>> = budgetDao.observeBudgets()
     val budgetHistories: Flow<List<BudgetMonthlyHistoryEntity>> = budgetDao.observeBudgetHistory()
     val budgetSettings: Flow<BudgetSettingsEntity?> = budgetDao.observeBudgetSettings()
@@ -336,6 +345,124 @@ class AccountingRepository(
     suspend fun deleteShortcut(shortcut: ShortcutEntity) {
         shortcutDao.delete(shortcut)
         shortcutDao.clearShortcutTags(shortcut.id)
+    }
+
+    suspend fun getRecurringRule(ruleId: UUID): RecurringRuleEntity? {
+        return recurringDao.getRule(ruleId)
+    }
+
+    suspend fun upsertRecurringRule(rule: RecurringRuleEntity) {
+        recurringDao.upsertRule(rule)
+    }
+
+    suspend fun deleteRecurringRule(rule: RecurringRuleEntity) {
+        database.withTransaction {
+            recurringDao.deleteOccurrencesForRule(rule.id)
+            recurringDao.deleteRule(rule)
+        }
+    }
+
+    suspend fun syncDueRecurringOccurrences(now: Instant = Instant.now()) {
+        database.withTransaction {
+            val existingKeys = recurringDao.getAllOccurrences()
+                .mapNotNull { occurrence ->
+                    val ruleId = occurrence.ruleId ?: return@mapNotNull null
+                    "$ruleId|${occurrence.dueDate}"
+                }
+                .toMutableSet()
+            val activeRules = recurringDao.getAllRules().filter { rule ->
+                !rule.isPaused && (rule.type == TransactionType.Income || rule.type == TransactionType.Expense)
+            }
+            activeRules.forEach { rule ->
+                var cursor = rule.nextDueDate
+                var generated = 0
+                val occurrences = mutableListOf<RecurringOccurrenceEntity>()
+                while (!cursor.isAfter(now) && generated < 24) {
+                    val key = "${rule.id}|$cursor"
+                    if (key !in existingKeys) {
+                        occurrences.add(
+                            RecurringOccurrenceEntity(
+                                id = UUID.randomUUID(),
+                                dueDate = cursor,
+                                status = RECURRING_STATUS_PENDING,
+                                createdTransactionId = null,
+                                createdAt = now,
+                                updatedAt = now,
+                                ruleId = rule.id
+                            )
+                        )
+                        existingKeys.add(key)
+                    }
+                    cursor = nextRecurringDate(cursor, rule.frequency, rule.intervalCount)
+                    generated += 1
+                }
+                if (cursor != rule.nextDueDate || occurrences.isNotEmpty()) {
+                    if (occurrences.isNotEmpty()) {
+                        recurringDao.upsertOccurrences(occurrences)
+                    }
+                    recurringDao.upsertRule(rule.copy(nextDueDate = cursor, updatedAt = now))
+                }
+            }
+        }
+    }
+
+    suspend fun confirmRecurringOccurrence(occurrenceId: UUID): UUID? {
+        return database.withTransaction {
+            val occurrence = recurringDao.getOccurrence(occurrenceId) ?: return@withTransaction null
+            val rule = occurrence.ruleId?.let { recurringDao.getRule(it) } ?: return@withTransaction null
+            if (occurrence.status == RECURRING_STATUS_CONFIRMED) {
+                return@withTransaction occurrence.createdTransactionId
+            }
+            if (rule.type != TransactionType.Income && rule.type != TransactionType.Expense) {
+                return@withTransaction null
+            }
+            val accountId = rule.accountId ?: return@withTransaction null
+            val now = Instant.now()
+            val transactionId = occurrence.createdTransactionId ?: UUID.randomUUID()
+            val signedAmount = if (rule.type == TransactionType.Expense) {
+                rule.amount.abs().negate()
+            } else {
+                rule.amount.abs()
+            }
+            val transaction = TransactionEntity(
+                id = transactionId,
+                amount = signedAmount,
+                currencyCode = rule.currencyCode,
+                date = occurrence.dueDate,
+                note = rule.note.ifBlank { rule.title },
+                photoPath = null,
+                type = rule.type,
+                linkedTransactionId = null,
+                transferGroupId = null,
+                transferSide = null,
+                createdAt = now,
+                updatedAt = now,
+                accountId = accountId,
+                categoryId = rule.categoryId
+            )
+            transactionDao.upsert(transaction)
+            recurringDao.upsertOccurrence(
+                occurrence.copy(
+                    status = RECURRING_STATUS_CONFIRMED,
+                    createdTransactionId = transactionId,
+                    updatedAt = now
+                )
+            )
+            syncAllBudgetHistory()
+            transactionId
+        }
+    }
+
+    suspend fun skipRecurringOccurrence(occurrenceId: UUID) {
+        database.withTransaction {
+            val occurrence = recurringDao.getOccurrence(occurrenceId) ?: return@withTransaction
+            recurringDao.upsertOccurrence(
+                occurrence.copy(
+                    status = RECURRING_STATUS_SKIPPED,
+                    updatedAt = Instant.now()
+                )
+            )
+        }
     }
 
     suspend fun upsertBudget(budget: CategoryMonthlyBudgetEntity) {
@@ -811,6 +938,8 @@ class AccountingRepository(
         val transactionTags = transactionDao.getTransactionTags()
         val shortcuts = shortcutDao.getAll()
         val shortcutTags = shortcutDao.getShortcutTags()
+        val recurringRules = recurringDao.getAllRules()
+        val recurringOccurrences = recurringDao.getAllOccurrences()
         val budgets = budgetDao.getAll()
         val budgetHistories = budgetDao.getAllHistory()
         val budgetSettings = budgetDao.getSettings()
@@ -822,7 +951,7 @@ class AccountingRepository(
         val shortcutTagMap = shortcutTags.groupBy { it.shortcutId }
 
         return FullBackupData(
-            version = "1.7",
+            version = "1.8",
             timestamp = Instant.now(),
             accounts = accounts.map {
                 FullBackupData.AccountCodable(
@@ -876,6 +1005,36 @@ class AccountingRepository(
                     accountID = shortcut.accountId,
                     categoryID = shortcut.categoryId,
                     tagIDs = shortcutTagMap[shortcut.id]?.map { it.tagId } ?: emptyList()
+                )
+            },
+            recurringRules = recurringRules.map { rule ->
+                FullBackupData.RecurringRuleCodable(
+                    id = rule.id,
+                    title = rule.title,
+                    amount = rule.amount,
+                    currencyCode = rule.currencyCode,
+                    type = rule.type.rawValue,
+                    note = rule.note,
+                    frequency = rule.frequency,
+                    intervalCount = rule.intervalCount,
+                    nextDueDate = rule.nextDueDate,
+                    isPaused = rule.isPaused,
+                    accountID = rule.accountId,
+                    categoryID = rule.categoryId,
+                    tagIDs = emptyList(),
+                    createdAt = rule.createdAt,
+                    updatedAt = rule.updatedAt
+                )
+            },
+            recurringOccurrences = recurringOccurrences.map { occurrence ->
+                FullBackupData.RecurringOccurrenceCodable(
+                    id = occurrence.id,
+                    dueDate = occurrence.dueDate,
+                    status = occurrence.status,
+                    createdTransactionID = occurrence.createdTransactionId,
+                    ruleID = occurrence.ruleId,
+                    createdAt = occurrence.createdAt,
+                    updatedAt = occurrence.updatedAt
                 )
             },
             budgets = budgets.map { budget ->
@@ -1043,6 +1202,39 @@ class AccountingRepository(
             shortcut.tagIDs.map { tagId -> ShortcutTagCrossRef(shortcut.id, tagId) }
         }
 
+        val recurringRuleEntities = data.recurringRules?.map { rule ->
+            RecurringRuleEntity(
+                id = rule.id,
+                title = rule.title,
+                amount = rule.amount,
+                currencyCode = rule.currencyCode,
+                type = org.duckdns.lhfser.aiaccounting.core.model.TransactionType.entries
+                    .firstOrNull { type -> type.rawValue == rule.type }
+                    ?: org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Expense,
+                note = rule.note,
+                frequency = rule.frequency,
+                intervalCount = rule.intervalCount.coerceAtLeast(1),
+                nextDueDate = rule.nextDueDate,
+                isPaused = rule.isPaused,
+                createdAt = rule.createdAt ?: Instant.now(),
+                updatedAt = rule.updatedAt ?: Instant.now(),
+                accountId = rule.accountID,
+                categoryId = rule.categoryID
+            )
+        }.orEmpty()
+
+        val recurringOccurrenceEntities = data.recurringOccurrences?.map { occurrence ->
+            RecurringOccurrenceEntity(
+                id = occurrence.id,
+                dueDate = occurrence.dueDate,
+                status = occurrence.status,
+                createdTransactionId = occurrence.createdTransactionID,
+                createdAt = occurrence.createdAt ?: Instant.now(),
+                updatedAt = occurrence.updatedAt ?: Instant.now(),
+                ruleId = occurrence.ruleID
+            )
+        }.orEmpty()
+
         val budgetEntities = data.budgets?.map { budget ->
             CategoryMonthlyBudgetEntity(
                 id = budget.id,
@@ -1147,6 +1339,12 @@ class AccountingRepository(
             if (shortcutTags.isNotEmpty()) {
                 shortcutDao.insertShortcutTags(shortcutTags)
             }
+            if (recurringRuleEntities.isNotEmpty()) {
+                recurringDao.upsertRules(recurringRuleEntities)
+            }
+            if (recurringOccurrenceEntities.isNotEmpty()) {
+                recurringDao.upsertOccurrences(recurringOccurrenceEntities)
+            }
             if (budgetEntities.isNotEmpty()) {
                 budgetDao.upsertAll(budgetEntities)
             }
@@ -1244,6 +1442,8 @@ class AccountingRepository(
         budgetDao.deleteAllSettings()
         budgetDao.deleteAllHistory()
         budgetDao.deleteAll()
+        recurringDao.deleteAllOccurrences()
+        recurringDao.deleteAllRules()
         shortcutDao.deleteAllShortcuts()
         transactionDao.deleteAllTransactions()
         tagDao.deleteAll()
@@ -1417,6 +1617,17 @@ class AccountingRepository(
     private fun monthKeyFromInstant(instant: Instant): String {
         val date = instant.atZone(ZoneId.systemDefault()).toLocalDate()
         return "%04d-%02d".format(date.year, date.monthValue)
+    }
+
+    private fun nextRecurringDate(date: Instant, frequency: String, intervalCount: Int): Instant {
+        val safeInterval = intervalCount.coerceAtLeast(1).toLong()
+        val zonedDateTime = date.atZone(ZoneId.systemDefault())
+        val next = when (frequency) {
+            "Daily" -> zonedDateTime.plusDays(safeInterval)
+            "Weekly" -> zonedDateTime.plusWeeks(safeInterval)
+            else -> zonedDateTime.plusMonths(safeInterval)
+        }
+        return next.toInstant()
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -64,6 +64,8 @@ import org.duckdns.lhfser.aiaccounting.ui.screens.DataHealthScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.DebtEntryScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.OverviewScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReceiptScanScreen
+import org.duckdns.lhfser.aiaccounting.ui.screens.RecurringRuleEditorScreen
+import org.duckdns.lhfser.aiaccounting.ui.screens.RecurringTransactionsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReportsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.SettingsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.SettlementCenterScreen
@@ -104,6 +106,8 @@ private sealed class AppDestination(
     data object Tags : AppDestination("tags", "標籤管理")
     data object TagEdit : AppDestination("tags/edit/{tagId}", "編輯標籤")
     data object Budgets : AppDestination("budgets", "預算與提醒")
+    data object Recurring : AppDestination("recurring", "定期記帳")
+    data object RecurringEdit : AppDestination("recurring/edit/{ruleId}", "編輯定期記帳")
     data object DataHealth : AppDestination("data-health", "資料健康檢查")
     data object Settlements : AppDestination("settlements", "結算中心")
     data object AccountEdit : AppDestination("accounts/edit/{accountId}", "編輯帳戶")
@@ -258,6 +262,7 @@ fun AIAccountingRoot(
                     onOpenCategories = { navController.navigate(AppDestination.Categories.route) },
                     onOpenTags = { navController.navigate(AppDestination.Tags.route) },
                     onOpenBudgets = { navController.navigate(AppDestination.Budgets.route) },
+                    onOpenRecurring = { navController.navigate(AppDestination.Recurring.route) },
                     onOpenAdvances = { navController.navigate("advances") },
                     onOpenSettlements = { navController.navigate(AppDestination.Settlements.route) },
                     onOpenHealth = { navController.navigate(AppDestination.DataHealth.route) }
@@ -357,6 +362,21 @@ fun AIAccountingRoot(
                 )
             }
             composable(AppDestination.Budgets.route) { BudgetsScreen() }
+            composable(AppDestination.Recurring.route) {
+                RecurringTransactionsScreen(
+                    onAddRule = { navController.navigate("recurring/edit/${UUID.randomUUID()}") },
+                    onEditRule = { id -> navController.navigate("recurring/edit/$id") }
+                )
+            }
+            composable(
+                AppDestination.RecurringEdit.route,
+                arguments = listOf(navArgument("ruleId") { type = NavType.StringType })
+            ) { entry ->
+                RecurringRuleEditorScreen(
+                    ruleId = entry.arguments?.getString("ruleId"),
+                    onDone = { navController.popBackStack() }
+                )
+            }
             composable(AppDestination.DataHealth.route) { DataHealthScreen() }
             composable(
                 AppDestination.AccountEdit.route,
@@ -507,6 +527,8 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
         route == AppDestination.Tags.route -> "標籤"
         route.startsWith("tags/edit") -> "編輯標籤"
         route == AppDestination.Budgets.route -> "預算與提醒"
+        route == AppDestination.Recurring.route -> "定期記帳"
+        route.startsWith("recurring/edit") -> "編輯定期記帳"
         route == AppDestination.DataHealth.route -> "資料健康檢查"
         route == AppDestination.Settlements.route -> "結算中心"
         route.startsWith("accounts/edit") -> "編輯帳戶"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
@@ -1,0 +1,564 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+import kotlinx.coroutines.launch
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringOccurrenceEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
+import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityMenuField
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
+
+private enum class RecurringFrequencyOption(val rawValue: String, val label: String) {
+    Daily("Daily", "每日"),
+    Weekly("Weekly", "每週"),
+    Monthly("Monthly", "每月");
+
+    companion object {
+        fun fromRaw(rawValue: String): RecurringFrequencyOption {
+            return entries.firstOrNull { it.rawValue == rawValue } ?: Monthly
+        }
+    }
+}
+
+@Composable
+fun RecurringTransactionsScreen(
+    onAddRule: () -> Unit,
+    onEditRule: (UUID) -> Unit
+) {
+    val repository = LocalRepository.current
+    val scope = rememberCoroutineScope()
+    val rules by repository.recurringRules.collectAsState(initial = emptyList())
+    val occurrences by repository.recurringOccurrences.collectAsState(initial = emptyList())
+    val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val categories by repository.categories.collectAsState(initial = emptyList())
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(Unit) {
+        repository.syncDueRecurringOccurrences()
+    }
+
+    val rulesById = remember(rules) { rules.associateBy { it.id } }
+    val pendingOccurrences = remember(occurrences) {
+        occurrences
+            .filter { it.status == "Pending" }
+            .sortedBy { it.dueDate }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        ParityTopSection(
+            title = "定期記帳",
+            subtitle = "先產生待確認項目，確認後才會寫入正式帳目。",
+            accessory = {
+                TextButton(onClick = onAddRule) { Text("新增") }
+            }
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            ParitySectionHeader(
+                title = "待確認",
+                detail = if (pendingOccurrences.isEmpty()) "目前沒有到期項目。" else "確認後會建立正式收入或支出。"
+            )
+            if (pendingOccurrences.isEmpty()) {
+                SectionCard {
+                    Text(
+                        "沒有待確認的定期記帳。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(AppSpacing.card)
+                    )
+                }
+            } else {
+                pendingOccurrences.forEach { occurrence ->
+                    val rule = occurrence.ruleId?.let { rulesById[it] }
+                    PendingOccurrenceCard(
+                        occurrence = occurrence,
+                        rule = rule,
+                        account = rule?.accountId?.let { id -> accounts.firstOrNull { it.id == id } },
+                        category = rule?.categoryId?.let { id -> categories.firstOrNull { it.id == id } },
+                        onConfirm = {
+                            scope.launch { repository.confirmRecurringOccurrence(occurrence.id) }
+                        },
+                        onSkip = {
+                            scope.launch { repository.skipRecurringOccurrence(occurrence.id) }
+                        }
+                    )
+                }
+            }
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+            ParitySectionHeader(
+                title = "規則",
+                detail = "支援收入與支出；轉帳、代墊與借貸先保持手動確認。"
+            )
+            if (rules.isEmpty()) {
+                SectionCard {
+                    Text(
+                        "尚未建立定期記帳規則。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(AppSpacing.card)
+                    )
+                }
+            } else {
+                rules.sortedBy { it.nextDueDate }.forEach { rule ->
+                    RuleCard(
+                        rule = rule,
+                        account = rule.accountId?.let { id -> accounts.firstOrNull { it.id == id } },
+                        category = rule.categoryId?.let { id -> categories.firstOrNull { it.id == id } },
+                        onClick = { onEditRule(rule.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PendingOccurrenceCard(
+    occurrence: RecurringOccurrenceEntity,
+    rule: RecurringRuleEntity?,
+    account: AccountEntity?,
+    category: CategoryEntity?,
+    onConfirm: () -> Unit,
+    onSkip: () -> Unit
+) {
+    SectionCard {
+        Column(
+            modifier = Modifier.padding(AppSpacing.card),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline), modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(rule?.title ?: "定期記帳", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        listOfNotNull(account?.name, category?.name, occurrence.dueDate.toDateText()).joinToString(" · "),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                ParityStatusPill(text = "待確認", tint = MaterialTheme.colorScheme.primary)
+            }
+            Text(
+                rule?.let { signedRuleAmount(it) } ?: "資料不完整",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                TextButton(onClick = onSkip, modifier = Modifier.weight(1f)) { Text("略過") }
+                Button(onClick = onConfirm, enabled = rule != null && account != null, modifier = Modifier.weight(1f)) {
+                    Text("確認入帳")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RuleCard(
+    rule: RecurringRuleEntity,
+    account: AccountEntity?,
+    category: CategoryEntity?,
+    onClick: () -> Unit
+) {
+    PressableCard(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick
+    ) {
+        Column(
+            modifier = Modifier.padding(AppSpacing.card),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline), modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(rule.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        listOfNotNull(account?.name, category?.name, RecurringFrequencyOption.fromRaw(rule.frequency).label).joinToString(" · "),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (rule.isPaused) {
+                    ParityStatusPill(text = "已暫停", tint = MaterialTheme.colorScheme.outline)
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline), modifier = Modifier.fillMaxWidth()) {
+                Text(signedRuleAmount(rule), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                Text(
+                    "下次 ${rule.nextDueDate.toDateText()}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RecurringRuleEditorScreen(
+    ruleId: String?,
+    onDone: () -> Unit
+) {
+    val repository = LocalRepository.current
+    val currencyService = LocalCurrencyService.current
+    val scope = rememberCoroutineScope()
+    val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val categories by repository.categories.collectAsState(initial = emptyList())
+    val rules by repository.recurringRules.collectAsState(initial = emptyList())
+    val scrollState = rememberScrollState()
+
+    val parsedRuleId = remember(ruleId) { ruleId?.let { runCatching { UUID.fromString(it) }.getOrNull() } ?: UUID.randomUUID() }
+    val existingRule = rules.firstOrNull { it.id == parsedRuleId }
+    val ownAccounts = accounts.filter { it.type != AccountType.Debt && !it.isArchived }
+
+    var loaded by remember(parsedRuleId) { mutableStateOf(false) }
+    var title by remember { mutableStateOf("") }
+    var amount by remember { mutableStateOf("") }
+    var currencyCode by remember { mutableStateOf(currencyService.mainCurrency) }
+    var type by remember { mutableStateOf(TransactionType.Expense) }
+    var note by remember { mutableStateOf("") }
+    var frequency by remember { mutableStateOf(RecurringFrequencyOption.Monthly) }
+    var intervalCount by remember { mutableStateOf("1") }
+    var nextDueDate by remember { mutableStateOf(LocalDate.now().toString()) }
+    var isPaused by remember { mutableStateOf(false) }
+    var selectedAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    val filteredCategories = categories.filter { it.kind.supports(type) }
+
+    LaunchedEffect(existingRule, ownAccounts, filteredCategories) {
+        if (loaded) return@LaunchedEffect
+        if (existingRule != null) {
+            title = existingRule.title
+            amount = existingRule.amount.toPlainString()
+            currencyCode = existingRule.currencyCode
+            type = existingRule.type
+            note = existingRule.note
+            frequency = RecurringFrequencyOption.fromRaw(existingRule.frequency)
+            intervalCount = existingRule.intervalCount.toString()
+            nextDueDate = existingRule.nextDueDate.atZone(ZoneId.systemDefault()).toLocalDate().toString()
+            isPaused = existingRule.isPaused
+            selectedAccount = ownAccounts.firstOrNull { it.id == existingRule.accountId }
+            selectedCategory = filteredCategories.firstOrNull { it.id == existingRule.categoryId }
+            loaded = true
+        } else if (ownAccounts.isNotEmpty()) {
+            selectedAccount = ownAccounts.first()
+            currencyCode = selectedAccount?.currency ?: currencyService.mainCurrency
+            selectedCategory = filteredCategories.firstOrNull()
+            loaded = true
+        }
+    }
+
+    LaunchedEffect(type, filteredCategories) {
+        if (selectedCategory != null && filteredCategories.none { it.id == selectedCategory?.id }) {
+            selectedCategory = filteredCategories.firstOrNull()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        ParityTopSection(
+            title = if (existingRule == null) "新增定期記帳" else "編輯定期記帳",
+            subtitle = "到期後先進待確認，不會偷偷寫入帳目。"
+        )
+
+        SectionCard {
+            Column(modifier = Modifier.padding(AppSpacing.card), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                ParitySegmentedControl(
+                    options = listOf(TransactionType.Expense, TransactionType.Income),
+                    selected = type,
+                    label = { if (it == TransactionType.Expense) "支出" else "收入" },
+                    onSelect = { type = it }
+                )
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    label = { Text("名稱") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                    CurrencyPicker(
+                        selected = currencyCode,
+                        onSelect = { currencyCode = it },
+                        buttonStyle = CurrencyButtonStyle.Tonal
+                    )
+                    OutlinedTextField(
+                        value = amount,
+                        onValueChange = { amount = sanitizeAmountInput(it) },
+                        label = { Text("金額") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true
+                    )
+                }
+                AccountDropdown(
+                    accounts = ownAccounts,
+                    selected = selectedAccount,
+                    onSelect = {
+                        selectedAccount = it
+                        currencyCode = it.currency
+                    }
+                )
+                CategoryDropdown(
+                    categories = filteredCategories,
+                    selected = selectedCategory,
+                    onSelect = { selectedCategory = it }
+                )
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it },
+                    label = { Text("備註") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+
+        ParitySectionHeader(title = "週期", detail = "先支援每日、每週、每月；每次到期都需要你確認。")
+        SectionCard {
+            Column(modifier = Modifier.padding(AppSpacing.card), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                ParitySegmentedControl(
+                    options = RecurringFrequencyOption.entries,
+                    selected = frequency,
+                    label = { it.label },
+                    onSelect = { frequency = it }
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                    OutlinedTextField(
+                        value = intervalCount,
+                        onValueChange = { intervalCount = it.filter(Char::isDigit).take(3) },
+                        label = { Text("間隔") },
+                        modifier = Modifier.weight(0.35f),
+                        singleLine = true
+                    )
+                    OutlinedTextField(
+                        value = nextDueDate,
+                        onValueChange = { nextDueDate = it },
+                        label = { Text("下次日期 yyyy-MM-dd") },
+                        modifier = Modifier.weight(0.65f),
+                        singleLine = true
+                    )
+                }
+                TextButton(onClick = { isPaused = !isPaused }) {
+                    Text(if (isPaused) "目前已暫停，點擊恢復" else "目前啟用中，點擊暫停")
+                }
+            }
+        }
+
+        Button(
+            onClick = {
+                val nextDueInstant = parseDateInput(nextDueDate)
+                val parsedAmount = amount.toBigDecimalOrNull()
+                val account = selectedAccount
+                if (nextDueInstant != null && parsedAmount != null && parsedAmount > BigDecimal.ZERO && account != null) {
+                    val now = Instant.now()
+                    val rule = RecurringRuleEntity(
+                        id = parsedRuleId,
+                        title = title.trim().ifBlank { if (type == TransactionType.Expense) "定期支出" else "定期收入" },
+                        amount = parsedAmount.abs(),
+                        currencyCode = currencyCode,
+                        type = type,
+                        note = note.trim(),
+                        frequency = frequency.rawValue,
+                        intervalCount = intervalCount.toIntOrNull()?.coerceAtLeast(1) ?: 1,
+                        nextDueDate = nextDueInstant,
+                        isPaused = isPaused,
+                        createdAt = existingRule?.createdAt ?: now,
+                        updatedAt = now,
+                        accountId = account.id,
+                        categoryId = selectedCategory?.id
+                    )
+                    scope.launch {
+                        repository.upsertRecurringRule(rule)
+                        repository.syncDueRecurringOccurrences()
+                        onDone()
+                    }
+                }
+            },
+            enabled = selectedAccount != null && amount.toBigDecimalOrNull()?.let { it > BigDecimal.ZERO } == true && parseDateInput(nextDueDate) != null,
+            modifier = Modifier.fillMaxWidth().height(52.dp)
+        ) {
+            Text("儲存")
+        }
+
+        if (existingRule != null) {
+            TextButton(onClick = { showDeleteConfirm = true }, modifier = Modifier.fillMaxWidth()) {
+                Text("刪除規則", color = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+
+    if (showDeleteConfirm && existingRule != null) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("刪除定期規則？") },
+            text = { Text("此操作會一併刪除尚未確認的到期項目；已確認產生的正式帳目不會被刪除。") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirm = false
+                        scope.launch {
+                            repository.deleteRecurringRule(existingRule)
+                            onDone()
+                        }
+                    }
+                ) { Text("刪除", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("取消") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun AccountDropdown(
+    accounts: List<AccountEntity>,
+    selected: AccountEntity?,
+    onSelect: (AccountEntity) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ParityMenuField(
+        label = "帳戶",
+        value = selected?.name.orEmpty(),
+        placeholder = "選擇自己的帳戶",
+        onClick = { expanded = true }
+    )
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        accounts.forEach { account ->
+            DropdownMenuItem(
+                text = { Text("${account.name} · ${account.currency}") },
+                onClick = {
+                    expanded = false
+                    onSelect(account)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryDropdown(
+    categories: List<CategoryEntity>,
+    selected: CategoryEntity?,
+    onSelect: (CategoryEntity?) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ParityMenuField(
+        label = "分類",
+        value = selected?.name.orEmpty(),
+        placeholder = "無分類",
+        onClick = { expanded = true }
+    )
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        DropdownMenuItem(
+            text = { Text("無分類") },
+            onClick = {
+                expanded = false
+                onSelect(null)
+            }
+        )
+        categories.forEach { category ->
+            DropdownMenuItem(
+                text = { Text(category.name) },
+                onClick = {
+                    expanded = false
+                    onSelect(category)
+                }
+            )
+        }
+    }
+}
+
+private fun signedRuleAmount(rule: RecurringRuleEntity): String {
+    val prefix = if (rule.type == TransactionType.Expense) "-" else "+"
+    return prefix + rule.amount.asCurrencyText(rule.currencyCode)
+}
+
+private fun sanitizeAmountInput(input: String): String {
+    val allowed = input.filter { it.isDigit() || it == '.' }
+    var hasDot = false
+    val result = StringBuilder()
+    for (char in allowed) {
+        if (char == '.') {
+            if (hasDot) continue
+            hasDot = true
+        }
+        result.append(char)
+    }
+    return result.toString()
+}
+
+private fun parseDateInput(input: String): Instant? {
+    return runCatching {
+        LocalDate.parse(input.trim()).atStartOfDay(ZoneId.systemDefault()).toInstant()
+    }.getOrNull()
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -52,6 +52,7 @@ fun SettingsScreen(
     onOpenCategories: () -> Unit,
     onOpenTags: () -> Unit,
     onOpenBudgets: () -> Unit,
+    onOpenRecurring: () -> Unit,
     onOpenAdvances: () -> Unit,
     onOpenSettlements: () -> Unit,
     onOpenHealth: () -> Unit
@@ -191,6 +192,7 @@ fun SettingsScreen(
                 ParitySettingRow("代墊追蹤", "查看待還款與還款紀錄", onClick = onOpenAdvances)
                 ParitySettingRow("結算中心", "集中查看代墊、借貸、還款與免除債務", onClick = onOpenSettlements)
                 ParitySettingRow("預算與超支提醒", "設定每月分類預算與 AI 建議", onClick = onOpenBudgets)
+                ParitySettingRow("定期記帳", "管理待確認的週期收入與支出", onClick = onOpenRecurring)
                 ParitySettingRow("資料健康檢查", "檢查缺失分類、帳戶與歷史異常", onClick = onOpenHealth)
             }
         }

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -5,9 +5,15 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.CategoryKind
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.data.backup.BackupJsonAdapter
 import org.duckdns.lhfser.aiaccounting.data.backup.FullBackupData
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -19,6 +25,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.math.BigDecimal
+import java.time.Instant
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -137,6 +145,82 @@ class BackupRoundTripTest {
             assertFalse(secondReport.issues.any { it.title == "收入交易記到了借貸帳戶" })
             assertFalse(secondReport.issues.any { it.title == "收入捷徑綁到了借貸帳戶" })
             assertEquals(0, secondReport.errorCount)
+        } finally {
+            secondDatabase.close()
+        }
+    }
+
+    @Test
+    fun recurringRule_syncConfirmExport_reimportsCleanly() = runBlocking {
+        val accountId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        val categoryId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        val ruleId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+        database.accountDao().upsert(
+            AccountEntity(
+                id = accountId,
+                name = "Wallet",
+                currency = "HKD",
+                type = AccountType.Cash,
+                baseBalance = BigDecimal.ZERO,
+                sortOrder = 0,
+                isArchived = false
+            )
+        )
+        database.categoryDao().upsert(
+            CategoryEntity(
+                id = categoryId,
+                name = "Subscription",
+                icon = "creditcard",
+                colorHex = "#42A5F5",
+                kind = CategoryKind.Expense
+            )
+        )
+        repository.upsertRecurringRule(
+            RecurringRuleEntity(
+                id = ruleId,
+                title = "Streaming",
+                amount = BigDecimal("120"),
+                currencyCode = "HKD",
+                type = TransactionType.Expense,
+                note = "Monthly plan",
+                frequency = "Monthly",
+                intervalCount = 1,
+                nextDueDate = Instant.parse("2026-04-01T00:00:00Z"),
+                isPaused = false,
+                createdAt = Instant.parse("2026-03-01T00:00:00Z"),
+                updatedAt = Instant.parse("2026-03-01T00:00:00Z"),
+                accountId = accountId,
+                categoryId = categoryId
+            )
+        )
+
+        repository.syncDueRecurringOccurrences(Instant.parse("2026-04-27T00:00:00Z"))
+
+        val occurrence = database.recurringDao().getAllOccurrences().single()
+        assertEquals("Pending", occurrence.status)
+
+        val transactionId = repository.confirmRecurringOccurrence(occurrence.id)
+        assertNotNull(transactionId)
+
+        val transaction = repository.getTransaction(transactionId!!)
+        assertNotNull(transaction)
+        assertEquals(TransactionType.Expense, transaction?.transaction?.type)
+        assertEquals("-120", transaction?.transaction?.amount?.toPlainString())
+
+        val exportedJson = repository.exportBackupJson()
+        val exported = BackupJsonAdapter.gson.fromJson(exportedJson, FullBackupData::class.java)
+        assertEquals("1.8", exported.version)
+        assertEquals(1, exported.recurringRules?.size)
+        assertEquals(1, exported.recurringOccurrences?.size)
+
+        val secondDatabase = buildDatabase()
+        try {
+            val secondRepository = AccountingRepository(secondDatabase, currencyService)
+            secondRepository.importBackupJson(exportedJson, replaceExisting = true)
+            assertEquals(1, secondDatabase.recurringDao().getAllRules().size)
+            assertEquals(1, secondDatabase.recurringDao().getAllOccurrences().size)
+            assertNotNull(secondRepository.getTransaction(transactionId))
         } finally {
             secondDatabase.close()
         }


### PR DESCRIPTION
## Summary
- Add cross-platform recurring transaction rules for income and expense flows.
- Generate due occurrences as pending items; users can confirm them into real transactions or skip them.
- Include recurring rules and occurrences in JSON backup/import without breaking older backups.
- Add Android Room migration, Android/iOS settings entry points, and backup round-trip coverage.

Closes #36

## Validation
- Android: `./gradlew assembleDebug`
- Android: `./gradlew testDebugUnitTest`
- iOS: `xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- iOS: `xcodebuild test -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' -only-testing:'AI 記帳Tests/BackupCompatibilityTests' CODE_SIGNING_ALLOWED=NO`

## Notes
- `Localizable.xcstrings` has local user changes and is intentionally excluded from this PR.
- v1 supports income and expense only; transfer, debt, and advance recurrence remain manual.
