### PR TITLE
Secure Android Gemini settings and transfer dates

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/ai/GeminiSettingsStore.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/ai/GeminiSettingsStore.kt
@@ -1,18 +1,38 @@
 package org.duckdns.lhfser.aiaccounting.core.ai
 
 import android.content.Context
+import org.duckdns.lhfser.aiaccounting.core.security.KeystoreStringCipher
 
 class GeminiSettingsStore(context: Context) {
     private val prefs = context.applicationContext.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+    private val cipher = KeystoreStringCipher("ai_accounting_gemini_settings")
 
     var apiKey: String
-        get() = prefs.getString(KEY_API_KEY, "")?.trim().orEmpty()
+        get() {
+            val encrypted = prefs.getString(KEY_API_KEY_ENCRYPTED, null)
+            if (!encrypted.isNullOrBlank()) return cipher.decrypt(encrypted).trim()
+
+            val legacyPlaintext = prefs.getString(KEY_API_KEY, "")?.trim().orEmpty()
+            if (legacyPlaintext.isNotBlank()) {
+                apiKey = legacyPlaintext
+            }
+            return legacyPlaintext
+        }
         set(value) {
-            prefs.edit().putString(KEY_API_KEY, value.trim()).apply()
+            val trimmed = value.trim()
+            prefs.edit().apply {
+                remove(KEY_API_KEY)
+                if (trimmed.isBlank()) {
+                    remove(KEY_API_KEY_ENCRYPTED)
+                } else {
+                    putString(KEY_API_KEY_ENCRYPTED, cipher.encrypt(trimmed))
+                }
+            }.apply()
         }
 
     companion object {
         private const val PREF_NAME = "gemini_settings"
         private const val KEY_API_KEY = "api_key"
+        private const val KEY_API_KEY_ENCRYPTED = "api_key_encrypted"
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/backup/RemoteBackupService.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/backup/RemoteBackupService.kt
@@ -1,17 +1,13 @@
 package org.duckdns.lhfser.aiaccounting.core.backup
 
 import android.content.Context
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
 import android.util.Base64
 import com.google.gson.annotations.SerializedName
-import java.security.KeyStore
 import java.security.SecureRandom
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import javax.crypto.Cipher
-import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
@@ -24,6 +20,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.duckdns.lhfser.aiaccounting.core.security.KeystoreStringCipher
 import org.duckdns.lhfser.aiaccounting.data.backup.BackupJsonAdapter
 import org.duckdns.lhfser.aiaccounting.data.backup.FullBackupData
 
@@ -221,7 +218,7 @@ class RemoteBackupService(
 
 class WebDavSettingsStore(context: Context) {
     private val prefs = context.applicationContext.getSharedPreferences("webdav_backup_settings", Context.MODE_PRIVATE)
-    private val cipher = KeystoreStringCipher()
+    private val cipher = KeystoreStringCipher("ai_accounting_webdav_settings")
 
     var baseUrl: String
         get() = prefs.getString("base_url", "").orEmpty()
@@ -242,46 +239,4 @@ class WebDavSettingsStore(context: Context) {
     fun credentials(): WebDavCredentials {
         return WebDavCredentials(baseUrl = baseUrl, username = username, password = password, passphrase = passphrase)
     }
-}
-
-private class KeystoreStringCipher {
-    private val alias = "ai_accounting_webdav_settings"
-
-    fun encrypt(value: String): String {
-        if (value.isBlank()) return ""
-        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
-        val ciphertext = cipher.doFinal(value.toByteArray(Charsets.UTF_8))
-        return "${base64(cipher.iv)}:${base64(ciphertext)}"
-    }
-
-    fun decrypt(value: String): String {
-        if (value.isBlank() || !value.contains(":")) return ""
-        return runCatching {
-            val parts = value.split(":", limit = 2)
-            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(128, unbase64(parts[0])))
-            cipher.doFinal(unbase64(parts[1])).toString(Charsets.UTF_8)
-        }.getOrDefault("")
-    }
-
-    private fun getOrCreateKey(): SecretKey {
-        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
-        (keyStore.getKey(alias, null) as? SecretKey)?.let { return it }
-
-        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
-        val spec = KeyGenParameterSpec.Builder(
-            alias,
-            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-        )
-            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-            .setRandomizedEncryptionRequired(true)
-            .build()
-        generator.init(spec)
-        return generator.generateKey()
-    }
-
-    private fun base64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
-    private fun unbase64(value: String): ByteArray = Base64.decode(value, Base64.NO_WRAP)
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/security/KeystoreStringCipher.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/security/KeystoreStringCipher.kt
@@ -1,0 +1,50 @@
+package org.duckdns.lhfser.aiaccounting.core.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class KeystoreStringCipher(private val alias: String) {
+    fun encrypt(value: String): String {
+        if (value.isBlank()) return ""
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        val ciphertext = cipher.doFinal(value.toByteArray(Charsets.UTF_8))
+        return "${base64(cipher.iv)}:${base64(ciphertext)}"
+    }
+
+    fun decrypt(value: String): String {
+        if (value.isBlank() || !value.contains(":")) return ""
+        return runCatching {
+            val parts = value.split(":", limit = 2)
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(128, unbase64(parts[0])))
+            cipher.doFinal(unbase64(parts[1])).toString(Charsets.UTF_8)
+        }.getOrDefault("")
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (keyStore.getKey(alias, null) as? SecretKey)?.let { return it }
+
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+        generator.init(spec)
+        return generator.generateKey()
+    }
+
+    private fun base64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    private fun unbase64(value: String): ByteArray = Base64.decode(value, Base64.NO_WRAP)
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
@@ -1,5 +1,7 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
@@ -40,8 +43,11 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.components.TransferRateHint
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+import org.duckdns.lhfser.aiaccounting.ui.utils.toDateTimeText
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 private enum class AddTransferMode(val label: String) {
     OneToOne("一般 (1 -> 1)"),
@@ -60,6 +66,7 @@ private data class AddTransferLegInput(
 fun AddTransferScreen(onDone: () -> Unit) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val scrollState = rememberScrollState()
@@ -89,6 +96,7 @@ fun AddTransferScreen(onDone: () -> Unit) {
     var sourceLegs by remember { mutableStateOf(listOf(AddTransferLegInput())) }
 
     var note by remember { mutableStateOf("") }
+    var date by remember { mutableStateOf(Instant.now()) }
 
     Column(
         modifier = Modifier
@@ -235,6 +243,16 @@ fun AddTransferScreen(onDone: () -> Unit) {
             )
         }
 
+        ParitySectionHeader(
+            title = "日期與時間",
+            detail = "預設為現在，也可以補記過去的轉帳。"
+        )
+        SectionCard {
+            TextButton(onClick = { showDateTimePicker(context, date) { picked -> date = picked } }) {
+                Text(date.toDateTimeText())
+            }
+        }
+
         Button(
             onClick = {
                 scope.launch {
@@ -252,7 +270,7 @@ fun AddTransferScreen(onDone: () -> Unit) {
                                 currencyOut = currencyOut,
                                 amountIn = amountInValue,
                                 currencyIn = currencyIn,
-                                date = Instant.now(),
+                                date = date,
                                 note = note
                             )
                         }
@@ -270,7 +288,7 @@ fun AddTransferScreen(onDone: () -> Unit) {
                                 sourceAmount = sourceValue,
                                 sourceCurrency = sourceCurrency,
                                 destinations = legs,
-                                date = Instant.now(),
+                                date = date,
                                 note = note
                             )
                         }
@@ -288,7 +306,7 @@ fun AddTransferScreen(onDone: () -> Unit) {
                                 destinationAmount = destinationValue,
                                 destinationCurrency = destinationCurrency,
                                 sources = legs,
-                                date = Instant.now(),
+                                date = date,
                                 note = note
                             )
                         }
@@ -418,4 +436,31 @@ private fun sanitizeAmount(input: String): String {
 
 private fun parsePositive(input: String): BigDecimal? {
     return input.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO }
+}
+
+private fun showDateTimePicker(
+    context: android.content.Context,
+    initial: Instant,
+    onPicked: (Instant) -> Unit
+) {
+    val zone = ZoneId.systemDefault()
+    val initialDateTime = initial.atZone(zone).toLocalDateTime()
+    DatePickerDialog(
+        context,
+        { _, year, month, day ->
+            val pickedDate = LocalDate.of(year, month + 1, day)
+            TimePickerDialog(
+                context,
+                { _, hour, minute ->
+                    onPicked(pickedDate.atTime(hour, minute).atZone(zone).toInstant())
+                },
+                initialDateTime.hour,
+                initialDateTime.minute,
+                true
+            ).show()
+        },
+        initialDateTime.year,
+        initialDateTime.monthValue - 1,
+        initialDateTime.dayOfMonth
+    ).show()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
@@ -180,7 +181,8 @@ fun SettingsScreen(
                     label = { Text("Gemini API Key（可選）") },
                     placeholder = { Text("輸入後可使用 AI 預算與掃描功能") },
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(18.dp)
+                    shape = RoundedCornerShape(18.dp),
+                    visualTransformation = PasswordVisualTransformation()
                 )
             }
         }


### PR DESCRIPTION
## Summary
- store Android Gemini API keys with Android Keystore-backed encryption
- migrate legacy plaintext Gemini API key preferences on read
- mask Gemini API key input in Settings
- allow Android transfer creation to choose date and time instead of always using now

## Tests
- ANDROID_HOME=/Users/lhf/Library/Android/sdk ./gradlew testDebugUnitTest assembleDebug
- xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO