### PR TITLE
Improve iOS ledger edit rendering performance

### DIFF
--- a/AI 記帳.xcodeproj/project.pbxproj
+++ b/AI 記帳.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		FFA001000000000000000004 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFA001000000000000000002 /* XCTest.framework */; };
+		FFA002000000000000000004 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFA001000000000000000002 /* XCTest.framework */; };
 		FFE186662F067E15007E709F /* GoogleGenerativeAI in Frameworks */ = {isa = PBXBuildFile; productRef = FFE186652F067E15007E709F /* GoogleGenerativeAI */; };
 		FFE186742F06A5DB007E709F /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = FFE186732F06A5DB007E709F /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
@@ -20,11 +21,19 @@
 			remoteGlobalIDString = FF50821C2F057AD70012E7D0;
 			remoteInfo = "AI 記帳";
 		};
+		FFA00200000000000000000D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FF5082152F057AD70012E7D0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF50821C2F057AD70012E7D0;
+			remoteInfo = "AI 記帳";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		FF50821D2F057AD70012E7D0 /* AI 記帳.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AI 記帳.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFA001000000000000000001 /* AI 記帳Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AI 記帳Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFA002000000000000000001 /* AI 記帳UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AI 記帳UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFA001000000000000000002 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		FFE186732F06A5DB007E709F /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -38,6 +47,11 @@
 		FFA001000000000000000003 /* AI 記帳Tests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "AI 記帳Tests";
+			sourceTree = "<group>";
+		};
+		FFA002000000000000000003 /* AI 記帳UITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "AI 記帳UITests";
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -59,6 +73,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FFA002000000000000000005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FFA002000000000000000004 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -68,8 +90,10 @@
 				FFE186732F06A5DB007E709F /* Localizable.xcstrings */,
 				FF50821D2F057AD70012E7D0 /* AI 記帳.app */,
 				FFA001000000000000000001 /* AI 記帳Tests.xctest */,
+				FFA002000000000000000001 /* AI 記帳UITests.xctest */,
 				FF50821F2F057AD70012E7D0 /* AI 記帳 */,
 				FFA001000000000000000003 /* AI 記帳Tests */,
+				FFA002000000000000000003 /* AI 記帳UITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -122,6 +146,29 @@
 			productReference = FFA001000000000000000001 /* AI 記帳Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FFA002000000000000000008 /* AI 記帳UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FFA00200000000000000000B /* Build configuration list for PBXNativeTarget "AI 記帳UITests" */;
+			buildPhases = (
+				FFA002000000000000000006 /* Sources */,
+				FFA002000000000000000005 /* Frameworks */,
+				FFA002000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FFA00200000000000000000E /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				FFA002000000000000000003 /* AI 記帳UITests */,
+			);
+			name = "AI 記帳UITests";
+			packageProductDependencies = (
+			);
+			productName = "AI 記帳UITests";
+			productReference = FFA002000000000000000001 /* AI 記帳UITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -136,6 +183,10 @@
 						CreatedOnToolsVersion = 26.2;
 					};
 					FFA001000000000000000008 = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = FF50821C2F057AD70012E7D0;
+					};
+					FFA002000000000000000008 = {
 						CreatedOnToolsVersion = 26.2;
 						TestTargetID = FF50821C2F057AD70012E7D0;
 					};
@@ -165,6 +216,7 @@
 			targets = (
 				FF50821C2F057AD70012E7D0 /* AI 記帳 */,
 				FFA001000000000000000008 /* AI 記帳Tests */,
+				FFA002000000000000000008 /* AI 記帳UITests */,
 			);
 		};
 /* End PBXProject section */
@@ -179,6 +231,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		FFA001000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FFA002000000000000000007 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -202,6 +261,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FFA002000000000000000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -209,6 +275,11 @@
 			isa = PBXTargetDependency;
 			target = FF50821C2F057AD70012E7D0 /* AI 記帳 */;
 			targetProxy = FFA00100000000000000000D /* PBXContainerItemProxy */;
+		};
+		FFA00200000000000000000E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FF50821C2F057AD70012E7D0 /* AI 記帳 */;
+			targetProxy = FFA00200000000000000000D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -464,6 +535,58 @@
 				};
 				name = Release;
 			};
+		FFA002000000000000000009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8999ZB8MC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.duckdns.lhfser.AIMoneyUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "AI 記帳";
+			};
+			name = Debug;
+		};
+		FFA00200000000000000000A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8999ZB8MC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.duckdns.lhfser.AIMoneyUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "AI 記帳";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -490,6 +613,15 @@
 			buildConfigurations = (
 				FFA001000000000000000009 /* Debug */,
 				FFA00100000000000000000A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FFA00200000000000000000B /* Build configuration list for PBXNativeTarget "AI 記帳UITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FFA002000000000000000009 /* Debug */,
+				FFA00200000000000000000A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AI 記帳.xcodeproj/xcshareddata/xcschemes/AI 記帳UITests.xcscheme
+++ b/AI 記帳.xcodeproj/xcshareddata/xcschemes/AI 記帳UITests.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FF50821C2F057AD70012E7D0"
+               BuildableName = "AI &#x8a18;&#x5e33;.app"
+               BlueprintName = "AI &#x8a18;&#x5e33;"
+               ReferencedContainer = "container:AI &#x8a18;&#x5e33;.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FFA002000000000000000008"
+               BuildableName = "AI &#x8a18;&#x5e33;UITests.xctest"
+               BlueprintName = "AI &#x8a18;&#x5e33;UITests"
+               ReferencedContainer = "container:AI &#x8a18;&#x5e33;.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FFA002000000000000000008"
+               BuildableName = "AI &#x8a18;&#x5e33;UITests.xctest"
+               BlueprintName = "AI &#x8a18;&#x5e33;UITests"
+               ReferencedContainer = "container:AI &#x8a18;&#x5e33;.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF50821C2F057AD70012E7D0"
+            BuildableName = "AI &#x8a18;&#x5e33;.app"
+            BlueprintName = "AI &#x8a18;&#x5e33;"
+            ReferencedContainer = "container:AI &#x8a18;&#x5e33;.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF50821C2F057AD70012E7D0"
+            BuildableName = "AI &#x8a18;&#x5e33;.app"
+            BlueprintName = "AI &#x8a18;&#x5e33;"
+            ReferencedContainer = "container:AI &#x8a18;&#x5e33;.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -6,6 +6,12 @@ private extension ProcessInfo {
     static var isRunningXCTest: Bool {
         processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
+
+    static var usesInMemoryStoreForTests: Bool {
+        isRunningXCTest
+            || processInfo.environment["AI_ACCOUNTING_UI_TESTS"] == "1"
+            || processInfo.arguments.contains("-UITestSeedLedgerPerformanceData")
+    }
 }
 
 @main
@@ -202,7 +208,7 @@ struct AI___App: App {
             AdvanceRepayment.self
         ])
 
-        if ProcessInfo.isRunningXCTest {
+        if ProcessInfo.usesInMemoryStoreForTests {
             let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
             do {
                 return try ModelContainer(for: schema, configurations: [configuration])

--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -34,6 +34,9 @@ struct ContentView: View {
     @State private var idleBackupTask: Task<Void, Never>?
     @State private var showingUserGuide = false
     @State private var initialGuideChecked = false
+#if DEBUG
+    @State private var uiTestSeeded = false
+#endif
 
     private var budgetHistorySyncToken: Int {
         var hasher = Hasher()
@@ -79,6 +82,8 @@ struct ContentView: View {
 
     private var isRunningXCTest: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            || ProcessInfo.processInfo.environment["AI_ACCOUNTING_UI_TESTS"] == "1"
+            || ProcessInfo.processInfo.arguments.contains("-UITestSeedLedgerPerformanceData")
     }
 
     var body: some View {
@@ -191,6 +196,11 @@ struct ContentView: View {
                 showingUserGuide = true
             }
         }
+#if DEBUG
+        .task {
+            seedUITestDataIfNeeded()
+        }
+#endif
         .task(id: budgetHistorySyncToken) {
             guard !isRunningXCTest else { return }
             do {
@@ -230,6 +240,7 @@ struct ContentView: View {
             }
         }
         .accessibilityLabel("新增記錄")
+        .accessibilityIdentifier("global.addButton")
     }
 
     private func floatingButtonBottomPadding(safeAreaBottom: CGFloat) -> CGFloat {
@@ -258,4 +269,15 @@ struct ContentView: View {
             print("⚠️ 定期記帳同步失敗: \(error)")
         }
     }
+
+#if DEBUG
+    @MainActor
+    private func seedUITestDataIfNeeded() {
+        guard ProcessInfo.processInfo.arguments.contains("-UITestSeedLedgerPerformanceData") else { return }
+        guard !uiTestSeeded else { return }
+        uiTestSeeded = true
+        selectedTab = .ledger
+        UITestSeedService.seedLedgerPerformanceData(in: modelContext)
+    }
+#endif
 }

--- a/AI 記帳/Services/TransferPresentationService.swift
+++ b/AI 記帳/Services/TransferPresentationService.swift
@@ -5,11 +5,26 @@ struct TransferCounterpartInfo {
     let currencyCode: String
 }
 
+struct TransferCounterpartInput {
+    let id: UUID
+    let type: TransactionType
+    let amount: Decimal
+    let currencyCode: String
+    let linkedTransactionID: UUID?
+    let transferGroupID: UUID?
+    let transferSide: TransferSide?
+}
+
 enum TransferPresentationService {
+    @MainActor
     static func counterpartMap(transactions: [FinancialTransaction]) -> [UUID: TransferCounterpartInfo] {
-        let transferTransactions = transactions.filter { $0.type == .transfer }
+        counterpartMap(inputs: transactions.map(TransferCounterpartInput.init))
+    }
+
+    static func counterpartMap(inputs: [TransferCounterpartInput]) -> [UUID: TransferCounterpartInfo] {
+        let transferTransactions = inputs.filter { $0.type == .transfer }
         let idIndex = Dictionary(uniqueKeysWithValues: transferTransactions.map { ($0.id, $0) })
-        let groupIndex = Dictionary(grouping: transferTransactions.compactMap { tx -> (UUID, FinancialTransaction)? in
+        let groupIndex = Dictionary(grouping: transferTransactions.compactMap { tx -> (UUID, TransferCounterpartInput)? in
             guard let groupID = tx.transferGroupID else { return nil }
             return (groupID, tx)
         }, by: { $0.0 }).mapValues { $0.map(\.1) }
@@ -40,5 +55,19 @@ enum TransferPresentationService {
         }
         
         return result
+    }
+}
+
+private extension TransferCounterpartInput {
+    init(transaction: FinancialTransaction) {
+        self.init(
+            id: transaction.id,
+            type: transaction.type,
+            amount: transaction.amount,
+            currencyCode: transaction.currencyCode,
+            linkedTransactionID: transaction.linkedTransactionID,
+            transferGroupID: transaction.transferGroupID,
+            transferSide: transaction.transferSide
+        )
     }
 }

--- a/AI 記帳/Services/UITestSeedService.swift
+++ b/AI 記帳/Services/UITestSeedService.swift
@@ -1,0 +1,149 @@
+#if DEBUG
+import Foundation
+import SwiftData
+
+@MainActor
+enum UITestSeedService {
+    static func seedLedgerPerformanceData(in modelContext: ModelContext) {
+        do {
+            let existing = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+            guard !existing.contains(where: { $0.note.contains("UITest") }) else { return }
+        } catch {
+            return
+        }
+
+        let cash = Account(name: "UITest Cash", currency: "HKD", type: .cash, baseBalance: 1_000, sortOrder: 1)
+        let bank = Account(name: "UITest Bank HKD", currency: "HKD", type: .bank, baseBalance: 8_000, sortOrder: 2)
+        let usdPocket = Account(name: "UITest Bank USD", currency: "USD", type: .bank, baseBalance: 500, sortOrder: 3)
+        let friendDebt = Account(name: "UITest Friend Debt", currency: "HKD", type: .debt, baseBalance: 0, sortOrder: 4)
+
+        let food = Category(name: "UITest Food", icon: "fork.knife", colorHex: "FF9500", kind: .expense)
+        let repaymentCategory = Category(name: "UITest Repayment", icon: "arrow.down.circle", colorHex: "30B0C7", kind: .income)
+        let tag = Tag(name: "UITest")
+
+        modelContext.insert(cash)
+        modelContext.insert(bank)
+        modelContext.insert(usdPocket)
+        modelContext.insert(friendDebt)
+        modelContext.insert(food)
+        modelContext.insert(repaymentCategory)
+        modelContext.insert(tag)
+
+        let now = Date()
+        let expense = FinancialTransaction(
+            amount: -42,
+            currencyCode: "HKD",
+            date: now.addingTimeInterval(-60),
+            note: "UITest 普通支出",
+            type: .expense,
+            account: cash,
+            category: food,
+            tags: [tag]
+        )
+
+        let transferGroupID = UUID()
+        let transferOutID = UUID()
+        let transferInID = UUID()
+        let transferOut = FinancialTransaction(
+            id: transferOutID,
+            amount: -100,
+            currencyCode: "HKD",
+            date: now.addingTimeInterval(-120),
+            note: "UITest 轉帳",
+            type: .transfer,
+            linkedTransactionID: transferInID,
+            transferGroupID: transferGroupID,
+            transferSide: .outgoing,
+            account: bank
+        )
+        let transferIn = FinancialTransaction(
+            id: transferInID,
+            amount: 12.8,
+            currencyCode: "USD",
+            date: now.addingTimeInterval(-120),
+            note: "UITest 轉帳",
+            type: .transfer,
+            linkedTransactionID: transferOutID,
+            transferGroupID: transferGroupID,
+            transferSide: .incoming,
+            account: usdPocket
+        )
+
+        let advanceCase = AdvanceCase(
+            title: "UITest 代墊晚餐",
+            date: now.addingTimeInterval(-180),
+            currencyCode: "HKD",
+            myShareAmount: 50,
+            note: "UITest 代墊案件",
+            payerAccount: cash,
+            expenseCategory: food
+        )
+        let participant = AdvanceParticipant(
+            name: "UITest Friend",
+            owedAmount: 80,
+            repaidAmount: 20,
+            advanceCase: advanceCase,
+            debtAccount: friendDebt
+        )
+        advanceCase.participants = [participant]
+
+        let repaymentGroupID = UUID()
+        let repaymentOutID = UUID()
+        let repaymentInID = UUID()
+        let repayment = AdvanceRepayment(
+            amount: 20,
+            currencyCode: "HKD",
+            normalizedAmount: 20,
+            date: now.addingTimeInterval(-240),
+            note: "UITest 代墊還款",
+            linkedTransferGroupID: repaymentGroupID,
+            advanceCase: advanceCase,
+            participant: participant,
+            receivedAccount: bank
+        )
+        advanceCase.repayments = [repayment]
+
+        let repaymentOut = FinancialTransaction(
+            id: repaymentOutID,
+            amount: -20,
+            currencyCode: "HKD",
+            date: now.addingTimeInterval(-240),
+            note: "UITest 代墊還款 (還款至 UITest Bank HKD)",
+            type: .transfer,
+            linkedTransactionID: repaymentInID,
+            transferGroupID: repaymentGroupID,
+            transferSide: .outgoing,
+            account: friendDebt
+        )
+        let repaymentIn = FinancialTransaction(
+            id: repaymentInID,
+            amount: 20,
+            currencyCode: "HKD",
+            date: now.addingTimeInterval(-240),
+            note: "UITest 代墊還款 (還款至 UITest Bank HKD)",
+            type: .transfer,
+            linkedTransactionID: repaymentOutID,
+            transferGroupID: repaymentGroupID,
+            transferSide: .incoming,
+            account: bank,
+            category: repaymentCategory,
+            tags: [tag]
+        )
+
+        modelContext.insert(expense)
+        modelContext.insert(transferOut)
+        modelContext.insert(transferIn)
+        modelContext.insert(advanceCase)
+        modelContext.insert(participant)
+        modelContext.insert(repayment)
+        modelContext.insert(repaymentOut)
+        modelContext.insert(repaymentIn)
+
+        do {
+            try modelContext.save()
+        } catch {
+            print("⚠️ UI test seed failed: \(error)")
+        }
+    }
+}
+#endif

--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -6,15 +6,6 @@ struct AccountDetailView: View {
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
     @Environment(\.modelContext) private var modelContext
     
-    // 只篩選該帳戶的交易
-    var accountTransactions: [FinancialTransaction] {
-        allTransactions.filter { $0.account?.id == account.id }
-    }
-    
-    private var transferCounterpartByID: [UUID: TransferCounterpartInfo] {
-        TransferPresentationService.counterpartMap(transactions: allTransactions)
-    }
-    
     // 🔥 修正 1：定義一個結構體來代替 Tuple，讓 ForEach 能識別
     struct CurrencyBalance: Identifiable {
         var id: String { currency } // 使用幣種作為唯一 ID
@@ -22,41 +13,22 @@ struct AccountDetailView: View {
         let amount: Decimal
     }
     
-    // 🔥 修正 2：回傳 [CurrencyBalance] 結構體陣列
-    var currencyBalances: [CurrencyBalance] {
-        var balances: [String: Decimal] = [:]
-        
-        // 1. 加上初始餘額 (歸入帳戶預設幣種)
-        if account.baseBalance != 0 {
-            balances[account.currency, default: 0] += account.baseBalance
-        }
-        
-        // 2. 加上所有交易 (歸入交易各自的幣種)
-        for tx in accountTransactions {
-            balances[tx.currencyCode, default: 0] += tx.amount
-        }
-        
-        // 過濾掉金額為 0 的，並轉為結構體陣列
-        return balances
-            .filter { $0.value != 0 }
-            .map { CurrencyBalance(currency: $0.key, amount: $0.value) }
-            .sorted { $0.currency < $1.currency }
-    }
-    
     var body: some View {
+        let renderState = AccountDetailRenderState(account: account, allTransactions: allTransactions)
+
         List {
             // 1. 頂部資訊卡 (總覽)
             Section {
                 VStack(spacing: 16) {
                     
-                    if currencyBalances.isEmpty {
+                    if renderState.currencyBalances.isEmpty {
                         // 如果剛好歸零，顯示 0 (預設幣種)
                         Text(Decimal(0).formatted(.currency(code: account.currency)))
                             .font(.system(size: 36, weight: .bold))
                             .foregroundStyle(.secondary)
                     } else {
                         // 🔥 修正 3：現在 ForEach 可以正常運作了
-                        ForEach(currencyBalances) { item in
+                        ForEach(renderState.currencyBalances) { item in
                             HStack {
                                 Text(item.currency)
                                     .font(.headline)
@@ -72,12 +44,12 @@ struct AccountDetailView: View {
                             }
                             
                             // 分隔線邏輯：如果不是最後一個，顯示分隔線
-                            if item.id != currencyBalances.last?.id {
+                            if item.id != renderState.currencyBalances.last?.id {
                                 Divider()
                             }
                         }
                     }
-                    
+
                     HStack {
                         Text(account.name)
                             .font(.headline)
@@ -98,10 +70,10 @@ struct AccountDetailView: View {
             
             // 2. 交易列表
             Section("交易紀錄") {
-                ForEach(accountTransactions) { transaction in
+                ForEach(renderState.accountTransactions) { transaction in
                     TransactionRow(
                         transaction: transaction,
-                        transferCounterpart: transferCounterpartByID[transaction.id]
+                        transferCounterpart: renderState.transferCounterpartByID[transaction.id]
                     )
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             Button(role: .destructive) {
@@ -140,5 +112,42 @@ struct AccountDetailView: View {
         }
         
         modelContext.delete(transaction)
+    }
+}
+
+private struct AccountDetailRenderState {
+    let accountTransactions: [FinancialTransaction]
+    let transferCounterpartByID: [UUID: TransferCounterpartInfo]
+    let currencyBalances: [AccountDetailView.CurrencyBalance]
+
+    init(account: Account, allTransactions: [FinancialTransaction]) {
+        let accountTransactions = allTransactions.filter { $0.account?.id == account.id }
+
+        self.accountTransactions = accountTransactions
+        self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: allTransactions)
+        self.currencyBalances = Self.currencyBalances(
+            account: account,
+            accountTransactions: accountTransactions
+        )
+    }
+
+    private static func currencyBalances(
+        account: Account,
+        accountTransactions: [FinancialTransaction]
+    ) -> [AccountDetailView.CurrencyBalance] {
+        var balances: [String: Decimal] = [:]
+
+        if account.baseBalance != 0 {
+            balances[account.currency, default: 0] += account.baseBalance
+        }
+
+        for tx in accountTransactions {
+            balances[tx.currencyCode, default: 0] += tx.amount
+        }
+
+        return balances
+            .filter { $0.value != 0 }
+            .map { AccountDetailView.CurrencyBalance(currency: $0.key, amount: $0.value) }
+            .sorted { $0.currency < $1.currency }
     }
 }

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -55,6 +55,8 @@ struct ChartsView: View {
     }
     
     var body: some View {
+        let renderState = makeRenderState()
+
         NavigationStack {
             VStack(spacing: 0) {
                 // 頂部控制列
@@ -96,22 +98,22 @@ struct ChartsView: View {
                 
                 // 內容區
                 ScrollView {
-                    if currentData.isEmpty {
+                    if renderState.currentData.isEmpty {
                         ContentUnavailableView(flowMode.emptyTitle, systemImage: "chart.pie", description: Text("試試切換日期或記一筆帳"))
                             .padding(.top, 40)
                     } else if chartMode == .tag && selectedTagForDetail != nil {
-                        tagDetailView
+                        tagDetailView(renderState: renderState)
                     } else {
-                        mainChartView
+                        mainChartView(data: renderState.currentData)
                     }
                 }
                 
-                if !budgetAlerts.isEmpty && flowMode == .expense {
+                if !renderState.budgetAlerts.isEmpty && flowMode == .expense {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("本月超支提醒")
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                        ForEach(budgetAlerts.prefix(3)) { status in
+                        ForEach(renderState.budgetAlerts.prefix(3)) { status in
                             HStack {
                                 Text(status.budget.category?.name ?? "未分類")
                                     .font(.caption)
@@ -141,14 +143,14 @@ struct ChartsView: View {
     }
     
     // MARK: - 主圖表視圖
-    var mainChartView: some View {
+    func mainChartView(data: [ChartData]) -> some View {
         VStack(spacing: 24) {
-            chartView(data: currentData)
+            chartView(data: data)
                 .frame(height: 300)
                 .padding(.horizontal)
             
             LazyVStack(spacing: 16) {
-                ForEach(currentData, id: \.key) { item in
+                ForEach(data, id: \.key) { item in
                     Button(action: {
                         if chartMode == .tag {
                             withAnimation { selectedTagForDetail = item.name }
@@ -158,7 +160,7 @@ struct ChartsView: View {
                     }) {
                         rowView(
                             item: item,
-                            total: totalAmount(data: currentData),
+                            total: totalAmount(data: data),
                             trailingIcon: chartMode == .tag ? "chevron.right" : "list.bullet"
                         )
                     }
@@ -170,7 +172,7 @@ struct ChartsView: View {
     }
     
     // MARK: - 標籤詳情視圖
-    var tagDetailView: some View {
+    private func tagDetailView(renderState: ChartsRenderState) -> some View {
         VStack(spacing: 24) {
             HStack {
                 Button(action: { withAnimation { selectedTagForDetail = nil } }) {
@@ -183,7 +185,7 @@ struct ChartsView: View {
             }
             .padding(.horizontal)
             
-            let detailData = getCategoryBreakdown(for: selectedTagForDetail!)
+            let detailData = renderState.categoryBreakdown(for: selectedTagForDetail)
             
             if detailData.isEmpty {
                 ContentUnavailableView("此標籤無分類數據", systemImage: "tag.slash")
@@ -266,85 +268,24 @@ struct ChartsView: View {
     }
     
     // MARK: - Data Logic
+    private func makeRenderState() -> ChartsRenderState {
+        ChartsRenderState(
+            transactions: transactions,
+            budgets: budgets,
+            currencyService: currencyService,
+            filterType: filterType,
+            selectedDate: selectedDate,
+            chartMode: chartMode,
+            flowMode: flowMode
+        )
+    }
+
     struct ChartData {
         let key: String
         let name: String
         let amount: Decimal
         let color: Color
         let transactions: [FinancialTransaction]
-    }
-    
-    var currentData: [ChartData] {
-        if chartMode == .category {
-            let grouped = Dictionary(grouping: filteredTransactions) { $0.category?.id.uuidString ?? "uncategorized" }
-            let sorted = grouped.sorted {
-                let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-                let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-                return sum0 > sum1
-            }
-            return sorted.map { item in
-                let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-                let category = item.value.compactMap { $0.category }.first
-                let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
-                return ChartData(
-                    key: item.key,
-                    name: category?.name ?? "未分類",
-                    amount: total,
-                    color: displayColor,
-                    transactions: item.value
-                )
-            }
-        } else {
-            var tagDict: [String: Decimal] = [:]
-            var tagTransactions: [String: [FinancialTransaction]] = [:]
-            for tx in filteredTransactions {
-                let amount = currencyService.convert(amount: abs(tx.amount), from: tx.currencyCode)
-                if tx.tags.isEmpty {
-                    tagDict["無標籤", default: 0] += amount
-                    tagTransactions["無標籤", default: []].append(tx)
-                } else {
-                    for tag in tx.tags {
-                        tagDict[tag.name, default: 0] += amount
-                        tagTransactions[tag.name, default: []].append(tx)
-                    }
-                }
-            }
-            let sorted = tagDict.sorted { $0.value > $1.value }
-            return sorted.enumerated().map { (index, item) in
-                ChartData(
-                    key: item.key,
-                    name: item.key,
-                    amount: item.value,
-                    color: Color.generateDistinctColor(index: index, total: sorted.count),
-                    transactions: tagTransactions[item.key] ?? []
-                )
-            }
-        }
-    }
-    
-    func getCategoryBreakdown(for tagName: String) -> [ChartData] {
-        let tagTransactions = filteredTransactions.filter { tx in
-            if tagName == "無標籤" { return tx.tags.isEmpty }
-            return tx.tags.contains { $0.name == tagName }
-        }
-        let grouped = Dictionary(grouping: tagTransactions) { $0.category?.id.uuidString ?? "uncategorized" }
-        let sorted = grouped.sorted {
-            let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-            let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-            return sum0 > sum1
-        }
-        return sorted.map { item in
-            let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-            let category = item.value.compactMap { $0.category }.first
-            let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
-            return ChartData(
-                key: item.key,
-                name: category?.name ?? "未分類",
-                amount: total,
-                color: displayColor,
-                transactions: item.value
-            )
-        }
     }
     
     func presentTransactions(for item: ChartData, tagName: String? = nil) {
@@ -372,8 +313,66 @@ struct ChartsView: View {
             let f = DateFormatter(); f.dateFormat = "M月d日"; return f.string(from: selectedDate)
         }
     }
-    
-    var filteredExpenses: [FinancialTransaction] {
+}
+
+private struct ChartsRenderState {
+    let filteredTransactions: [FinancialTransaction]
+    let currentData: [ChartsView.ChartData]
+    let budgetAlerts: [BudgetStatus]
+
+    private let currencyService: CurrencyService
+
+    init(
+        transactions: [FinancialTransaction],
+        budgets: [CategoryMonthlyBudget],
+        currencyService: CurrencyService,
+        filterType: FilterType,
+        selectedDate: Date,
+        chartMode: ChartsView.ChartMode,
+        flowMode: ChartsView.FlowMode
+    ) {
+        let filteredTransactions = Self.filteredTransactions(
+            from: transactions,
+            filterType: filterType,
+            selectedDate: selectedDate,
+            flowMode: flowMode
+        )
+
+        self.filteredTransactions = filteredTransactions
+        self.currentData = Self.currentData(
+            from: filteredTransactions,
+            chartMode: chartMode,
+            currencyService: currencyService
+        )
+        self.budgetAlerts = BudgetService.statuses(
+            for: BudgetService.monthKey(from: Date()),
+            budgets: budgets,
+            transactions: transactions,
+            currencyService: currencyService
+        )
+        .filter { $0.ratio >= 1 }
+        self.currencyService = currencyService
+    }
+
+    func categoryBreakdown(for tagName: String?) -> [ChartsView.ChartData] {
+        guard let tagName else { return [] }
+
+        let tagTransactions = filteredTransactions.filter { tx in
+            if tagName == "無標籤" { return tx.tags.isEmpty }
+            return tx.tags.contains { $0.name == tagName }
+        }
+        return Self.categoryBreakdown(
+            from: tagTransactions,
+            currencyService: currencyService
+        )
+    }
+
+    private static func filteredTransactions(
+        from transactions: [FinancialTransaction],
+        filterType: FilterType,
+        selectedDate: Date,
+        flowMode: ChartsView.FlowMode
+    ) -> [FinancialTransaction] {
         let calendar = Calendar.current
         return transactions.filter { tx in
             if tx.type != flowMode.transactionType { return false }
@@ -385,25 +384,120 @@ struct ChartsView: View {
             }
         }
     }
-    
-    var filteredTransactions: [FinancialTransaction] { filteredExpenses }
-    
-    var budgetAlerts: [BudgetStatus] {
-        let key = BudgetService.monthKey(from: Date())
-        return BudgetService.statuses(for: key, budgets: budgets, transactions: transactions, currencyService: currencyService)
-            .filter { $0.ratio >= 1 }
+
+    private static func currentData(
+        from transactions: [FinancialTransaction],
+        chartMode: ChartsView.ChartMode,
+        currencyService: CurrencyService
+    ) -> [ChartsView.ChartData] {
+        switch chartMode {
+        case .category:
+            return categoryBreakdown(from: transactions, currencyService: currencyService)
+        case .tag:
+            return tagBreakdown(from: transactions, currencyService: currencyService)
+        }
+    }
+
+    private static func categoryBreakdown(
+        from transactions: [FinancialTransaction],
+        currencyService: CurrencyService
+    ) -> [ChartsView.ChartData] {
+        let grouped = Dictionary(grouping: transactions) { $0.category?.id.uuidString ?? "uncategorized" }
+        let sorted = grouped.sorted {
+            let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
+            let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
+            return sum0 > sum1
+        }
+        return sorted.map { item in
+            let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
+            let category = item.value.compactMap { $0.category }.first
+            let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
+            return ChartsView.ChartData(
+                key: item.key,
+                name: category?.name ?? "未分類",
+                amount: total,
+                color: displayColor,
+                transactions: item.value
+            )
+        }
+    }
+
+    private static func tagBreakdown(
+        from transactions: [FinancialTransaction],
+        currencyService: CurrencyService
+    ) -> [ChartsView.ChartData] {
+        var tagDict: [String: Decimal] = [:]
+        var tagTransactions: [String: [FinancialTransaction]] = [:]
+        for tx in transactions {
+            let amount = currencyService.convert(amount: abs(tx.amount), from: tx.currencyCode)
+            if tx.tags.isEmpty {
+                tagDict["無標籤", default: 0] += amount
+                tagTransactions["無標籤", default: []].append(tx)
+            } else {
+                for tag in tx.tags {
+                    tagDict[tag.name, default: 0] += amount
+                    tagTransactions[tag.name, default: []].append(tx)
+                }
+            }
+        }
+        let sorted = tagDict.sorted { $0.value > $1.value }
+        return sorted.enumerated().map { index, item in
+            ChartsView.ChartData(
+                key: item.key,
+                name: item.key,
+                amount: item.value,
+                color: Color.generateDistinctColor(index: index, total: sorted.count),
+                transactions: tagTransactions[item.key] ?? []
+            )
+        }
     }
 }
 
 private struct ReportTransactionListView: View {
     let title: String
     let transactions: [FinancialTransaction]
-    
-    private var transferCounterpartByID: [UUID: TransferCounterpartInfo] {
-        TransferPresentationService.counterpartMap(transactions: transactions)
+
+    var body: some View {
+        let renderState = ReportTransactionListRenderState(transactions: transactions)
+
+        NavigationStack {
+            Group {
+                if transactions.isEmpty {
+                    ContentUnavailableView("找不到交易", systemImage: "tray")
+                } else {
+                    List {
+                        ForEach(renderState.groupedTransactions, id: \.title) { group in
+                            Section(group.title) {
+                                ForEach(group.items) { tx in
+                                    TransactionRow(
+                                        transaction: tx,
+                                        transferCounterpart: renderState.transferCounterpartByID[tx.id]
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
     }
-    
-    private var groupedTransactions: [(title: String, items: [FinancialTransaction])] {
+}
+
+private struct ReportTransactionListRenderState {
+    let transferCounterpartByID: [UUID: TransferCounterpartInfo]
+    let groupedTransactions: [(title: String, items: [FinancialTransaction])]
+
+    init(transactions: [FinancialTransaction]) {
+        self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: transactions)
+        self.groupedTransactions = Self.groupedTransactions(from: transactions)
+    }
+
+    private static func groupedTransactions(
+        from transactions: [FinancialTransaction]
+    ) -> [(title: String, items: [FinancialTransaction])] {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy/MM/dd (E)"
         let grouped = Dictionary(grouping: transactions) { tx in
@@ -417,32 +511,6 @@ private struct ReportTransactionListView: View {
                 return leftDate > rightDate
             }
             .map { ($0.key, $0.value.sorted { $0.date > $1.date }) }
-    }
-    
-    var body: some View {
-        NavigationStack {
-            Group {
-                if transactions.isEmpty {
-                    ContentUnavailableView("找不到交易", systemImage: "tray")
-                } else {
-                    List {
-                        ForEach(groupedTransactions, id: \.title) { group in
-                            Section(group.title) {
-                                ForEach(group.items) { tx in
-                                    TransactionRow(
-                                        transaction: tx,
-                                        transferCounterpart: transferCounterpartByID[tx.id]
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    .listStyle(.insetGrouped)
-                }
-            }
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(.inline)
-        }
     }
 }
 

--- a/AI 記帳/Views/Common/DateFilterView.swift
+++ b/AI 記帳/Views/Common/DateFilterView.swift
@@ -25,6 +25,7 @@ struct DateFilterView: View {
                         }
                     }
                     .pickerStyle(.segmented)
+                    .accessibilityIdentifier("dateFilter.modePicker")
                 }
                 
                 if filterType == .year {
@@ -69,6 +70,7 @@ struct DateFilterView: View {
             .navigationTitle("篩選時間")
             .toolbar {
                 Button("完成") { dismiss() }
+                    .accessibilityIdentifier("dateFilter.doneButton")
             }
         }
         .presentationDetents([.medium, .large])

--- a/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
@@ -191,8 +191,10 @@ struct EditAdvanceTransferView: View {
 
                     Section("其他") {
                         DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                            .accessibilityIdentifier("advanceTransferEditor.datePicker")
                         TextField("備註", text: $note)
                             .focused($focusedField, equals: .note)
+                            .accessibilityIdentifier("advanceTransferEditor.noteField")
                     }
                 }
             }
@@ -214,6 +216,7 @@ struct EditAdvanceTransferView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("儲存") { saveChanges() }
                         .disabled(!canSubmit)
+                        .accessibilityIdentifier("advanceTransferEditor.saveButton")
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()

--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -58,6 +58,7 @@ struct EditTransactionView: View {
                             .keyboardType(.decimalPad)
                             .focused($isAmountFocused) // 🔥 綁定焦點
                             .onChange(of: amountString) { _, _ in updateTransactionAmount() }
+                            .accessibilityIdentifier("transactionEditor.amountField")
                     }
                     CurrencyRateHintView(
                         currencyService: currencyService,
@@ -87,7 +88,9 @@ struct EditTransactionView: View {
                     }
 
                     DatePicker("日期", selection: $transaction.date)
+                        .accessibilityIdentifier("transactionEditor.datePicker")
                     TextField("備註", text: $transaction.note)
+                        .accessibilityIdentifier("transactionEditor.noteField")
                 }
 
                 if transaction.type != .transfer {
@@ -120,6 +123,7 @@ struct EditTransactionView: View {
                         transaction.updatedAt = Date()
                         dismiss()
                     }
+                    .accessibilityIdentifier("transactionEditor.saveButton")
                 }
                 
                 // 🔥 新增：鍵盤工具列 (收起按鈕)

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -197,7 +197,9 @@ struct EditTransferView: View {
 
                     Section("其他") {
                         DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                            .accessibilityIdentifier("transferEditor.datePicker")
                         TextField("備註", text: $note)
+                            .accessibilityIdentifier("transferEditor.noteField")
                         if outgoingLegs.count == 1, incomingLegs.count == 1 {
                             TransferRateHintView(
                                 currencyService: currencyService,
@@ -223,6 +225,7 @@ struct EditTransferView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("儲存") { saveChanges() }
                         .disabled(!canSubmit)
+                        .accessibilityIdentifier("transferEditor.saveButton")
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -72,6 +72,7 @@ struct TransactionsListView: View {
                         .clipShape(Capsule())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityIdentifier("ledger.dateFilter.button")
                     Spacer()
                 }
                 .padding(.vertical, 8)
@@ -121,6 +122,8 @@ struct TransactionsListView: View {
                                         transaction: transaction,
                                         transferCounterpart: renderState.transferCounterpartByID[transaction.id]
                                     )
+                                        .accessibilityIdentifier("ledger.transaction.row")
+                                        .accessibilityValue(transaction.note)
                                         .onTapGesture {
                                             transactionToEdit = transaction
                                         }
@@ -140,6 +143,7 @@ struct TransactionsListView: View {
                     }
                 }
                 .listStyle(.insetGrouped)
+                .accessibilityIdentifier("ledger.list")
             }
             .prominentInlineTitle("帳目明細")
             .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "搜尋備註、分類、金額")

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -45,8 +45,15 @@ struct TransactionsListView: View {
             }
         }
     }
+
+    struct TransactionGroup {
+        let title: String
+        let items: [LedgerItem]
+    }
     
     var body: some View {
+        let renderState = makeRenderState()
+
         NavigationStack {
             VStack(spacing: 0) {
                 // MARK: - 1. 日期選擇器 (固定)
@@ -105,14 +112,14 @@ struct TransactionsListView: View {
                 // MARK: - 3. 列表內容 (List)
                 List {
                     // 交易分組
-                    ForEach(groupedTransactions, id: \.title) { group in
+                    ForEach(renderState.groupedTransactions, id: \.title) { group in
                         Section(header: Text(group.title)) {
                             ForEach(group.items) { item in
                                 switch item {
                                 case .transaction(let transaction):
                                     TransactionRow(
                                         transaction: transaction,
-                                        transferCounterpart: transferCounterpartByID[transaction.id]
+                                        transferCounterpart: renderState.transferCounterpartByID[transaction.id]
                                     )
                                         .onTapGesture {
                                             transactionToEdit = transaction
@@ -144,7 +151,7 @@ struct TransactionsListView: View {
             }
             .sheet(item: $transactionToEdit) { tx in
                 if tx.type == .transfer {
-                    if isAdvanceTransfer(tx) {
+                    if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
                         EditAdvanceTransferView(originalTransaction: tx)
                     } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
                         AddDebtView(existingForgivenessTransaction: tx)
@@ -156,7 +163,7 @@ struct TransactionsListView: View {
                 }
             }
             .overlay {
-                if filteredLedgerItems.isEmpty {
+                if renderState.ledgerItems.isEmpty {
                     ContentUnavailableView("無交易紀錄", systemImage: "list.bullet.clipboard", description: Text("該區間或搜尋條件下無資料"))
                 }
             }
@@ -218,8 +225,16 @@ struct TransactionsListView: View {
     
     // MARK: - Logic
     
-    private var transferCounterpartByID: [UUID: TransferCounterpartInfo] {
-        TransferPresentationService.counterpartMap(transactions: transactions)
+    private func makeRenderState() -> TransactionsRenderState {
+        TransactionsRenderState(
+            transactions: transactions,
+            advanceCases: advanceCases,
+            advanceParticipants: advanceParticipants,
+            advanceRepayments: advanceRepayments,
+            filterType: filterType,
+            selectedDate: selectedDate,
+            searchText: searchText
+        )
     }
     
     private func executeShortcut() {
@@ -244,11 +259,6 @@ struct TransactionsListView: View {
         print("✅ 捷徑執行成功: \(sc.name) (\(currency))")
     }
     
-    // ... Helpers (Filter logic 同前，省略重複代碼以節省篇幅) ...
-    // 請保留原本的 filterDisplayString, filteredTransactions, groupedTransactions
-    // calculateTotalEstimate, calculateCurrencyBreakdown, deleteTransaction
-    // 注意：在 calculateCurrencyBreakdown 中，需使用 tx.currencyCode 替代舊的 tx.account.currency
-    
     var filterDisplayString: String {
         let formatter = DateFormatter()
         switch filterType {
@@ -259,91 +269,9 @@ struct TransactionsListView: View {
         }
     }
     
-    var filteredTransactions: [FinancialTransaction] {
-        let calendar = Calendar.current
-        let timeFiltered = transactions.filter { tx in
-            if tx.type == .transfer && tx.amount > 0 && !TransactionSemantics.isDebtForgiveness(note: tx.note) { return false }
-            if tx.type == .transfer,
-               tx.transferGroupID == nil,
-               tx.linkedTransactionID == nil,
-               isAssetAdjustment(note: tx.note) {
-                return false
-            }
-            if let groupID = tx.transferGroupID, initialAdvanceGroupIDs.contains(groupID) {
-                return false
-            }
-            switch filterType {
-            case .all: return true
-            case .year: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .year)
-            case .month: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .month)
-            case .day: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .day)
-            }
-        }
-        let searched = searchText.isEmpty ? timeFiltered : timeFiltered.filter { tx in
-            tx.note.localizedCaseInsensitiveContains(searchText) ||
-            (tx.category?.name.localizedCaseInsensitiveContains(searchText) ?? false) ||
-            tx.tags.contains { $0.name.localizedCaseInsensitiveContains(searchText) } ||
-            String(describing: abs(tx.amount)).contains(searchText)
-        }
-        return collapseTransferGroups(in: searched)
-    }
-
-    var filteredAdvanceCases: [AdvanceCase] {
-        let calendar = Calendar.current
-        let timeFiltered = advanceCases.filter { advanceCase in
-            switch filterType {
-            case .all: return true
-            case .year: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .year)
-            case .month: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .month)
-            case .day: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .day)
-            }
-        }
-
-        guard !searchText.isEmpty else {
-            return timeFiltered
-        }
-
-        return timeFiltered.filter { advanceCase in
-            advanceCase.title.localizedCaseInsensitiveContains(searchText)
-                || advanceCase.note.localizedCaseInsensitiveContains(searchText)
-                || (advanceCase.payerAccount?.name.localizedCaseInsensitiveContains(searchText) ?? false)
-                || advanceCase.participants.contains { $0.name.localizedCaseInsensitiveContains(searchText) }
-        }
-    }
-
-    var filteredLedgerItems: [LedgerItem] {
-        (filteredTransactions.map(LedgerItem.transaction) + filteredAdvanceCases.map(LedgerItem.advanceCaseSummary))
-            .sorted { lhs, rhs in
-                if lhs.date == rhs.date {
-                    return lhs.id > rhs.id
-                }
-                return lhs.date > rhs.date
-            }
-    }
-
-    struct TransactionGroup { let title: String; let items: [LedgerItem] }
-
-    var groupedTransactions: [TransactionGroup] {
-        let formatter = DateFormatter()
-        let grouping: (Date) -> String = { date in
-            switch filterType {
-            case .all: formatter.dateFormat = "yyyy年"; return formatter.string(from: date)
-            case .year: formatter.dateFormat = "M月"; return formatter.string(from: date)
-            case .month: formatter.dateFormat = "d日 (EEEE)"; return formatter.string(from: date)
-            case .day: return "明細"
-            }
-        }
-        let groupedDict = Dictionary(grouping: filteredLedgerItems) { item in grouping(item.date) }
-        let sortedKeys = groupedDict.keys.sorted { title1, title2 in
-            guard let item1 = groupedDict[title1]?.first, let item2 = groupedDict[title2]?.first else { return title1 > title2 }
-            return item1.date > item2.date
-        }
-        return sortedKeys.map { TransactionGroup(title: $0, items: groupedDict[$0] ?? []) }
-    }
-    
     func calculateTotalEstimate() -> String {
         var total: Decimal = 0
-        for tx in filteredTransactions {
+        for tx in makeRenderState().filteredTransactions {
             if tx.type == .transfer { continue }
             // 🔥 使用交易本身的 currencyCode
             let converted = CurrencyService.shared.convert(amount: tx.amount, from: tx.currencyCode)
@@ -355,7 +283,7 @@ struct TransactionsListView: View {
     struct CurrencyTotal { let currency: String; let amount: Decimal }
     
     func calculateCurrencyBreakdown() -> [CurrencyTotal] {
-        let validTransactions = filteredTransactions.filter { $0.type != .transfer }
+        let validTransactions = makeRenderState().filteredTransactions.filter { $0.type != .transfer }
         // 🔥 使用交易本身的 currencyCode 分組
         let grouped = Dictionary(grouping: validTransactions) { $0.currencyCode }
         return grouped.map { (curr, txs) in
@@ -387,17 +315,7 @@ struct TransactionsListView: View {
         modelContext.delete(tx)
     }
     
-    private var advanceGroupIDs: Set<UUID> {
-        var ids = Set<UUID>(advanceParticipants.compactMap(\.initialTransferGroupID))
-        ids.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
-        return ids
-    }
-
-    private var initialAdvanceGroupIDs: Set<UUID> {
-        Set(advanceParticipants.compactMap(\.initialTransferGroupID))
-    }
-
-    private func isAdvanceTransfer(_ tx: FinancialTransaction) -> Bool {
+    private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {
         guard tx.type == .transfer else { return false }
         if let groupID = tx.transferGroupID, advanceGroupIDs.contains(groupID) {
             return true
@@ -408,8 +326,155 @@ struct TransactionsListView: View {
             || compacted.contains("(還款至")
             || compacted.contains("(還款給")
     }
-    
-    private func collapseTransferGroups(in items: [FinancialTransaction]) -> [FinancialTransaction] {
+}
+
+private struct TransactionsRenderState {
+    let filteredTransactions: [FinancialTransaction]
+    let filteredAdvanceCases: [AdvanceCase]
+    let ledgerItems: [TransactionsListView.LedgerItem]
+    let groupedTransactions: [TransactionsListView.TransactionGroup]
+    let transferCounterpartByID: [UUID: TransferCounterpartInfo]
+    let advanceGroupIDs: Set<UUID>
+    let initialAdvanceGroupIDs: Set<UUID>
+
+    init(
+        transactions: [FinancialTransaction],
+        advanceCases: [AdvanceCase],
+        advanceParticipants: [AdvanceParticipant],
+        advanceRepayments: [AdvanceRepayment],
+        filterType: FilterType,
+        selectedDate: Date,
+        searchText: String
+    ) {
+        let initialAdvanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
+        var advanceGroupIDs = initialAdvanceGroupIDs
+        advanceGroupIDs.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
+
+        let filteredTransactions = Self.filteredTransactions(
+            from: transactions,
+            initialAdvanceGroupIDs: initialAdvanceGroupIDs,
+            filterType: filterType,
+            selectedDate: selectedDate,
+            searchText: searchText
+        )
+        let filteredAdvanceCases = Self.filteredAdvanceCases(
+            from: advanceCases,
+            filterType: filterType,
+            selectedDate: selectedDate,
+            searchText: searchText
+        )
+        let ledgerItems = Self.ledgerItems(
+            transactions: filteredTransactions,
+            advanceCases: filteredAdvanceCases
+        )
+
+        self.filteredTransactions = filteredTransactions
+        self.filteredAdvanceCases = filteredAdvanceCases
+        self.ledgerItems = ledgerItems
+        self.groupedTransactions = Self.groupedTransactions(from: ledgerItems, filterType: filterType)
+        self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: transactions)
+        self.advanceGroupIDs = advanceGroupIDs
+        self.initialAdvanceGroupIDs = initialAdvanceGroupIDs
+    }
+
+    private static func filteredTransactions(
+        from transactions: [FinancialTransaction],
+        initialAdvanceGroupIDs: Set<UUID>,
+        filterType: FilterType,
+        selectedDate: Date,
+        searchText: String
+    ) -> [FinancialTransaction] {
+        let calendar = Calendar.current
+        let timeFiltered = transactions.filter { tx in
+            if tx.type == .transfer && tx.amount > 0 && !TransactionSemantics.isDebtForgiveness(note: tx.note) { return false }
+            if tx.type == .transfer,
+               tx.transferGroupID == nil,
+               tx.linkedTransactionID == nil,
+               isAssetAdjustment(note: tx.note) {
+                return false
+            }
+            if let groupID = tx.transferGroupID, initialAdvanceGroupIDs.contains(groupID) {
+                return false
+            }
+            switch filterType {
+            case .all: return true
+            case .year: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .year)
+            case .month: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .month)
+            case .day: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .day)
+            }
+        }
+        let searched = searchText.isEmpty ? timeFiltered : timeFiltered.filter { tx in
+            tx.note.localizedCaseInsensitiveContains(searchText) ||
+            (tx.category?.name.localizedCaseInsensitiveContains(searchText) ?? false) ||
+            tx.tags.contains { $0.name.localizedCaseInsensitiveContains(searchText) } ||
+            String(describing: abs(tx.amount)).contains(searchText)
+        }
+        return collapseTransferGroups(in: searched)
+    }
+
+    private static func filteredAdvanceCases(
+        from advanceCases: [AdvanceCase],
+        filterType: FilterType,
+        selectedDate: Date,
+        searchText: String
+    ) -> [AdvanceCase] {
+        let calendar = Calendar.current
+        let timeFiltered = advanceCases.filter { advanceCase in
+            switch filterType {
+            case .all: return true
+            case .year: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .year)
+            case .month: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .month)
+            case .day: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .day)
+            }
+        }
+
+        guard !searchText.isEmpty else {
+            return timeFiltered
+        }
+
+        return timeFiltered.filter { advanceCase in
+            advanceCase.title.localizedCaseInsensitiveContains(searchText)
+                || advanceCase.note.localizedCaseInsensitiveContains(searchText)
+                || (advanceCase.payerAccount?.name.localizedCaseInsensitiveContains(searchText) ?? false)
+                || advanceCase.participants.contains { $0.name.localizedCaseInsensitiveContains(searchText) }
+        }
+    }
+
+    private static func ledgerItems(
+        transactions: [FinancialTransaction],
+        advanceCases: [AdvanceCase]
+    ) -> [TransactionsListView.LedgerItem] {
+        (transactions.map(TransactionsListView.LedgerItem.transaction) + advanceCases.map(TransactionsListView.LedgerItem.advanceCaseSummary))
+            .sorted { lhs, rhs in
+                if lhs.date == rhs.date {
+                    return lhs.id > rhs.id
+                }
+                return lhs.date > rhs.date
+            }
+    }
+
+    private static func groupedTransactions(
+        from ledgerItems: [TransactionsListView.LedgerItem],
+        filterType: FilterType
+    ) -> [TransactionsListView.TransactionGroup] {
+        let formatter = DateFormatter()
+        let grouping: (Date) -> String = { date in
+            switch filterType {
+            case .all: formatter.dateFormat = "yyyy年"; return formatter.string(from: date)
+            case .year: formatter.dateFormat = "M月"; return formatter.string(from: date)
+            case .month: formatter.dateFormat = "d日 (EEEE)"; return formatter.string(from: date)
+            case .day: return "明細"
+            }
+        }
+        let groupedDict = Dictionary(grouping: ledgerItems) { item in grouping(item.date) }
+        let sortedKeys = groupedDict.keys.sorted { title1, title2 in
+            guard let item1 = groupedDict[title1]?.first, let item2 = groupedDict[title2]?.first else { return title1 > title2 }
+            return item1.date > item2.date
+        }
+        return sortedKeys.map { TransactionsListView.TransactionGroup(title: $0, items: groupedDict[$0] ?? []) }
+    }
+
+    private static func collapseTransferGroups(in items: [FinancialTransaction]) -> [FinancialTransaction] {
         let representatives = Dictionary(grouping: items.compactMap { tx -> (UUID, FinancialTransaction)? in
             guard let groupID = tx.transferGroupID else { return nil }
             return (groupID, tx)
@@ -419,27 +484,27 @@ struct TransactionsListView: View {
                 ?? transfers.first(where: { $0.amount < 0 })
                 ?? transfers.first
         }
-        
+
         var seenGroupIDs = Set<UUID>()
         var output: [FinancialTransaction] = []
-        
+
         for tx in items {
             guard tx.type == .transfer, let groupID = tx.transferGroupID else {
                 output.append(tx)
                 continue
             }
-            
+
             if seenGroupIDs.contains(groupID) {
                 continue
             }
             seenGroupIDs.insert(groupID)
             output.append(representatives[groupID] ?? tx)
         }
-        
+
         return output
     }
-    
-    private func isAssetAdjustment(note: String) -> Bool {
+
+    private static func isAssetAdjustment(note: String) -> Bool {
         note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix(TransactionSemantics.assetAdjustmentMarker)
     }
 }

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -119,3 +119,82 @@ final class BackupCompatibilityTests: XCTestCase {
         return tempURL
     }
 }
+
+@MainActor
+final class TransferPresentationServiceTests: XCTestCase {
+    func testCounterpartMap_usesLinkedTransferPair() {
+        let outgoingID = UUID()
+        let incomingID = UUID()
+
+        let result = TransferPresentationService.counterpartMap(inputs: [
+            transferInput(id: outgoingID, amount: -100, currencyCode: "USD", linkedTransactionID: incomingID, transferSide: .outgoing),
+            transferInput(id: incomingID, amount: 780, currencyCode: "HKD", linkedTransactionID: outgoingID, transferSide: .incoming),
+        ])
+
+        XCTAssertEqual(result[outgoingID]?.amount, 780)
+        XCTAssertEqual(result[outgoingID]?.currencyCode, "HKD")
+        XCTAssertEqual(result[incomingID]?.amount, -100)
+        XCTAssertEqual(result[incomingID]?.currencyCode, "USD")
+    }
+
+    func testCounterpartMap_handlesTransferGroupSplitMerge() {
+        let groupID = UUID()
+        let outgoingID = UUID()
+        let firstIncomingID = UUID()
+        let secondIncomingID = UUID()
+
+        let result = TransferPresentationService.counterpartMap(inputs: [
+            transferInput(id: outgoingID, amount: -100, currencyCode: "HKD", transferGroupID: groupID, transferSide: .outgoing),
+            transferInput(id: firstIncomingID, amount: 40, currencyCode: "HKD", transferGroupID: groupID, transferSide: .incoming),
+            transferInput(id: secondIncomingID, amount: 60, currencyCode: "HKD", transferGroupID: groupID, transferSide: .incoming),
+        ])
+
+        XCTAssertNil(result[outgoingID])
+        XCTAssertEqual(result[firstIncomingID]?.amount, -100)
+        XCTAssertEqual(result[firstIncomingID]?.currencyCode, "HKD")
+        XCTAssertEqual(result[secondIncomingID]?.amount, -100)
+        XCTAssertEqual(result[secondIncomingID]?.currencyCode, "HKD")
+    }
+
+    func testCounterpartMap_ignoresMissingLinkedTransfer() {
+        let result = TransferPresentationService.counterpartMap(inputs: [
+            transferInput(id: UUID(), amount: -100, currencyCode: "HKD", linkedTransactionID: UUID(), transferSide: .outgoing),
+        ])
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testCounterpartMap_supportsSameAccountCrossCurrencyTransferShape() {
+        let outgoingID = UUID()
+        let incomingID = UUID()
+
+        let result = TransferPresentationService.counterpartMap(inputs: [
+            transferInput(id: outgoingID, amount: -100, currencyCode: "HKD", linkedTransactionID: incomingID, transferSide: .outgoing),
+            transferInput(id: incomingID, amount: 92, currencyCode: "CNY", linkedTransactionID: outgoingID, transferSide: .incoming),
+        ])
+
+        XCTAssertEqual(result[outgoingID]?.amount, 92)
+        XCTAssertEqual(result[outgoingID]?.currencyCode, "CNY")
+        XCTAssertEqual(result[incomingID]?.amount, -100)
+        XCTAssertEqual(result[incomingID]?.currencyCode, "HKD")
+    }
+
+    private func transferInput(
+        id: UUID,
+        amount: Decimal,
+        currencyCode: String,
+        linkedTransactionID: UUID? = nil,
+        transferGroupID: UUID? = nil,
+        transferSide: TransferSide? = nil
+    ) -> TransferCounterpartInput {
+        TransferCounterpartInput(
+            id: id,
+            type: .transfer,
+            amount: amount,
+            currencyCode: currencyCode,
+            linkedTransactionID: linkedTransactionID,
+            transferGroupID: transferGroupID,
+            transferSide: transferSide
+        )
+    }
+}

--- a/AI 記帳UITests/LedgerEditPerformanceUITests.swift
+++ b/AI 記帳UITests/LedgerEditPerformanceUITests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+final class LedgerEditPerformanceUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        app = XCUIApplication()
+        app.launchArguments = [
+            "-UITestSeedLedgerPerformanceData",
+            "-UITestDisableAnimations"
+        ]
+        app.launchEnvironment["AI_ACCOUNTING_UI_TESTS"] = "1"
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        if let failureCount = testRun?.failureCount, failureCount > 0 {
+            let screenshot = XCUIScreen.main.screenshot()
+            let attachment = XCTAttachment(screenshot: screenshot)
+            attachment.name = "Failure Screenshot"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+        app = nil
+    }
+
+    func testLedgerEditFlowRunsWithoutManualOperation() throws {
+        openLedger()
+        openAndDismissDateFilter()
+        editTransaction(named: "UITest 普通支出", noteFieldIdentifier: "transactionEditor.noteField", saveButtonIdentifier: "transactionEditor.saveButton")
+        editTransaction(named: "UITest 轉帳", noteFieldIdentifier: "transferEditor.noteField", saveButtonIdentifier: "transferEditor.saveButton")
+        editTransaction(named: "UITest 代墊還款", noteFieldIdentifier: "advanceTransferEditor.noteField", saveButtonIdentifier: "advanceTransferEditor.saveButton")
+    }
+
+    private func openLedger() {
+        let ledgerTab = app.tabBars.buttons["帳目"]
+        XCTAssertTrue(ledgerTab.waitForExistence(timeout: 15), "Ledger tab should be available")
+        ledgerTab.tap()
+
+        let ledgerList = app.collectionViews["ledger.list"]
+        XCTAssertTrue(ledgerList.waitForExistence(timeout: 10), "Ledger list should be visible")
+    }
+
+    private func openAndDismissDateFilter() {
+        let filterButton = app.buttons["ledger.dateFilter.button"]
+        XCTAssertTrue(filterButton.waitForExistence(timeout: 10), "Date filter button should be visible")
+        filterButton.tap()
+
+        let doneButton = app.buttons["dateFilter.doneButton"]
+        XCTAssertTrue(doneButton.waitForExistence(timeout: 10), "Date filter done button should be visible")
+        doneButton.tap()
+
+        XCTAssertTrue(filterButton.waitForExistence(timeout: 10), "Ledger should be visible after closing date filter")
+    }
+
+    private func editTransaction(named rowText: String, noteFieldIdentifier: String, saveButtonIdentifier: String) {
+        let rowLabel = app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", rowText)).firstMatch
+        XCTAssertTrue(rowLabel.waitForExistence(timeout: 10), "Expected ledger row containing \(rowText)")
+        rowLabel.tap()
+
+        let noteField = app.textFields[noteFieldIdentifier]
+        XCTAssertTrue(noteField.waitForExistence(timeout: 10), "Expected note field \(noteFieldIdentifier)")
+        noteField.tap()
+        noteField.typeText(" ui")
+
+        let saveButton = app.buttons[saveButtonIdentifier]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 10), "Expected save button \(saveButtonIdentifier)")
+        saveButton.tap()
+
+        let ledgerList = app.collectionViews["ledger.list"]
+        XCTAssertTrue(ledgerList.waitForExistence(timeout: 10), "Ledger list should return after saving \(rowText)")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds lightweight transfer counterpart inputs so map creation avoids repeated SwiftData model reads.
- Builds ledger, charts, report detail, and account detail render state once per render pass instead of recomputing inside row rendering.
- Adds counterpart map tests for linked transfers, split/merge groups, missing links, and same-account cross-currency transfer shape.

## Tests
- xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
- xcodebuild test -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO