### PR TITLE
[codex] Add WebDAV remote backup

### DIFF
--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -369,6 +369,32 @@ class BackupManager: NSObject, ObservableObject {
     }
 
     @MainActor
+    func restoreBackupData(_ backup: FullBackupData, modelContext: ModelContext, replaceExisting: Bool = false) throws {
+        if replaceExisting {
+            try deleteAllBackupData(modelContext: modelContext)
+        }
+        try restoreDecodedBackup(backup, modelContext: modelContext)
+    }
+
+    @MainActor
+    private func deleteAllBackupData(modelContext: ModelContext) throws {
+        try modelContext.delete(model: FinancialTransaction.self)
+        try modelContext.delete(model: Shortcut.self)
+        try modelContext.delete(model: RecurringOccurrence.self)
+        try modelContext.delete(model: RecurringRule.self)
+        try modelContext.delete(model: CategoryMonthlyBudget.self)
+        try modelContext.delete(model: BudgetMonthlyHistory.self)
+        try modelContext.delete(model: BudgetSettings.self)
+        try modelContext.delete(model: AdvanceRepayment.self)
+        try modelContext.delete(model: AdvanceParticipant.self)
+        try modelContext.delete(model: AdvanceCase.self)
+        try modelContext.delete(model: Account.self)
+        try modelContext.delete(model: Category.self)
+        try modelContext.delete(model: Tag.self)
+        try modelContext.save()
+    }
+
+    @MainActor
     private func restoreDecodedBackup(_ backup: FullBackupData, modelContext: ModelContext) throws {
         var accountByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<Account>())) ?? []).map { ($0.id, $0) })
         var categoryByID = Dictionary(uniqueKeysWithValues: ((try? modelContext.fetch(FetchDescriptor<Category>())) ?? []).map { ($0.id, $0) })

--- a/AI 記帳/Services/RemoteBackupService.swift
+++ b/AI 記帳/Services/RemoteBackupService.swift
@@ -1,0 +1,277 @@
+import Foundation
+import CryptoKit
+import CommonCrypto
+
+struct WebDAVCredentials {
+    let baseURL: URL
+    let username: String
+    let password: String
+    let passphrase: String
+}
+
+struct RemoteBackupFile: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let url: URL
+    let size: Int?
+    let modifiedAt: Date?
+}
+
+struct RemoteBackupPreview {
+    let title: String
+    let detail: String
+}
+
+private struct EncryptedBackupEnvelope: Codable {
+    let formatVersion: Int
+    let algorithm: String
+    let createdAt: Date
+    let salt: String
+    let iv: String
+    let ciphertext: String
+    let tagBits: Int
+}
+
+enum RemoteBackupError: LocalizedError {
+    case invalidURL
+    case invalidCredentials
+    case invalidResponse
+    case httpStatus(Int)
+    case invalidEnvelope
+    case decryptFailed
+    case keyDerivationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "WebDAV URL 無效。"
+        case .invalidCredentials:
+            "請先填寫 WebDAV URL、帳戶、密碼與加密 passphrase。"
+        case .invalidResponse:
+            "WebDAV 回應無效。"
+        case .httpStatus(let status):
+            "WebDAV 回應錯誤：HTTP \(status)。"
+        case .invalidEnvelope:
+            "遠端備份格式無效。"
+        case .decryptFailed:
+            "無法解密備份，請確認 passphrase 是否正確。"
+        case .keyDerivationFailed:
+            "無法建立備份加密金鑰。"
+        }
+    }
+}
+
+final class RemoteBackupService {
+    static let shared = RemoteBackupService()
+
+    private let backupExtension = "aibackup"
+    private let keyDerivationIterations: UInt32 = 120_000
+    private let gcmTagByteCount = 16
+
+    private init() {}
+
+    func testConnection(credentials: WebDAVCredentials) async throws {
+        var request = try makeRequest(credentials: credentials, url: credentials.baseURL)
+        request.httpMethod = "PROPFIND"
+        request.setValue("0", forHTTPHeaderField: "Depth")
+        request.httpBody = propfindBody()
+        let (_, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, accepted: [200, 207])
+    }
+
+    func listBackups(credentials: WebDAVCredentials) async throws -> [RemoteBackupFile] {
+        var request = try makeRequest(credentials: credentials, url: credentials.baseURL)
+        request.httpMethod = "PROPFIND"
+        request.setValue("1", forHTTPHeaderField: "Depth")
+        request.httpBody = propfindBody()
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, accepted: [200, 207])
+        let xml = String(decoding: data, as: UTF8.self)
+        return parseBackupFiles(from: xml, baseURL: credentials.baseURL)
+    }
+
+    func uploadBackup(jsonData: Data, credentials: WebDAVCredentials) async throws -> RemoteBackupFile {
+        let encrypted = try encrypt(jsonData, passphrase: credentials.passphrase)
+        let filename = "AIAccounting_Backup_\(Self.filenameDateFormatter.string(from: Date())).\(backupExtension)"
+        let targetURL = credentials.baseURL.appendingPathComponent(filename)
+        var request = try makeRequest(credentials: credentials, url: targetURL)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = encrypted
+        let (_, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, accepted: [200, 201, 204])
+        return RemoteBackupFile(name: filename, url: targetURL, size: encrypted.count, modifiedAt: Date())
+    }
+
+    func downloadBackup(_ file: RemoteBackupFile, credentials: WebDAVCredentials) async throws -> Data {
+        var request = try makeRequest(credentials: credentials, url: file.url)
+        request.httpMethod = "GET"
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, accepted: [200])
+        return try decrypt(data, passphrase: credentials.passphrase)
+    }
+
+    func makePreview(from backup: FullBackupData) -> RemoteBackupPreview {
+        let dates = backup.transactions.map(\.date)
+        let rangeText: String
+        if let first = dates.min(), let last = dates.max() {
+            rangeText = "\(first.formatted(date: .abbreviated, time: .omitted)) - \(last.formatted(date: .abbreviated, time: .omitted))"
+        } else {
+            rangeText = "沒有交易日期"
+        }
+
+        let detail = """
+        版本：\(backup.version)
+        建立時間：\(backup.timestamp.formatted(date: .abbreviated, time: .shortened))
+        帳戶：\(backup.accounts.count)
+        交易：\(backup.transactions.count)
+        分類：\(backup.categories.count)
+        標籤：\(backup.tags.count)
+        代墊案件：\(backup.advanceCases?.count ?? 0)
+        預算：\(backup.budgets?.count ?? 0)
+        日期範圍：\(rangeText)
+        """
+        return RemoteBackupPreview(title: "遠端備份預覽", detail: detail)
+    }
+
+    private func encrypt(_ data: Data, passphrase: String) throws -> Data {
+        let salt = SymmetricKey(size: .bits128).withUnsafeBytes { Data($0) }
+        let key = try deriveKey(passphrase: passphrase, salt: salt)
+        let nonce = AES.GCM.Nonce()
+        let sealed = try AES.GCM.seal(data, using: key, nonce: nonce)
+        let combinedCiphertext = sealed.ciphertext + sealed.tag
+        let envelope = EncryptedBackupEnvelope(
+            formatVersion: 1,
+            algorithm: "AES.GCM.PBKDF2.HMACSHA256",
+            createdAt: Date(),
+            salt: salt.base64EncodedString(),
+            iv: Data(nonce).base64EncodedString(),
+            ciphertext: combinedCiphertext.base64EncodedString(),
+            tagBits: gcmTagByteCount * 8
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(envelope)
+    }
+
+    private func decrypt(_ envelopeData: Data, passphrase: String) throws -> Data {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(EncryptedBackupEnvelope.self, from: envelopeData)
+        guard envelope.formatVersion == 1,
+              envelope.algorithm == "AES.GCM.PBKDF2.HMACSHA256",
+              let salt = Data(base64Encoded: envelope.salt),
+              let nonceData = Data(base64Encoded: envelope.iv),
+              let combinedCiphertext = Data(base64Encoded: envelope.ciphertext),
+              envelope.tagBits == gcmTagByteCount * 8,
+              combinedCiphertext.count > gcmTagByteCount else {
+            throw RemoteBackupError.invalidEnvelope
+        }
+        let key = try deriveKey(passphrase: passphrase, salt: salt)
+        do {
+            let ciphertext = combinedCiphertext.dropLast(gcmTagByteCount)
+            let tag = combinedCiphertext.suffix(gcmTagByteCount)
+            let nonce = try AES.GCM.Nonce(data: nonceData)
+            let sealed = try AES.GCM.SealedBox(nonce: nonce, ciphertext: Data(ciphertext), tag: Data(tag))
+            return try AES.GCM.open(sealed, using: key)
+        } catch {
+            throw RemoteBackupError.decryptFailed
+        }
+    }
+
+    private func deriveKey(passphrase: String, salt: Data) throws -> SymmetricKey {
+        let password = Data(passphrase.utf8)
+        var derivedKey = Data(repeating: 0, count: kCCKeySizeAES256)
+
+        let status = derivedKey.withUnsafeMutableBytes { derivedKeyBytes in
+            salt.withUnsafeBytes { saltBytes in
+                password.withUnsafeBytes { passwordBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.bindMemory(to: Int8.self).baseAddress,
+                        password.count,
+                        saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        keyDerivationIterations,
+                        derivedKeyBytes.bindMemory(to: UInt8.self).baseAddress,
+                        kCCKeySizeAES256
+                    )
+                }
+            }
+        }
+
+        guard status == kCCSuccess else {
+            throw RemoteBackupError.keyDerivationFailed
+        }
+        return SymmetricKey(data: derivedKey)
+    }
+
+    private func makeRequest(credentials: WebDAVCredentials, url: URL) throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        request.setValue("application/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        let auth = "\(credentials.username):\(credentials.password)"
+        guard let authData = auth.data(using: .utf8) else {
+            throw RemoteBackupError.invalidCredentials
+        }
+        request.setValue("Basic \(authData.base64EncodedString())", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    private func validate(response: URLResponse, accepted: Set<Int>) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw RemoteBackupError.invalidResponse
+        }
+        guard accepted.contains(http.statusCode) else {
+            throw RemoteBackupError.httpStatus(http.statusCode)
+        }
+    }
+
+    private func propfindBody() -> Data {
+        Data("""
+        <?xml version="1.0" encoding="utf-8" ?>
+        <propfind xmlns="DAV:">
+          <prop>
+            <getlastmodified />
+            <getcontentlength />
+          </prop>
+        </propfind>
+        """.utf8)
+    }
+
+    private func parseBackupFiles(from xml: String, baseURL: URL) -> [RemoteBackupFile] {
+        let hrefs = matches(pattern: #"<[^>]*href[^>]*>(.*?)</[^>]*href>"#, in: xml)
+        return hrefs.compactMap { rawHref in
+            let decoded = rawHref
+                .replacingOccurrences(of: "&amp;", with: "&")
+                .removingPercentEncoding ?? rawHref
+            let name = (decoded as NSString).lastPathComponent
+            guard name.hasSuffix(".\(backupExtension)") else { return nil }
+            return RemoteBackupFile(name: name, url: baseURL.appendingPathComponent(name), size: nil, modifiedAt: nil)
+        }
+        .sorted { $0.name > $1.name }
+    }
+
+    private func matches(pattern: String, in text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard match.numberOfRanges > 1,
+                  let captureRange = Range(match.range(at: 1), in: text) else {
+                return nil
+            }
+            return String(text[captureRange])
+        }
+    }
+
+    private static let filenameDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        return formatter
+    }()
+}

--- a/AI 記帳/Views/Settings/RemoteBackupView.swift
+++ b/AI 記帳/Views/Settings/RemoteBackupView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+import SwiftData
+
+struct RemoteBackupView: View {
+    @Environment(\.modelContext) private var modelContext
+    @AppStorage("webdavBackupURL") private var webdavURL: String = ""
+    @AppStorage("webdavBackupUsername") private var webdavUsername: String = ""
+
+    @State private var webdavPassword: String = ""
+    @State private var backupPassphrase: String = ""
+    @State private var files: [RemoteBackupFile] = []
+    @State private var isBusy = false
+    @State private var message: String?
+    @State private var preview: RemoteBackupPreview?
+    @State private var pendingRestoreBackup: FullBackupData?
+    @State private var showingRestoreConfirm = false
+
+    private let service = RemoteBackupService.shared
+    private let keychainServiceName = "org.duckdns.lhfser.AIMoney.webdav"
+    private let passwordAccountName = "webdav_password"
+    private let passphraseAccountName = "backup_passphrase"
+
+    var body: some View {
+        List {
+            Section("WebDAV 連線") {
+                TextField("WebDAV URL", text: $webdavURL)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                TextField("帳戶", text: $webdavUsername)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                SecureField("WebDAV 密碼", text: $webdavPassword)
+                SecureField("備份加密 passphrase", text: $backupPassphrase)
+                Button {
+                    saveSecrets()
+                    run("連線測試成功") {
+                        try await service.testConnection(credentials: credentials())
+                    }
+                } label: {
+                    Label("測試連線", systemImage: "network")
+                }
+                .disabled(isBusy || !canUseRemoteBackup)
+            }
+
+            Section("遠端備份") {
+                Button {
+                    saveSecrets()
+                    uploadBackup()
+                } label: {
+                    Label("加密並上傳目前備份", systemImage: "icloud.and.arrow.up")
+                }
+                .disabled(isBusy || !canUseRemoteBackup)
+
+                Button {
+                    saveSecrets()
+                    refreshList()
+                } label: {
+                    Label("重新載入遠端備份", systemImage: "arrow.clockwise")
+                }
+                .disabled(isBusy || !canUseRemoteBackup)
+
+                if let message {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("遠端檔案") {
+                if files.isEmpty {
+                    Text("尚未載入遠端備份。")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(files) { file in
+                        Button {
+                            loadPreview(file)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(file.name)
+                                        .foregroundStyle(.primary)
+                                    if let size = file.size {
+                                        Text("\(size) bytes")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .disabled(isBusy)
+                    }
+                }
+            }
+
+            if let preview {
+                Section(preview.title) {
+                    Text(preview.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("確認還原此備份") {
+                        showingRestoreConfirm = true
+                    }
+                    .disabled(pendingRestoreBackup == nil || isBusy)
+                }
+            }
+        }
+        .navigationTitle("WebDAV 遠端備份")
+        .onAppear(perform: loadSecrets)
+        .alert("還原遠端備份？", isPresented: $showingRestoreConfirm) {
+            Button("取消", role: .cancel) {}
+            Button("還原", role: .destructive) {
+                restorePendingBackup()
+            }
+        } message: {
+            Text("這會以遠端備份覆蓋目前資料庫。建議先確認你已有本地備份。")
+        }
+    }
+
+    private var canUseRemoteBackup: Bool {
+        !webdavURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !webdavUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !webdavPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !backupPassphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func loadSecrets() {
+        webdavPassword = KeychainService.shared.read(service: keychainServiceName, account: passwordAccountName) ?? ""
+        backupPassphrase = KeychainService.shared.read(service: keychainServiceName, account: passphraseAccountName) ?? ""
+    }
+
+    private func saveSecrets() {
+        _ = KeychainService.shared.save(service: keychainServiceName, account: passwordAccountName, value: webdavPassword)
+        _ = KeychainService.shared.save(service: keychainServiceName, account: passphraseAccountName, value: backupPassphrase)
+    }
+
+    private func credentials() throws -> WebDAVCredentials {
+        guard let url = URL(string: webdavURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw RemoteBackupError.invalidURL
+        }
+        guard canUseRemoteBackup else {
+            throw RemoteBackupError.invalidCredentials
+        }
+        return WebDAVCredentials(
+            baseURL: url,
+            username: webdavUsername.trimmingCharacters(in: .whitespacesAndNewlines),
+            password: webdavPassword.trimmingCharacters(in: .whitespacesAndNewlines),
+            passphrase: backupPassphrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private func uploadBackup() {
+        run("上傳完成") {
+            let backup = await MainActor.run {
+                BackupManager.shared.createBackupData(modelContext: modelContext)
+            }
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(backup)
+            _ = try await service.uploadBackup(jsonData: data, credentials: credentials())
+            let remoteFiles = try await service.listBackups(credentials: credentials())
+            await MainActor.run {
+                files = remoteFiles
+            }
+        }
+    }
+
+    private func refreshList() {
+        run("已載入遠端備份") {
+            let remoteFiles = try await service.listBackups(credentials: credentials())
+            await MainActor.run {
+                files = remoteFiles
+            }
+        }
+    }
+
+    private func loadPreview(_ file: RemoteBackupFile) {
+        run("已下載並解密備份") {
+            let data = try await service.downloadBackup(file, credentials: credentials())
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let backup = try decoder.decode(FullBackupData.self, from: data)
+            let nextPreview = service.makePreview(from: backup)
+            await MainActor.run {
+                pendingRestoreBackup = backup
+                preview = nextPreview
+            }
+        }
+    }
+
+    private func restorePendingBackup() {
+        guard let pendingRestoreBackup else { return }
+        do {
+            try BackupManager.shared.restoreBackupData(pendingRestoreBackup, modelContext: modelContext, replaceExisting: true)
+            message = "已完成遠端備份還原。"
+        } catch {
+            message = "還原失敗：\(error.localizedDescription)"
+        }
+    }
+
+    private func run(_ successMessage: String, operation: @escaping () async throws -> Void) {
+        guard !isBusy else { return }
+        isBusy = true
+        message = "處理中..."
+        Task {
+            do {
+                try await operation()
+                await MainActor.run {
+                    message = successMessage
+                    isBusy = false
+                }
+            } catch {
+                await MainActor.run {
+                    message = "失敗：\(error.localizedDescription)"
+                    isBusy = false
+                }
+            }
+        }
+    }
+}

--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -160,6 +160,10 @@ struct SettingsView: View {
 
                     Stepper("保留最近 \(backupRetentionDays) 天備份", value: $backupRetentionDays, in: 7...365)
 
+                    NavigationLink(destination: RemoteBackupView()) {
+                        Label("WebDAV 遠端備份", systemImage: "externaldrive.badge.icloud")
+                    }
+
                     Button {
                         let data = BackupManager.shared.createBackupData(modelContext: modelContext)
                         do {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.1.1")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("com.google.code.gson:gson:2.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
     ksp("androidx.room:room-compiler:2.6.1")

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/backup/RemoteBackupService.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/backup/RemoteBackupService.kt
@@ -1,0 +1,287 @@
+package org.duckdns.lhfser.aiaccounting.core.backup
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import com.google.gson.annotations.SerializedName
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.duckdns.lhfser.aiaccounting.data.backup.BackupJsonAdapter
+import org.duckdns.lhfser.aiaccounting.data.backup.FullBackupData
+
+data class WebDavCredentials(
+    val baseUrl: String,
+    val username: String,
+    val password: String,
+    val passphrase: String
+) {
+    val isComplete: Boolean
+        get() = baseUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank() && passphrase.isNotBlank()
+}
+
+data class RemoteBackupFile(
+    val name: String,
+    val url: String
+)
+
+data class RemoteBackupPreview(
+    val title: String,
+    val detail: String
+)
+
+private data class EncryptedBackupEnvelope(
+    val formatVersion: Int,
+    val algorithm: String,
+    val createdAt: Instant,
+    val salt: String,
+    val iv: String,
+    val ciphertext: String,
+    @SerializedName("tagBits") val tagBits: Int = 128
+)
+
+class RemoteBackupService(
+    private val client: OkHttpClient = OkHttpClient()
+) {
+    private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
+    private val xmlMediaType = "application/xml; charset=utf-8".toMediaType()
+    private val backupExtension = "aibackup"
+
+    suspend fun testConnection(credentials: WebDavCredentials) = withContext(Dispatchers.IO) {
+        val request = baseRequest(credentials, credentials.baseUrl)
+            .method("PROPFIND", propfindBody().toRequestBody(xmlMediaType))
+            .header("Depth", "0")
+            .build()
+        client.newCall(request).execute().use { response ->
+            require(response.code in setOf(200, 207)) { "WebDAV HTTP ${response.code}" }
+        }
+    }
+
+    suspend fun listBackups(credentials: WebDavCredentials): List<RemoteBackupFile> = withContext(Dispatchers.IO) {
+        val request = baseRequest(credentials, credentials.baseUrl)
+            .method("PROPFIND", propfindBody().toRequestBody(xmlMediaType))
+            .header("Depth", "1")
+            .build()
+        client.newCall(request).execute().use { response ->
+            require(response.code in setOf(200, 207)) { "WebDAV HTTP ${response.code}" }
+            val body = response.body?.string().orEmpty()
+            parseBackupFiles(body, credentials.baseUrl)
+        }
+    }
+
+    suspend fun uploadBackup(json: String, credentials: WebDavCredentials): RemoteBackupFile = withContext(Dispatchers.IO) {
+        val encrypted = encrypt(json.toByteArray(Charsets.UTF_8), credentials.passphrase)
+        val name = "AIAccounting_Backup_${filenameFormatter.format(Instant.now())}.$backupExtension"
+        val target = credentials.baseUrl.trimEnd('/') + "/" + name
+        val request = baseRequest(credentials, target)
+            .put(encrypted.toRequestBody(jsonMediaType))
+            .build()
+        client.newCall(request).execute().use { response ->
+            require(response.code in setOf(200, 201, 204)) { "WebDAV HTTP ${response.code}" }
+        }
+        RemoteBackupFile(name = name, url = target)
+    }
+
+    suspend fun downloadBackup(file: RemoteBackupFile, credentials: WebDavCredentials): String = withContext(Dispatchers.IO) {
+        val request = baseRequest(credentials, file.url).get().build()
+        client.newCall(request).execute().use { response ->
+            require(response.code == 200) { "WebDAV HTTP ${response.code}" }
+            val encrypted = response.body?.bytes() ?: error("遠端備份內容為空")
+            decrypt(encrypted, credentials.passphrase).toString(Charsets.UTF_8)
+        }
+    }
+
+    fun makePreview(backup: FullBackupData): RemoteBackupPreview {
+        val dates = backup.transactions.map { it.date }
+        val range = if (dates.isEmpty()) {
+            "沒有交易日期"
+        } else {
+            "${dateFormatter.format(dates.minOrNull()!!)} - ${dateFormatter.format(dates.maxOrNull()!!)}"
+        }
+        return RemoteBackupPreview(
+            title = "遠端備份預覽",
+            detail = """
+                版本：${backup.version}
+                建立時間：${dateTimeFormatter.format(backup.timestamp)}
+                帳戶：${backup.accounts.size}
+                交易：${backup.transactions.size}
+                分類：${backup.categories.size}
+                標籤：${backup.tags.size}
+                代墊案件：${backup.advanceCases?.size ?: 0}
+                預算：${backup.budgets?.size ?: 0}
+                日期範圍：$range
+            """.trimIndent()
+        )
+    }
+
+    fun decodeBackup(json: String): FullBackupData {
+        return BackupJsonAdapter.gson.fromJson(json, FullBackupData::class.java)
+    }
+
+    private fun baseRequest(credentials: WebDavCredentials, url: String): Request.Builder {
+        return Request.Builder()
+            .url(url)
+            .header("Authorization", Credentials.basic(credentials.username, credentials.password))
+    }
+
+    private fun propfindBody(): String {
+        return """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <propfind xmlns="DAV:">
+              <prop>
+                <getlastmodified />
+                <getcontentlength />
+              </prop>
+            </propfind>
+        """.trimIndent()
+    }
+
+    private fun parseBackupFiles(xml: String, baseUrl: String): List<RemoteBackupFile> {
+        val regex = Regex("<[^>]*href[^>]*>(.*?)</[^>]*href>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+        return regex.findAll(xml)
+            .mapNotNull { match ->
+                val href = match.groupValues.getOrNull(1).orEmpty()
+                    .replace("&amp;", "&")
+                val name = href.substringAfterLast('/').ifBlank { return@mapNotNull null }
+                val decodedName = java.net.URLDecoder.decode(name, Charsets.UTF_8.name())
+                if (!decodedName.endsWith(".$backupExtension")) return@mapNotNull null
+                RemoteBackupFile(
+                    name = decodedName,
+                    url = baseUrl.trimEnd('/') + "/" + decodedName
+                )
+            }
+            .distinctBy { it.name }
+            .sortedByDescending { it.name }
+            .toList()
+    }
+
+    private fun encrypt(data: ByteArray, passphrase: String): ByteArray {
+        val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val key = deriveKey(passphrase, salt)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+        val ciphertext = cipher.doFinal(data)
+        val envelope = EncryptedBackupEnvelope(
+            formatVersion = 1,
+            algorithm = "AES.GCM.PBKDF2.HMACSHA256",
+            createdAt = Instant.now(),
+            salt = base64(salt),
+            iv = base64(iv),
+            ciphertext = base64(ciphertext)
+        )
+        return BackupJsonAdapter.gson.toJson(envelope).toByteArray(Charsets.UTF_8)
+    }
+
+    private fun decrypt(envelopeBytes: ByteArray, passphrase: String): ByteArray {
+        val envelope = BackupJsonAdapter.gson.fromJson(
+            envelopeBytes.toString(Charsets.UTF_8),
+            EncryptedBackupEnvelope::class.java
+        )
+        require(envelope.formatVersion == 1) { "遠端備份格式版本不支援" }
+        require(envelope.algorithm == "AES.GCM.PBKDF2.HMACSHA256") { "遠端備份加密格式不支援" }
+        val key = deriveKey(passphrase, unbase64(envelope.salt))
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(envelope.tagBits, unbase64(envelope.iv)))
+        return cipher.doFinal(unbase64(envelope.ciphertext))
+    }
+
+    private fun deriveKey(passphrase: String, salt: ByteArray): SecretKeySpec {
+        val spec = PBEKeySpec(passphrase.toCharArray(), salt, 120_000, 256)
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        return SecretKeySpec(factory.generateSecret(spec).encoded, "AES")
+    }
+
+    private fun base64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    private fun unbase64(value: String): ByteArray = Base64.decode(value, Base64.NO_WRAP)
+
+    companion object {
+        private val filenameFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss").withZone(ZoneId.systemDefault())
+        private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
+        private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault())
+    }
+}
+
+class WebDavSettingsStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences("webdav_backup_settings", Context.MODE_PRIVATE)
+    private val cipher = KeystoreStringCipher()
+
+    var baseUrl: String
+        get() = prefs.getString("base_url", "").orEmpty()
+        set(value) { prefs.edit().putString("base_url", value.trim()).apply() }
+
+    var username: String
+        get() = prefs.getString("username", "").orEmpty()
+        set(value) { prefs.edit().putString("username", value.trim()).apply() }
+
+    var password: String
+        get() = prefs.getString("password", null)?.let(cipher::decrypt).orEmpty()
+        set(value) { prefs.edit().putString("password", cipher.encrypt(value.trim())).apply() }
+
+    var passphrase: String
+        get() = prefs.getString("passphrase", null)?.let(cipher::decrypt).orEmpty()
+        set(value) { prefs.edit().putString("passphrase", cipher.encrypt(value.trim())).apply() }
+
+    fun credentials(): WebDavCredentials {
+        return WebDavCredentials(baseUrl = baseUrl, username = username, password = password, passphrase = passphrase)
+    }
+}
+
+private class KeystoreStringCipher {
+    private val alias = "ai_accounting_webdav_settings"
+
+    fun encrypt(value: String): String {
+        if (value.isBlank()) return ""
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        val ciphertext = cipher.doFinal(value.toByteArray(Charsets.UTF_8))
+        return "${base64(cipher.iv)}:${base64(ciphertext)}"
+    }
+
+    fun decrypt(value: String): String {
+        if (value.isBlank() || !value.contains(":")) return ""
+        return runCatching {
+            val parts = value.split(":", limit = 2)
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(128, unbase64(parts[0])))
+            cipher.doFinal(unbase64(parts[1])).toString(Charsets.UTF_8)
+        }.getOrDefault("")
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (keyStore.getKey(alias, null) as? SecretKey)?.let { return it }
+
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+        generator.init(spec)
+        return generator.generateKey()
+    }
+
+    private fun base64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    private fun unbase64(value: String): ByteArray = Base64.decode(value, Base64.NO_WRAP)
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -66,6 +66,7 @@ import org.duckdns.lhfser.aiaccounting.ui.screens.OverviewScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReceiptScanScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.RecurringRuleEditorScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.RecurringTransactionsScreen
+import org.duckdns.lhfser.aiaccounting.ui.screens.RemoteBackupScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.ReportsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.SettingsScreen
 import org.duckdns.lhfser.aiaccounting.ui.screens.SettlementCenterScreen
@@ -108,6 +109,7 @@ private sealed class AppDestination(
     data object Budgets : AppDestination("budgets", "預算與提醒")
     data object Recurring : AppDestination("recurring", "定期記帳")
     data object RecurringEdit : AppDestination("recurring/edit/{ruleId}", "編輯定期記帳")
+    data object RemoteBackup : AppDestination("remote-backup", "WebDAV 遠端備份")
     data object DataHealth : AppDestination("data-health", "資料健康檢查")
     data object Settlements : AppDestination("settlements", "結算中心")
     data object AccountEdit : AppDestination("accounts/edit/{accountId}", "編輯帳戶")
@@ -263,6 +265,7 @@ fun AIAccountingRoot(
                     onOpenTags = { navController.navigate(AppDestination.Tags.route) },
                     onOpenBudgets = { navController.navigate(AppDestination.Budgets.route) },
                     onOpenRecurring = { navController.navigate(AppDestination.Recurring.route) },
+                    onOpenRemoteBackup = { navController.navigate(AppDestination.RemoteBackup.route) },
                     onOpenAdvances = { navController.navigate("advances") },
                     onOpenSettlements = { navController.navigate(AppDestination.Settlements.route) },
                     onOpenHealth = { navController.navigate(AppDestination.DataHealth.route) }
@@ -377,6 +380,7 @@ fun AIAccountingRoot(
                     onDone = { navController.popBackStack() }
                 )
             }
+            composable(AppDestination.RemoteBackup.route) { RemoteBackupScreen() }
             composable(AppDestination.DataHealth.route) { DataHealthScreen() }
             composable(
                 AppDestination.AccountEdit.route,
@@ -529,6 +533,7 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
         route == AppDestination.Budgets.route -> "預算與提醒"
         route == AppDestination.Recurring.route -> "定期記帳"
         route.startsWith("recurring/edit") -> "編輯定期記帳"
+        route == AppDestination.RemoteBackup.route -> "WebDAV 遠端備份"
         route == AppDestination.DataHealth.route -> "資料健康檢查"
         route == AppDestination.Settlements.route -> "結算中心"
         route.startsWith("accounts/edit") -> "編輯帳戶"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
@@ -1,0 +1,273 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.duckdns.lhfser.aiaccounting.core.backup.RemoteBackupFile
+import org.duckdns.lhfser.aiaccounting.core.backup.RemoteBackupPreview
+import org.duckdns.lhfser.aiaccounting.core.backup.RemoteBackupService
+import org.duckdns.lhfser.aiaccounting.core.backup.WebDavCredentials
+import org.duckdns.lhfser.aiaccounting.core.backup.WebDavSettingsStore
+import org.duckdns.lhfser.aiaccounting.data.backup.FullBackupData
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
+import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
+import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+
+@Composable
+fun RemoteBackupScreen() {
+    val repository = LocalRepository.current
+    val context = LocalContext.current
+    val settingsStore = remember(context) { WebDavSettingsStore(context) }
+    val service = remember { RemoteBackupService() }
+    val scope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
+
+    var baseUrl by remember { mutableStateOf(settingsStore.baseUrl) }
+    var username by remember { mutableStateOf(settingsStore.username) }
+    var password by remember { mutableStateOf(settingsStore.password) }
+    var passphrase by remember { mutableStateOf(settingsStore.passphrase) }
+    var files by remember { mutableStateOf<List<RemoteBackupFile>>(emptyList()) }
+    var preview by remember { mutableStateOf<RemoteBackupPreview?>(null) }
+    var pendingRestore by remember { mutableStateOf<FullBackupData?>(null) }
+    var message by remember { mutableStateOf<String?>(null) }
+    var isBusy by remember { mutableStateOf(false) }
+    var showRestoreConfirm by remember { mutableStateOf(false) }
+
+    fun saveSettings() {
+        settingsStore.baseUrl = baseUrl
+        settingsStore.username = username
+        settingsStore.password = password
+        settingsStore.passphrase = passphrase
+    }
+
+    fun credentials(): WebDavCredentials {
+        return WebDavCredentials(
+            baseUrl = baseUrl.trim(),
+            username = username.trim(),
+            password = password.trim(),
+            passphrase = passphrase.trim()
+        )
+    }
+
+    fun runRemote(successMessage: String, block: suspend () -> Unit) {
+        if (isBusy) return
+        val creds = credentials()
+        if (!creds.isComplete) {
+            message = "請先填寫 WebDAV URL、帳戶、密碼和加密 passphrase。"
+            return
+        }
+        saveSettings()
+        isBusy = true
+        message = "處理中..."
+        scope.launch {
+            runCatching { block() }
+                .onSuccess { message = successMessage }
+                .onFailure { message = "失敗：${it.localizedMessage ?: it.message ?: "未知錯誤"}" }
+            isBusy = false
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(
+                start = AppSpacing.screenHorizontal,
+                end = AppSpacing.screenHorizontal,
+                top = AppSpacing.screenVertical,
+                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+            ),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+    ) {
+        ParityTopSection(
+            title = "WebDAV 遠端備份",
+            subtitle = "手動加密上傳、下載預覽，再確認還原。"
+        )
+
+        ParitySectionHeader(title = "連線設定")
+        SectionCard {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = baseUrl,
+                    onValueChange = { baseUrl = it },
+                    label = { Text("WebDAV URL") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                OutlinedTextField(
+                    value = username,
+                    onValueChange = { username = it },
+                    label = { Text("帳戶") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("WebDAV 密碼") },
+                    modifier = Modifier.fillMaxWidth(),
+                    visualTransformation = PasswordVisualTransformation(),
+                    singleLine = true
+                )
+                OutlinedTextField(
+                    value = passphrase,
+                    onValueChange = { passphrase = it },
+                    label = { Text("備份加密 passphrase") },
+                    modifier = Modifier.fillMaxWidth(),
+                    visualTransformation = PasswordVisualTransformation(),
+                    singleLine = true
+                )
+                Button(
+                    onClick = {
+                        runRemote("連線測試成功。") {
+                            service.testConnection(credentials())
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth().height(50.dp)
+                ) {
+                    Text("測試連線")
+                }
+            }
+        }
+
+        ParitySectionHeader(title = "遠端備份")
+        SectionCard {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Button(
+                    onClick = {
+                        runRemote("加密上傳完成。") {
+                            service.uploadBackup(repository.exportBackupJson(), credentials())
+                            files = service.listBackups(credentials())
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth().height(50.dp)
+                ) {
+                    Text("加密並上傳目前備份")
+                }
+                Button(
+                    onClick = {
+                        runRemote("已載入遠端備份。") {
+                            files = service.listBackups(credentials())
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                ) {
+                    Text("重新載入遠端備份")
+                }
+                if (message != null) {
+                    Text(message.orEmpty(), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        ParitySectionHeader(title = "遠端檔案")
+        if (files.isEmpty()) {
+            SectionCard {
+                Text(
+                    "尚未載入遠端備份。",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            files.forEach { file ->
+                PressableCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        runRemote("已下載並解密備份。") {
+                            val json = service.downloadBackup(file, credentials())
+                            val backup = service.decodeBackup(json)
+                            pendingRestore = backup
+                            preview = service.makePreview(backup)
+                        }
+                    }
+                ) {
+                    Row(
+                        modifier = Modifier.padding(AppSpacing.card).fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline)
+                    ) {
+                        Text(file.name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.titleSmall)
+                        Text("預覽", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+            }
+        }
+
+        preview?.let { currentPreview ->
+            ParitySectionHeader(title = currentPreview.title)
+            SectionCard {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Text(currentPreview.detail, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Button(
+                        onClick = { showRestoreConfirm = true },
+                        enabled = pendingRestore != null && !isBusy,
+                        modifier = Modifier.fillMaxWidth().height(50.dp)
+                    ) {
+                        Text("確認還原此備份")
+                    }
+                }
+            }
+        }
+    }
+
+    if (showRestoreConfirm) {
+        AlertDialog(
+            onDismissRequest = { showRestoreConfirm = false },
+            title = { Text("還原遠端備份？") },
+            text = { Text("這會以遠端備份覆蓋目前資料庫。建議先確認你已有本地備份。") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val backup = pendingRestore ?: return@TextButton
+                        showRestoreConfirm = false
+                        scope.launch {
+                            runCatching {
+                                repository.importBackupJson(
+                                    org.duckdns.lhfser.aiaccounting.data.backup.BackupJsonAdapter.gson.toJson(backup),
+                                    replaceExisting = true
+                                )
+                            }.onSuccess {
+                                message = "已完成遠端備份還原。"
+                            }.onFailure {
+                                message = "還原失敗：${it.localizedMessage ?: "未知錯誤"}"
+                            }
+                        }
+                    }
+                ) {
+                    Text("還原", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRestoreConfirm = false }) { Text("取消") }
+            }
+        )
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -53,6 +53,7 @@ fun SettingsScreen(
     onOpenTags: () -> Unit,
     onOpenBudgets: () -> Unit,
     onOpenRecurring: () -> Unit,
+    onOpenRemoteBackup: () -> Unit,
     onOpenAdvances: () -> Unit,
     onOpenSettlements: () -> Unit,
     onOpenHealth: () -> Unit
@@ -222,6 +223,7 @@ fun SettingsScreen(
                 ) {
                     Text("匯入 JSON 備份")
                 }
+                ParitySettingRow("WebDAV 遠端備份", "加密上傳、下載預覽並手動還原", onClick = onOpenRemoteBackup)
                 if (message != null) {
                     Text(message.orEmpty(), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }


### PR DESCRIPTION
## Summary
- Add manual WebDAV remote backup on iOS and Android.
- Encrypt remote backup payloads before upload and decrypt before preview/restore.
- Store WebDAV secrets locally only: iOS Keychain and Android Keystore-backed preferences.
- Add restore preview with version, timestamp, record counts, and date range before destructive restore.
- Align restore semantics across platforms: confirmed remote restore replaces current local data.

Closes #34

## Notes
- This is manual remote backup, not live multi-device sync.
- Remote backup files use `.aibackup` encrypted envelopes.
- Cross-platform envelope uses `AES.GCM.PBKDF2.HMACSHA256`.
- `Localizable.xcstrings` remains a local uncommitted change and is not included in this PR.

## Validation
- `xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild test -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' -only-testing:'AI 記帳Tests/BackupCompatibilityTests' CODE_SIGNING_ALLOWED=NO`
- `./gradlew assembleDebug`
- `./gradlew testDebugUnitTest`
- `git diff --cached --check`
- cached diff privacy scan for local paths, account strings, API keys/tokens, and local signing files
