### PR TITLE
Persist Android recurring tags and warn on HTTP WebDAV

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
@@ -15,6 +15,7 @@ class AppContainer(context: Context) {
             .addMigrations(AIAccountingDatabase.MIGRATION_1_2)
             .addMigrations(AIAccountingDatabase.MIGRATION_2_3)
             .addMigrations(AIAccountingDatabase.MIGRATION_3_4)
+            .addMigrations(AIAccountingDatabase.MIGRATION_4_5)
             .addCallback(SeedData.callback(appContext))
             .build()
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
@@ -16,6 +16,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ShortcutEntity::class,
         ShortcutTagCrossRef::class,
         RecurringRuleEntity::class,
+        RecurringRuleTagCrossRef::class,
         RecurringOccurrenceEntity::class,
         CategoryMonthlyBudgetEntity::class,
         BudgetMonthlyHistoryEntity::class,
@@ -24,7 +25,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AdvanceParticipantEntity::class,
         AdvanceRepaymentEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -126,6 +127,21 @@ abstract class AIAccountingDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_occurrences_ruleId` ON `recurring_occurrences` (`ruleId`)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_occurrences_dueDate` ON `recurring_occurrences` (`dueDate`)")
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_recurring_occurrences_ruleId_dueDate` ON `recurring_occurrences` (`ruleId`, `dueDate`)")
+            }
+        }
+
+        val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `recurring_rule_tag_cross_ref` (
+                        `ruleId` TEXT NOT NULL,
+                        `tagId` TEXT NOT NULL,
+                        PRIMARY KEY(`ruleId`, `tagId`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_rule_tag_cross_ref_tagId` ON `recurring_rule_tag_cross_ref` (`tagId`)")
             }
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
@@ -187,6 +187,18 @@ interface RecurringDao {
     suspend fun upsertRules(rules: List<RecurringRuleEntity>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRuleTags(tags: List<RecurringRuleTagCrossRef>)
+
+    @Query("SELECT * FROM recurring_rule_tag_cross_ref")
+    suspend fun getRuleTags(): List<RecurringRuleTagCrossRef>
+
+    @Query("SELECT * FROM recurring_rule_tag_cross_ref WHERE ruleId = :ruleId")
+    suspend fun getRuleTags(ruleId: UUID): List<RecurringRuleTagCrossRef>
+
+    @Query("DELETE FROM recurring_rule_tag_cross_ref WHERE ruleId = :ruleId")
+    suspend fun clearRuleTags(ruleId: UUID)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertOccurrence(occurrence: RecurringOccurrenceEntity)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -203,6 +215,9 @@ interface RecurringDao {
 
     @Query("DELETE FROM recurring_rules")
     suspend fun deleteAllRules()
+
+    @Query("DELETE FROM recurring_rule_tag_cross_ref")
+    suspend fun deleteAllRuleTags()
 }
 
 @Dao

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
@@ -120,6 +120,16 @@ data class RecurringRuleEntity(
 )
 
 @Entity(
+    tableName = "recurring_rule_tag_cross_ref",
+    primaryKeys = ["ruleId", "tagId"],
+    indices = [Index("tagId")]
+)
+data class RecurringRuleTagCrossRef(
+    val ruleId: UUID,
+    val tagId: UUID
+)
+
+@Entity(
     tableName = "recurring_occurrences",
     indices = [
         Index("ruleId"),

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -28,6 +28,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.BudgetMonthlyHistoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.BudgetSettingsEntity
 import org.duckdns.lhfser.aiaccounting.data.db.RecurringOccurrenceEntity
 import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleTagCrossRef
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutEntity
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutTagCrossRef
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
@@ -392,13 +393,24 @@ class AccountingRepository(
         return recurringDao.getRule(ruleId)
     }
 
-    suspend fun upsertRecurringRule(rule: RecurringRuleEntity) {
-        recurringDao.upsertRule(rule)
+    suspend fun getRecurringRuleTagIds(ruleId: UUID): List<UUID> {
+        return recurringDao.getRuleTags(ruleId).map { it.tagId }
+    }
+
+    suspend fun upsertRecurringRule(rule: RecurringRuleEntity, tagIds: List<UUID> = emptyList()) {
+        database.withTransaction {
+            recurringDao.upsertRule(rule)
+            recurringDao.clearRuleTags(rule.id)
+            if (tagIds.isNotEmpty()) {
+                recurringDao.insertRuleTags(tagIds.map { RecurringRuleTagCrossRef(rule.id, it) })
+            }
+        }
     }
 
     suspend fun deleteRecurringRule(rule: RecurringRuleEntity) {
         database.withTransaction {
             recurringDao.deleteOccurrencesForRule(rule.id)
+            recurringDao.clearRuleTags(rule.id)
             recurringDao.deleteRule(rule)
         }
     }
@@ -482,6 +494,13 @@ class AccountingRepository(
                 categoryId = rule.categoryId
             )
             transactionDao.upsert(transaction)
+            val ruleTags = recurringDao.getRuleTags(rule.id)
+            if (ruleTags.isNotEmpty()) {
+                transactionDao.clearTransactionTags(transactionId)
+                transactionDao.insertTransactionTags(
+                    ruleTags.map { TransactionTagCrossRef(transactionId, it.tagId) }
+                )
+            }
             recurringDao.upsertOccurrence(
                 occurrence.copy(
                     status = RECURRING_STATUS_CONFIRMED,
@@ -980,6 +999,7 @@ class AccountingRepository(
         val shortcuts = shortcutDao.getAll()
         val shortcutTags = shortcutDao.getShortcutTags()
         val recurringRules = recurringDao.getAllRules()
+        val recurringRuleTags = recurringDao.getRuleTags()
         val recurringOccurrences = recurringDao.getAllOccurrences()
         val budgets = budgetDao.getAll()
         val budgetHistories = budgetDao.getAllHistory()
@@ -990,6 +1010,7 @@ class AccountingRepository(
 
         val transactionTagMap = transactionTags.groupBy { it.transactionId }
         val shortcutTagMap = shortcutTags.groupBy { it.shortcutId }
+        val recurringRuleTagMap = recurringRuleTags.groupBy { it.ruleId }
 
         return FullBackupData(
             version = "1.8",
@@ -1062,7 +1083,7 @@ class AccountingRepository(
                     isPaused = rule.isPaused,
                     accountID = rule.accountId,
                     categoryID = rule.categoryId,
-                    tagIDs = emptyList(),
+                    tagIDs = recurringRuleTagMap[rule.id]?.map { it.tagId } ?: emptyList(),
                     createdAt = rule.createdAt,
                     updatedAt = rule.updatedAt
                 )
@@ -1263,6 +1284,9 @@ class AccountingRepository(
                 categoryId = rule.categoryID
             )
         }.orEmpty()
+        val recurringRuleTags = data.recurringRules?.flatMap { rule ->
+            rule.tagIDs.map { tagId -> RecurringRuleTagCrossRef(rule.id, tagId) }
+        }.orEmpty()
 
         val recurringOccurrenceEntities = data.recurringOccurrences?.map { occurrence ->
             RecurringOccurrenceEntity(
@@ -1383,6 +1407,9 @@ class AccountingRepository(
             if (recurringRuleEntities.isNotEmpty()) {
                 recurringDao.upsertRules(recurringRuleEntities)
             }
+            if (recurringRuleTags.isNotEmpty()) {
+                recurringDao.insertRuleTags(recurringRuleTags)
+            }
             if (recurringOccurrenceEntities.isNotEmpty()) {
                 recurringDao.upsertOccurrences(recurringOccurrenceEntities)
             }
@@ -1484,6 +1511,7 @@ class AccountingRepository(
         budgetDao.deleteAllHistory()
         budgetDao.deleteAll()
         recurringDao.deleteAllOccurrences()
+        recurringDao.deleteAllRuleTags()
         recurringDao.deleteAllRules()
         shortcutDao.deleteAllShortcuts()
         transactionDao.deleteAllTransactions()

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
@@ -39,6 +39,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.RecurringOccurrenceEntity
 import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
@@ -262,6 +263,7 @@ fun RecurringRuleEditorScreen(
     val scope = rememberCoroutineScope()
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val categories by repository.categories.collectAsState(initial = emptyList())
+    val tags by repository.tags.collectAsState(initial = emptyList())
     val rules by repository.recurringRules.collectAsState(initial = emptyList())
     val scrollState = rememberScrollState()
 
@@ -281,6 +283,7 @@ fun RecurringRuleEditorScreen(
     var isPaused by remember { mutableStateOf(false) }
     var selectedAccount by remember { mutableStateOf<AccountEntity?>(null) }
     var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
+    var selectedTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
     val filteredCategories = categories.filter { it.kind.supports(type) }
@@ -299,6 +302,8 @@ fun RecurringRuleEditorScreen(
             isPaused = existingRule.isPaused
             selectedAccount = ownAccounts.firstOrNull { it.id == existingRule.accountId }
             selectedCategory = filteredCategories.firstOrNull { it.id == existingRule.categoryId }
+            val existingTagIds = repository.getRecurringRuleTagIds(existingRule.id).toSet()
+            selectedTags = tags.filter { it.id in existingTagIds }
             loaded = true
         } else if (ownAccounts.isNotEmpty()) {
             selectedAccount = ownAccounts.first()
@@ -373,6 +378,7 @@ fun RecurringRuleEditorScreen(
                     selected = selectedCategory,
                     onSelect = { selectedCategory = it }
                 )
+                RecurringTagPicker(tags = tags, selected = selectedTags, onChange = { selectedTags = it })
                 OutlinedTextField(
                     value = note,
                     onValueChange = { note = it },
@@ -437,7 +443,7 @@ fun RecurringRuleEditorScreen(
                         categoryId = selectedCategory?.id
                     )
                     scope.launch {
-                        repository.upsertRecurringRule(rule)
+                        repository.upsertRecurringRule(rule, selectedTags.map { it.id })
                         repository.syncDueRecurringOccurrences()
                         onDone()
                     }
@@ -534,6 +540,37 @@ private fun CategoryDropdown(
                     onSelect(category)
                 }
             )
+        }
+    }
+}
+
+@Composable
+private fun RecurringTagPicker(
+    tags: List<TagEntity>,
+    selected: List<TagEntity>,
+    onChange: (List<TagEntity>) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text("標籤", style = MaterialTheme.typography.titleSmall)
+        if (tags.isEmpty()) {
+            Text("尚未建立標籤", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        } else {
+            tags.forEach { tag ->
+                val isSelected = selected.any { it.id == tag.id }
+                TextButton(
+                    onClick = {
+                        onChange(
+                            if (isSelected) {
+                                selected.filterNot { it.id == tag.id }
+                            } else {
+                                selected + tag
+                            }
+                        )
+                    }
+                ) {
+                    Text(if (isSelected) "✓ ${tag.name}" else tag.name)
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
@@ -59,6 +59,8 @@ fun RemoteBackupScreen() {
     var message by remember { mutableStateOf<String?>(null) }
     var isBusy by remember { mutableStateOf(false) }
     var showRestoreConfirm by remember { mutableStateOf(false) }
+    var showHttpRiskConfirm by remember { mutableStateOf(false) }
+    var pendingHttpAction by remember { mutableStateOf<(() -> Unit)?>(null) }
 
     fun saveSettings() {
         settingsStore.baseUrl = baseUrl
@@ -76,11 +78,20 @@ fun RemoteBackupScreen() {
         )
     }
 
-    fun runRemote(successMessage: String, block: suspend () -> Unit) {
+    fun isInsecureHttp(url: String): Boolean {
+        return url.trim().startsWith("http://", ignoreCase = true)
+    }
+
+    fun runRemote(successMessage: String, allowInsecureHttp: Boolean = false, block: suspend () -> Unit) {
         if (isBusy) return
         val creds = credentials()
         if (!creds.isComplete) {
             message = "請先填寫 WebDAV URL、帳戶、密碼和加密 passphrase。"
+            return
+        }
+        if (!allowInsecureHttp && isInsecureHttp(creds.baseUrl)) {
+            pendingHttpAction = { runRemote(successMessage, allowInsecureHttp = true, block = block) }
+            showHttpRiskConfirm = true
             return
         }
         saveSettings()
@@ -267,6 +278,41 @@ fun RemoteBackupScreen() {
             },
             dismissButton = {
                 TextButton(onClick = { showRestoreConfirm = false }) { Text("取消") }
+            }
+        )
+    }
+
+    if (showHttpRiskConfirm) {
+        AlertDialog(
+            onDismissRequest = {
+                showHttpRiskConfirm = false
+                pendingHttpAction = null
+            },
+            title = { Text("HTTP 連線不安全") },
+            text = {
+                Text("目前 WebDAV URL 使用 http://，傳輸途中可能被讀取或竄改。localhost / LAN 可以用作測試，但仍不建議放敏感備份。確定要繼續？")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val action = pendingHttpAction
+                        showHttpRiskConfirm = false
+                        pendingHttpAction = null
+                        action?.invoke()
+                    }
+                ) {
+                    Text("仍然繼續", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showHttpRiskConfirm = false
+                        pendingHttpAction = null
+                    }
+                ) {
+                    Text("取消")
+                }
             }
         )
     }


### PR DESCRIPTION
## Summary
- add Room v5 recurring_rule_tag_cross_ref with migration
- allow Android recurring rules to save and restore tags
- copy recurring rule tags onto confirmed recurring transactions
- preserve recurring tags through JSON export/import
- require explicit confirmation before running WebDAV operations over http://

## Tests
- ANDROID_HOME=/Users/lhf/Library/Android/sdk ./gradlew testDebugUnitTest assembleDebug
- xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO