### PR TITLE
Add semantic ledger deletion

### DIFF
--- a/AI 記帳/Services/LedgerDeletionService.swift
+++ b/AI 記帳/Services/LedgerDeletionService.swift
@@ -1,0 +1,95 @@
+import Foundation
+import SwiftData
+
+enum LedgerDeletionError: LocalizedError {
+    case advanceInitialTransferRequiresCase
+
+    var errorDescription: String? {
+        switch self {
+        case .advanceInitialTransferRequiresCase:
+            return "這是代墊建立分錄，請進入代墊詳情刪除整個代墊案件。"
+        }
+    }
+}
+
+@MainActor
+enum LedgerDeletionService {
+    static func delete(transaction: FinancialTransaction, modelContext: ModelContext) throws {
+        if let groupID = transaction.transferGroupID {
+            try deleteTransferGroup(groupID, fallbackTransaction: transaction, modelContext: modelContext)
+            return
+        }
+
+        if isAdvanceSelfExpense(transaction, modelContext: modelContext) {
+            throw LedgerDeletionError.advanceInitialTransferRequiresCase
+        }
+
+        if transaction.type == .transfer, let linkedID = transaction.linkedTransactionID {
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.id == linkedID }
+            )
+            if let linked = try modelContext.fetch(descriptor).first {
+                modelContext.delete(linked)
+            }
+        }
+
+        modelContext.delete(transaction)
+        try modelContext.save()
+    }
+
+    private static func deleteTransferGroup(
+        _ groupID: UUID,
+        fallbackTransaction: FinancialTransaction,
+        modelContext: ModelContext
+    ) throws {
+        if let repayment = try repayment(for: groupID, modelContext: modelContext),
+           let advanceCase = repayment.advanceCase {
+            try AdvanceService.rollbackRepayment(
+                advanceCase: advanceCase,
+                repayment: repayment,
+                autosave: true,
+                modelContext: modelContext
+            )
+            return
+        }
+
+        if try isAdvanceInitialTransferGroup(groupID, modelContext: modelContext) {
+            throw LedgerDeletionError.advanceInitialTransferRequiresCase
+        }
+
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        let groupedTransfers = try modelContext.fetch(descriptor)
+        if groupedTransfers.isEmpty {
+            modelContext.delete(fallbackTransaction)
+        } else {
+            for transfer in groupedTransfers {
+                modelContext.delete(transfer)
+            }
+        }
+        try modelContext.save()
+    }
+
+    private static func repayment(for groupID: UUID, modelContext: ModelContext) throws -> AdvanceRepayment? {
+        let descriptor = FetchDescriptor<AdvanceRepayment>(
+            predicate: #Predicate { $0.linkedTransferGroupID == groupID }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private static func isAdvanceInitialTransferGroup(_ groupID: UUID, modelContext: ModelContext) throws -> Bool {
+        let descriptor = FetchDescriptor<AdvanceParticipant>(
+            predicate: #Predicate { $0.initialTransferGroupID == groupID }
+        )
+        return try modelContext.fetch(descriptor).first != nil
+    }
+
+    private static func isAdvanceSelfExpense(_ transaction: FinancialTransaction, modelContext: ModelContext) -> Bool {
+        let transactionID: UUID? = transaction.id
+        let descriptor = FetchDescriptor<AdvanceCase>(
+            predicate: #Predicate { $0.selfExpenseTransactionID == transactionID }
+        )
+        return ((try? modelContext.fetch(descriptor)) ?? []).isEmpty == false
+    }
+}

--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -5,6 +5,7 @@ struct AccountDetailView: View {
     let account: Account
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
     @Environment(\.modelContext) private var modelContext
+    @State private var deletionErrorMessage: String?
     
     // 🔥 修正 1：定義一個結構體來代替 Tuple，讓 ForEach 能識別
     struct CurrencyBalance: Identifiable {
@@ -87,31 +88,22 @@ struct AccountDetailView: View {
         }
         .navigationTitle(account.name)
         .navigationBarTitleDisplayMode(.inline)
+        .alert("無法刪除", isPresented: Binding(
+            get: { deletionErrorMessage != nil },
+            set: { if !$0 { deletionErrorMessage = nil } }
+        )) {
+            Button("好", role: .cancel) { deletionErrorMessage = nil }
+        } message: {
+            Text(deletionErrorMessage ?? "")
+        }
     }
     
     private func deleteTransaction(_ transaction: FinancialTransaction) {
-        if transaction.type == .transfer, let groupID = transaction.transferGroupID {
-            let descriptor = FetchDescriptor<FinancialTransaction>(
-                predicate: #Predicate { $0.transferGroupID == groupID }
-            )
-            if let groupedTransfers = try? modelContext.fetch(descriptor) {
-                for transfer in groupedTransfers {
-                    modelContext.delete(transfer)
-                }
-                return
-            }
+        do {
+            try LedgerDeletionService.delete(transaction: transaction, modelContext: modelContext)
+        } catch {
+            deletionErrorMessage = error.localizedDescription
         }
-        
-        if transaction.type == .transfer, let linkedID = transaction.linkedTransactionID {
-            let descriptor = FetchDescriptor<FinancialTransaction>(
-                predicate: #Predicate { $0.id == linkedID }
-            )
-            if let linkedTx = try? modelContext.fetch(descriptor).first {
-                modelContext.delete(linkedTx)
-            }
-        }
-        
-        modelContext.delete(transaction)
     }
 }
 

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -22,6 +22,7 @@ struct TransactionsListView: View {
     @State private var showingShortcutConfirm = false
     @State private var shortcutToDelete: Shortcut?
     @State private var showingShortcutDeleteConfirm = false
+    @State private var deletionErrorMessage: String?
 
     enum LedgerItem: Identifiable {
         case transaction(FinancialTransaction)
@@ -197,6 +198,14 @@ struct TransactionsListView: View {
             } message: {
                 Text(shortcutToDelete?.name ?? "")
             }
+            .alert("無法刪除", isPresented: Binding(
+                get: { deletionErrorMessage != nil },
+                set: { if !$0 { deletionErrorMessage = nil } }
+            )) {
+                Button("好", role: .cancel) { deletionErrorMessage = nil }
+            } message: {
+                Text(deletionErrorMessage ?? "")
+            }
         }
     }
     
@@ -296,27 +305,11 @@ struct TransactionsListView: View {
     }
     
     private func deleteTransaction(_ tx: FinancialTransaction) {
-        if tx.type == .transfer, let groupID = tx.transferGroupID {
-            let descriptor = FetchDescriptor<FinancialTransaction>(
-                predicate: #Predicate { $0.transferGroupID == groupID }
-            )
-            if let groupedTransfers = try? modelContext.fetch(descriptor) {
-                for transfer in groupedTransfers {
-                    modelContext.delete(transfer)
-                }
-                return
-            }
+        do {
+            try LedgerDeletionService.delete(transaction: tx, modelContext: modelContext)
+        } catch {
+            deletionErrorMessage = error.localizedDescription
         }
-        
-        if tx.type == .transfer, let linkedID = tx.linkedTransactionID {
-            let descriptor = FetchDescriptor<FinancialTransaction>(
-                predicate: #Predicate { $0.id == linkedID }
-            )
-            if let linked = try? modelContext.fetch(descriptor).first {
-                modelContext.delete(linked)
-            }
-        }
-        modelContext.delete(tx)
     }
     
     private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -64,6 +64,11 @@ data class AccountDeletionImpact(
         get() = !counts.hasBookkeeping
 }
 
+enum class LedgerDeletionResult {
+    Deleted,
+    AdvanceInitialRequiresCase
+}
+
 private const val RECURRING_STATUS_PENDING = "Pending"
 private const val RECURRING_STATUS_CONFIRMED = "Confirmed"
 private const val RECURRING_STATUS_SKIPPED = "Skipped"
@@ -320,6 +325,36 @@ class AccountingRepository(
         }
     }
 
+    suspend fun deleteLedgerTransactionById(transactionId: UUID): LedgerDeletionResult {
+        return database.withTransaction {
+            val existing = transactionDao.getTransaction(transactionId)?.transaction
+                ?: return@withTransaction LedgerDeletionResult.Deleted
+
+            existing.transferGroupId?.let { groupId ->
+                return@withTransaction deleteLedgerTransferGroupLocked(groupId)
+            }
+
+            val linkedId = existing.linkedTransactionId
+            if (existing.type == TransactionType.Transfer && linkedId != null) {
+                transactionDao.getTransaction(linkedId)?.transaction?.let { linked ->
+                    transactionDao.delete(linked)
+                    transactionDao.clearTransactionTags(linked.id)
+                }
+            }
+
+            val isAdvanceSelfExpense = advanceDao.getAllCases()
+                .any { it.selfExpenseTransactionId == existing.id }
+            if (isAdvanceSelfExpense) {
+                return@withTransaction LedgerDeletionResult.AdvanceInitialRequiresCase
+            }
+
+            transactionDao.delete(existing)
+            transactionDao.clearTransactionTags(existing.id)
+            syncAllBudgetHistory()
+            LedgerDeletionResult.Deleted
+        }
+    }
+
     suspend fun deleteTransferGroup(groupId: UUID) {
         database.withTransaction {
             val existing = transactionDao.getTransferGroup(groupId)
@@ -328,6 +363,12 @@ class AccountingRepository(
                 transactionDao.clearTransactionTags(tx.transaction.id)
             }
             syncAllBudgetHistory()
+        }
+    }
+
+    suspend fun deleteLedgerTransferGroup(groupId: UUID): LedgerDeletionResult {
+        return database.withTransaction {
+            deleteLedgerTransferGroupLocked(groupId)
         }
     }
 
@@ -1528,6 +1569,28 @@ class AccountingRepository(
             directTransactionsToDelete = directTransactionsToDelete,
             shortcutsToDetach = shortcutsToDetach
         )
+    }
+
+    private suspend fun deleteLedgerTransferGroupLocked(groupId: UUID): LedgerDeletionResult {
+        val repayment = advanceDao.getAllRepayments().firstOrNull { it.linkedTransferGroupId == groupId }
+        if (repayment != null) {
+            rollbackRepayments(listOf(repayment))
+            syncAllBudgetHistory()
+            return LedgerDeletionResult.Deleted
+        }
+
+        val isInitialAdvanceGroup = advanceDao.getAllParticipants().any { it.initialTransferGroupId == groupId }
+        if (isInitialAdvanceGroup) {
+            return LedgerDeletionResult.AdvanceInitialRequiresCase
+        }
+
+        val existing = transactionDao.getTransferGroup(groupId)
+        existing.forEach { tx ->
+            transactionDao.delete(tx.transaction)
+            transactionDao.clearTransactionTags(tx.transaction.id)
+        }
+        syncAllBudgetHistory()
+        return LedgerDeletionResult.Deleted
     }
 
     private suspend fun rollbackRepayments(repayments: List<AdvanceRepaymentEntity>) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
@@ -41,6 +41,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyRateHint
@@ -101,6 +102,7 @@ fun TransactionEditorScreen(
     var selectedCurrency by remember { mutableStateOf("HKD") }
     var date by remember { mutableStateOf(Instant.now()) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
     var showCreateCategoryDialog by remember { mutableStateOf(false) }
     var newCategoryName by remember { mutableStateOf("") }
     var newCategoryIcon by remember { mutableStateOf("square.grid.2x2") }
@@ -374,13 +376,28 @@ fun TransactionEditorScreen(
                 TextButton(onClick = {
                     showDeleteConfirm = false
                     scope.launch {
-                        repository.deleteTransactionById(UUID.fromString(transactionId))
-                        onDone()
+                        val result = repository.deleteLedgerTransactionById(UUID.fromString(transactionId))
+                        if (result == LedgerDeletionResult.AdvanceInitialRequiresCase) {
+                            errorMessage = "這是代墊建立分錄，請進入代墊詳情刪除整個代墊案件。"
+                        } else {
+                            onDone()
+                        }
                     }
                 }) { Text("刪除", color = MaterialTheme.colorScheme.error) }
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirm = false }) { Text("取消") }
+            }
+        )
+    }
+
+    if (errorMessage != null) {
+        AlertDialog(
+            onDismissRequest = { errorMessage = null },
+            title = { Text("無法刪除") },
+            text = { Text(errorMessage ?: "") },
+            confirmButton = {
+                TextButton(onClick = { errorMessage = null }) { Text("了解") }
             }
         )
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -56,6 +56,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
+import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
@@ -358,10 +359,9 @@ fun TransactionsScreen(
                 TextButton(onClick = {
                     showDeleteConfirm = false
                     scope.launch {
-                        if (isTransfer) {
-                            repository.deleteTransferGroup(UUID.fromString(groupId))
-                        } else {
-                            repository.deleteTransactionById(target.transaction.id)
+                        val result = repository.deleteLedgerTransactionById(target.transaction.id)
+                        if (result == LedgerDeletionResult.AdvanceInitialRequiresCase) {
+                            errorMessage = "這是代墊建立分錄，請進入代墊詳情刪除整個代墊案件。"
                         }
                     }
                 }) { Text("刪除", color = MaterialTheme.colorScheme.error) }
@@ -375,7 +375,7 @@ fun TransactionsScreen(
     if (errorMessage != null) {
         AlertDialog(
             onDismissRequest = { errorMessage = null },
-            title = { Text("無法執行捷徑") },
+            title = { Text("無法執行操作") },
             text = { Text(errorMessage ?: "") },
             confirmButton = {
                 TextButton(onClick = { errorMessage = null }) { Text("了解") }


### PR DESCRIPTION
## Summary
- centralize ledger deletion semantics on iOS and Android
- delete transfer groups as a unit
- rollback advance repayments instead of raw deleting repayment transfer legs
- block raw deletion of advance initial ledger entries and direct users to the advance case

## Tests
- xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO
- ANDROID_HOME=/Users/lhf/Library/Android/sdk ./gradlew testDebugUnitTest assembleDebug