### PR TITLE
Sync iOS budget history incrementally

### DIFF
--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -13,8 +13,6 @@ enum RootTab: Hashable {
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
-    @Query(sort: \CategoryMonthlyBudget.updatedAt, order: .reverse) private var budgets: [CategoryMonthlyBudget]
-    @Query(sort: \FinancialTransaction.updatedAt, order: .reverse) private var transactions: [FinancialTransaction]
     @Query(sort: \RecurringRule.updatedAt, order: .reverse) private var recurringRules: [RecurringRule]
     @Query(sort: \RecurringOccurrence.updatedAt, order: .reverse) private var recurringOccurrences: [RecurringOccurrence]
 
@@ -37,32 +35,6 @@ struct ContentView: View {
 #if DEBUG
     @State private var uiTestSeeded = false
 #endif
-
-    private var budgetHistorySyncToken: Int {
-        var hasher = Hasher()
-
-        for budget in budgets {
-            hasher.combine(budget.id)
-            hasher.combine(budget.monthKey)
-            hasher.combine(NSDecimalNumber(decimal: budget.amount).stringValue)
-            hasher.combine(budget.currencyCode)
-            hasher.combine(budget.isEnabled)
-            hasher.combine(budget.updatedAt.timeIntervalSince1970)
-            hasher.combine(budget.category?.id)
-        }
-
-        for transaction in transactions {
-            hasher.combine(transaction.id)
-            hasher.combine(transaction.type.rawValue)
-            hasher.combine(NSDecimalNumber(decimal: transaction.amount).stringValue)
-            hasher.combine(transaction.currencyCode)
-            hasher.combine(transaction.date.timeIntervalSince1970)
-            hasher.combine(transaction.updatedAt.timeIntervalSince1970)
-            hasher.combine(transaction.category?.id)
-        }
-
-        return hasher.finalize()
-    }
 
     private var recurringSyncToken: Int {
         var hasher = Hasher()
@@ -201,19 +173,6 @@ struct ContentView: View {
             seedUITestDataIfNeeded()
         }
 #endif
-        .task(id: budgetHistorySyncToken) {
-            guard !isRunningXCTest else { return }
-            do {
-                try BudgetHistoryService.shared.syncAll(
-                    modelContext: modelContext,
-                    currencyService: CurrencyService.shared,
-                    budgets: budgets,
-                    transactions: transactions
-                )
-            } catch {
-                print("⚠️ 預算歷史同步失敗: \(error)")
-            }
-        }
         .task(id: recurringSyncToken) {
             guard !isRunningXCTest else { return }
             syncRecurringOccurrences()

--- a/AI 記帳/Services/AccountDeletionCoordinator.swift
+++ b/AI 記帳/Services/AccountDeletionCoordinator.swift
@@ -145,5 +145,9 @@ enum AccountDeletionCoordinator {
 
         modelContext.delete(impact.account)
         try modelContext.save()
+        try BudgetHistoryService.shared.syncAll(
+            modelContext: modelContext,
+            currencyService: CurrencyService.shared
+        )
     }
 }

--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -143,6 +143,7 @@ enum AdvanceService {
             expenseCategory: category
         )
         modelContext.insert(advanceCase)
+        var budgetHistoryTransactions: [FinancialTransaction] = []
         
         if myShareAmount > 0 {
             let expenseNote = finalNote.isEmpty
@@ -160,6 +161,7 @@ enum AdvanceService {
                 tags: tags
             )
             modelContext.insert(expenseTx)
+            budgetHistoryTransactions.append(expenseTx)
             advanceCase.selfExpenseTransactionID = expenseTx.id
         }
         
@@ -244,6 +246,11 @@ enum AdvanceService {
         }
         
         try modelContext.save()
+        try BudgetHistoryService.shared.syncAffected(
+            by: budgetHistoryTransactions,
+            modelContext: modelContext,
+            currencyService: CurrencyService.shared
+        )
         return advanceCase
     }
     
@@ -489,6 +496,7 @@ enum AdvanceService {
     ) throws -> DeleteAdvanceResult {
         var deletedTransactionCount = 0
         var missingLinkedRecordCount = 0
+        var affectedBudgetKeys: [BudgetHistoryAffectedKey] = []
         
         if deleteLinkedTransactions {
             var groupIDs = Set<UUID>()
@@ -525,6 +533,9 @@ enum AdvanceService {
                     predicate: #Predicate { $0.id == expenseID }
                 )
                 if let expenseTx = try? modelContext.fetch(descriptor).first {
+                    if let key = BudgetHistoryService.affectedKey(for: expenseTx) {
+                        affectedBudgetKeys.append(key)
+                    }
                     modelContext.delete(expenseTx)
                     deletedTransactionCount += 1
                 } else {
@@ -536,6 +547,11 @@ enum AdvanceService {
         modelContext.delete(advanceCase)
         if autosave {
             try modelContext.save()
+            try BudgetHistoryService.shared.syncAffected(
+                keys: affectedBudgetKeys,
+                modelContext: modelContext,
+                currencyService: CurrencyService.shared
+            )
         }
         
         return DeleteAdvanceResult(

--- a/AI 記帳/Services/BudgetHistoryService.swift
+++ b/AI 記帳/Services/BudgetHistoryService.swift
@@ -52,6 +52,81 @@ final class BudgetHistoryService {
         try modelContext.save()
     }
 
+    func syncAffected(
+        by transactions: [FinancialTransaction],
+        modelContext: ModelContext,
+        currencyService: CurrencyService
+    ) throws {
+        let keys = transactions.compactMap(Self.affectedKey(for:))
+        try syncAffected(keys: keys, modelContext: modelContext, currencyService: currencyService)
+    }
+
+    func syncAffected(
+        keys: [BudgetHistoryAffectedKey],
+        modelContext: ModelContext,
+        currencyService: CurrencyService
+    ) throws {
+        let uniqueKeys = Array(Set(keys))
+        guard !uniqueKeys.isEmpty else { return }
+
+        let budgets = try modelContext.fetch(FetchDescriptor<CategoryMonthlyBudget>())
+        let existingHistories = try modelContext.fetch(FetchDescriptor<BudgetMonthlyHistory>())
+        let existingByKey = Dictionary(uniqueKeysWithValues: existingHistories.map { ($0.historyKey, $0) })
+
+        for key in uniqueKeys {
+            let historyKey = Self.historyKey(monthKey: key.monthKey, categoryID: key.categoryID)
+            guard let budget = budgets.first(where: { budget in
+                budget.monthKey == key.monthKey &&
+                budget.category?.id == key.categoryID &&
+                budget.isEnabled &&
+                budget.category?.kind.supports(.expense) == true
+            }) else {
+                if let existing = existingByKey[historyKey] {
+                    modelContext.delete(existing)
+                }
+                continue
+            }
+
+            let monthRange = Self.dateRange(forMonthKey: key.monthKey)
+            let expenseType = TransactionType.expense
+            let startDate = monthRange.start
+            let endDate = monthRange.end
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { transaction in
+                    transaction.type == expenseType &&
+                    transaction.date >= startDate &&
+                    transaction.date < endDate
+                }
+            )
+            let monthTransactions = try modelContext.fetch(descriptor)
+            let categoryTransactions = monthTransactions.filter { $0.category?.id == key.categoryID }
+
+            let snapshot = makeSnapshot(
+                for: budget,
+                transactions: categoryTransactions,
+                currencyService: currencyService
+            )
+
+            if let existing = existingByKey[historyKey] {
+                apply(snapshot, to: existing)
+            } else {
+                modelContext.insert(snapshot.asModel())
+            }
+        }
+
+        try modelContext.save()
+    }
+
+    static func affectedKey(for transaction: FinancialTransaction) -> BudgetHistoryAffectedKey? {
+        guard transaction.type == .expense,
+              let categoryID = transaction.category?.id
+        else { return nil }
+        return BudgetHistoryAffectedKey(
+            monthKey: BudgetService.monthKey(from: transaction.date),
+            categoryID: categoryID
+        )
+    }
+
     private func buildDesiredHistories(
         budgets: [CategoryMonthlyBudget],
         transactions: [FinancialTransaction],
@@ -62,35 +137,14 @@ final class BudgetHistoryService {
             .compactMap { budget in
                 guard let category = budget.category, category.kind.supports(.expense) else { return nil }
 
-                let spent = transactions
-                    .filter { transaction in
+                return makeSnapshot(
+                    for: budget,
+                    transactions: transactions.filter { transaction in
                         transaction.type == .expense &&
                         BudgetService.monthKey(from: transaction.date) == budget.monthKey &&
                         transaction.category?.id == category.id
-                    }
-                    .reduce(Decimal.zero) { partial, transaction in
-                        partial + currencyService.convert(
-                            amount: abs(transaction.amount),
-                            from: transaction.currencyCode,
-                            to: budget.currencyCode
-                        )
-                    }
-
-                let remaining = budget.amount - spent
-                let ratio: Decimal = budget.amount > 0 ? (spent / budget.amount) : 0
-                return BudgetHistorySnapshot(
-                    id: UUID(),
-                    historyKey: Self.historyKey(monthKey: budget.monthKey, categoryID: category.id),
-                    monthKey: budget.monthKey,
-                    categoryID: category.id,
-                    categoryNameSnapshot: category.name,
-                    budgetAmount: budget.amount,
-                    spentAmount: spent,
-                    remainingAmount: remaining,
-                    usageRatio: ratio,
-                    isOverBudget: remaining < 0,
-                    currencyCode: budget.currencyCode,
-                    updatedAt: Date()
+                    },
+                    currencyService: currencyService
                 )
             }
             .sorted {
@@ -99,6 +153,39 @@ final class BudgetHistoryService {
                 }
                 return $0.monthKey > $1.monthKey
             }
+    }
+
+    private func makeSnapshot(
+        for budget: CategoryMonthlyBudget,
+        transactions: [FinancialTransaction],
+        currencyService: CurrencyService
+    ) -> BudgetHistorySnapshot {
+        let category = budget.category
+        let categoryID = category?.id ?? UUID()
+        let spent = transactions.reduce(Decimal.zero) { partial, transaction in
+            partial + currencyService.convert(
+                amount: abs(transaction.amount),
+                from: transaction.currencyCode,
+                to: budget.currencyCode
+            )
+        }
+
+        let remaining = budget.amount - spent
+        let ratio: Decimal = budget.amount > 0 ? (spent / budget.amount) : 0
+        return BudgetHistorySnapshot(
+            id: UUID(),
+            historyKey: Self.historyKey(monthKey: budget.monthKey, categoryID: categoryID),
+            monthKey: budget.monthKey,
+            categoryID: categoryID,
+            categoryNameSnapshot: category?.name ?? "未分類",
+            budgetAmount: budget.amount,
+            spentAmount: spent,
+            remainingAmount: remaining,
+            usageRatio: ratio,
+            isOverBudget: remaining < 0,
+            currencyCode: budget.currencyCode,
+            updatedAt: Date()
+        )
     }
 
     private func apply(_ snapshot: BudgetHistorySnapshot, to history: BudgetMonthlyHistory) {
@@ -117,6 +204,24 @@ final class BudgetHistoryService {
     static func historyKey(monthKey: String, categoryID: UUID) -> String {
         "\(monthKey)|\(categoryID.uuidString)"
     }
+
+    private static func dateRange(forMonthKey monthKey: String) -> (start: Date, end: Date) {
+        let parts = monthKey.split(separator: "-").compactMap { Int($0) }
+        var components = DateComponents()
+        components.year = parts.first
+        components.month = parts.dropFirst().first
+        components.day = 1
+
+        let calendar = Calendar(identifier: .gregorian)
+        let start = calendar.date(from: components) ?? Date()
+        let end = calendar.date(byAdding: .month, value: 1, to: start) ?? start
+        return (start, end)
+    }
+}
+
+struct BudgetHistoryAffectedKey: Hashable {
+    let monthKey: String
+    let categoryID: UUID
 }
 
 private struct BudgetHistorySnapshot {

--- a/AI 記帳/Services/LedgerDeletionService.swift
+++ b/AI 記帳/Services/LedgerDeletionService.swift
@@ -20,6 +20,8 @@ enum LedgerDeletionService {
             return
         }
 
+        let affectedKeys = [BudgetHistoryService.affectedKey(for: transaction)].compactMap { $0 }
+
         if isAdvanceSelfExpense(transaction, modelContext: modelContext) {
             throw LedgerDeletionError.advanceInitialTransferRequiresCase
         }
@@ -35,6 +37,11 @@ enum LedgerDeletionService {
 
         modelContext.delete(transaction)
         try modelContext.save()
+        try BudgetHistoryService.shared.syncAffected(
+            keys: affectedKeys,
+            modelContext: modelContext,
+            currencyService: CurrencyService.shared
+        )
     }
 
     private static func deleteTransferGroup(
@@ -61,6 +68,8 @@ enum LedgerDeletionService {
             predicate: #Predicate { $0.transferGroupID == groupID }
         )
         let groupedTransfers = try modelContext.fetch(descriptor)
+        let affectedKeys = (groupedTransfers.isEmpty ? [fallbackTransaction] : groupedTransfers)
+            .compactMap { BudgetHistoryService.affectedKey(for: $0) }
         if groupedTransfers.isEmpty {
             modelContext.delete(fallbackTransaction)
         } else {
@@ -69,6 +78,11 @@ enum LedgerDeletionService {
             }
         }
         try modelContext.save()
+        try BudgetHistoryService.shared.syncAffected(
+            keys: affectedKeys,
+            modelContext: modelContext,
+            currencyService: CurrencyService.shared
+        )
     }
 
     private static func repayment(for groupID: UUID, modelContext: ModelContext) throws -> AdvanceRepayment? {

--- a/AI 記帳/Services/RecurringTransactionService.swift
+++ b/AI 記帳/Services/RecurringTransactionService.swift
@@ -90,6 +90,11 @@ enum RecurringTransactionService {
         occurrence.status = .confirmed
         rule.updatedAt = Date()
         try modelContext.save()
+        try BudgetHistoryService.shared.syncAffected(
+            by: [transaction],
+            modelContext: modelContext,
+            currencyService: CurrencyService.shared
+        )
         return transaction
     }
 

--- a/AI 記帳/Views/Transactions/AddTransactionView.swift
+++ b/AI 記帳/Views/Transactions/AddTransactionView.swift
@@ -392,6 +392,8 @@ struct AddTransactionView: View {
     }
 
     private func saveTransactions() {
+        var insertedTransactions: [FinancialTransaction] = []
+
         switch entryMode {
         case .normal:
             guard let account = selectedAccount,
@@ -401,12 +403,12 @@ struct AddTransactionView: View {
                 return
             }
 
-            insertTransaction(
+            insertedTransactions.append(insertTransaction(
                 amount: amount,
                 currencyCode: selectedCurrency,
                 account: account,
                 note: note
-            )
+            ))
 
         case .split:
             var legs: [(account: Account, amount: Decimal, currency: String)] = []
@@ -421,12 +423,12 @@ struct AddTransactionView: View {
             }
 
             for (index, leg) in legs.enumerated() {
-                insertTransaction(
+                insertedTransactions.append(insertTransaction(
                     amount: leg.amount,
                     currencyCode: leg.currency,
                     account: leg.account,
                     note: indexedNote(base: note, mode: .split, index: index, count: legs.count)
-                )
+                ))
             }
 
         case .merge:
@@ -445,19 +447,31 @@ struct AddTransactionView: View {
             }
 
             for (index, item) in items.enumerated() {
-                insertTransaction(
+                insertedTransactions.append(insertTransaction(
                     amount: item.amount,
                     currencyCode: item.currency,
                     account: account,
                     note: indexedNote(base: note, mode: .merge, index: index, count: items.count)
-                )
+                ))
             }
+        }
+
+        do {
+            try modelContext.save()
+            try BudgetHistoryService.shared.syncAffected(
+                by: insertedTransactions,
+                modelContext: modelContext,
+                currencyService: currencyService
+            )
+        } catch {
+            showValidation("儲存失敗：\(error.localizedDescription)")
+            return
         }
 
         dismiss()
     }
 
-    private func insertTransaction(amount: Decimal, currencyCode: String, account: Account, note: String) {
+    private func insertTransaction(amount: Decimal, currencyCode: String, account: Account, note: String) -> FinancialTransaction {
         let finalAmount = (selectedType == .expense) ? -abs(amount) : abs(amount)
 
         let tx = FinancialTransaction(
@@ -472,6 +486,7 @@ struct AddTransactionView: View {
         )
 
         modelContext.insert(tx)
+        return tx
     }
 
     private func indexedNote(base: String, mode: EntryMode, index: Int, count: Int) -> String {

--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct EditTransactionView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
     @Bindable var transaction: FinancialTransaction
     @StateObject private var currencyService = CurrencyService.shared
     
@@ -12,6 +13,8 @@ struct EditTransactionView: View {
     
     @State private var amountString: String = ""
     @State private var selectedTags: Set<Tag> = []
+    @State private var originalBudgetKey: BudgetHistoryAffectedKey?
+    @State private var errorMessage: String?
     
     // 🔥 新增：焦點控制
     @FocusState private var isAmountFocused: Bool
@@ -120,8 +123,7 @@ struct EditTransactionView: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("完成") {
-                        transaction.updatedAt = Date()
-                        dismiss()
+                        saveChanges()
                     }
                     .accessibilityIdentifier("transactionEditor.saveButton")
                 }
@@ -137,8 +139,34 @@ struct EditTransactionView: View {
             .onAppear {
                 amountString = String(format: "%.2f", abs(NSDecimalNumber(decimal: transaction.amount).doubleValue))
                 selectedTags = Set(transaction.tags)
+                originalBudgetKey = BudgetHistoryService.affectedKey(for: transaction)
                 Task { await currencyService.fetchRates() }
             }
+            .alert("儲存失敗", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("好", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    private func saveChanges() {
+        do {
+            let previousKey = originalBudgetKey
+            transaction.updatedAt = Date()
+            try modelContext.save()
+            let currentKey = BudgetHistoryService.affectedKey(for: transaction)
+            try BudgetHistoryService.shared.syncAffected(
+                keys: [previousKey, currentKey].compactMap { $0 },
+                modelContext: modelContext,
+                currencyService: currencyService
+            )
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
     

--- a/AI 記帳/Views/Transactions/ScannedResultView.swift
+++ b/AI 記帳/Views/Transactions/ScannedResultView.swift
@@ -112,6 +112,16 @@ struct ScannedResultView: View {
         )
 
         modelContext.insert(tx)
+        do {
+            try modelContext.save()
+            try BudgetHistoryService.shared.syncAffected(
+                by: [tx],
+                modelContext: modelContext,
+                currencyService: CurrencyService.shared
+            )
+        } catch {
+            print("⚠️ 掃描交易預算歷史同步失敗: \(error)")
+        }
 
         // 這裡需要連續 dismiss 兩次 (回到主頁)，或者使用 Binding 控制
         // 簡單做法：發送 Notification 讓 ContentView 關閉 Sheet


### PR DESCRIPTION
## Summary
- remove root-level full budget history resync from ContentView transaction hash changes
- add targeted budget history sync by affected month/category
- trigger incremental sync from iOS transaction add/edit/delete, scanned receipts, recurring confirmations, and advance self-expense changes
- keep full sync for import, budget settings, and account deletion fallback paths

## Tests
- xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO
- ANDROID_HOME=/Users/lhf/Library/Android/sdk ./gradlew testDebugUnitTest assembleDebug