### PR TITLE
Add per-page pinned section preferences

### DIFF
--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -12,6 +12,7 @@ struct ChartsView: View {
     @State private var showingFilterSheet = false
     @State private var chartMode: ChartMode = .category
     @State private var flowMode: FlowMode = .expense
+    @AppStorage("pinReportsControls") private var pinReportsControls: Bool = true
     
     // 互動狀態
     @State private var selectedTagForDetail: String?
@@ -59,45 +60,15 @@ struct ChartsView: View {
 
         NavigationStack {
             VStack(spacing: 0) {
-                // 頂部控制列
-                VStack(spacing: 10) {
-                    HStack {
-                        Button(action: { showingFilterSheet = true }) {
-                            HStack(spacing: 4) {
-                                Text(filterDisplayString).font(.headline)
-                                Image(systemName: "chevron.down").font(.caption).bold()
-                            }
-                            .foregroundStyle(.primary)
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 12)
-                            .background(Color.gray.opacity(0.1))
-                            .clipShape(Capsule())
-                        }
-                        Spacer()
-                    }
-                    
-                    HStack(spacing: 8) {
-                        Picker("收支", selection: $flowMode) {
-                            ForEach(FlowMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
-                        }
-                        .pickerStyle(.segmented)
-                        .onChange(of: flowMode) { _, _ in
-                            selectedTagForDetail = nil
-                        }
-                        
-                        Picker("模式", selection: $chartMode) {
-                            ForEach(ChartMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
-                        }
-                        .pickerStyle(.segmented)
-                        .onChange(of: chartMode) { _, _ in
-                            selectedTagForDetail = nil
-                        }
-                    }
+                if pinReportsControls {
+                    reportControls
                 }
-                .padding()
-                
-                // 內容區
+
                 ScrollView {
+                    if !pinReportsControls {
+                        reportControls
+                    }
+
                     if renderState.currentData.isEmpty {
                         ContentUnavailableView(flowMode.emptyTitle, systemImage: "chart.pie", description: Text("試試切換日期或記一筆帳"))
                             .padding(.top, 40)
@@ -140,6 +111,45 @@ struct ChartsView: View {
                 ReportTransactionListView(title: detail.title, transactions: detail.transactions)
             }
         }
+    }
+
+    private var reportControls: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Button(action: { showingFilterSheet = true }) {
+                    HStack(spacing: 4) {
+                        Text(filterDisplayString).font(.headline)
+                        Image(systemName: "chevron.down").font(.caption).bold()
+                    }
+                    .foregroundStyle(.primary)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(Color.gray.opacity(0.1))
+                    .clipShape(Capsule())
+                }
+                Spacer()
+            }
+
+            HStack(spacing: 8) {
+                Picker("收支", selection: $flowMode) {
+                    ForEach(FlowMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: flowMode) { _, _ in
+                    selectedTagForDetail = nil
+                }
+
+                Picker("模式", selection: $chartMode) {
+                    ForEach(ChartMode.allCases, id: \.self) { mode in Text(mode.rawValue).tag(mode) }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: chartMode) { _, _ in
+                    selectedTagForDetail = nil
+                }
+            }
+        }
+        .padding()
+        .background(Color(uiColor: .systemBackground))
     }
     
     // MARK: - 主圖表視圖

--- a/AI 記帳/Views/Home/HomeDashboardView.swift
+++ b/AI 記帳/Views/Home/HomeDashboardView.swift
@@ -8,6 +8,7 @@ struct HomeDashboardView: View {
     @State private var filterType: FilterType = .month
     @State private var selectedDate: Date = Date()
     @State private var showingFilterSheet = false
+    @AppStorage("pinOverviewControls") private var pinOverviewControls: Bool = true
 
     let onQuickAdd: () -> Void
     let onOpenGuide: () -> Void
@@ -57,16 +58,27 @@ struct HomeDashboardView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    summaryHeader
-                    filterControlRow
-                    quickActionPanel
-                    overviewCards
-                    shortcutsPanel
+            Group {
+                if pinOverviewControls {
+                    VStack(spacing: 0) {
+                        VStack(alignment: .leading, spacing: 16) {
+                            summaryHeader
+                            filterControlRow
+                        }
+                        .padding(.horizontal)
+                        .padding(.vertical, 12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(uiColor: .systemBackground))
+
+                        ScrollView {
+                            dashboardScrollableContent(includeHeader: false)
+                        }
+                    }
+                } else {
+                    ScrollView {
+                        dashboardScrollableContent(includeHeader: true)
+                    }
                 }
-                .padding(.horizontal)
-                .padding(.vertical, 12)
             }
             .prominentInlineTitle("總覽")
             .task {
@@ -76,6 +88,20 @@ struct HomeDashboardView: View {
                 DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
             }
         }
+    }
+
+    private func dashboardScrollableContent(includeHeader: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if includeHeader {
+                summaryHeader
+                filterControlRow
+            }
+            quickActionPanel
+            overviewCards
+            shortcutsPanel
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
     }
 
     private var summaryHeader: some View {

--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -12,6 +12,9 @@ struct SettingsView: View {
     @AppStorage("enableAutoBackup") private var enableAutoBackup: Bool = false
     @AppStorage("lastBackupDate") private var lastBackupDate: Double = 0
     @AppStorage("backupRetentionDays") private var backupRetentionDays: Int = 30
+    @AppStorage("pinOverviewControls") private var pinOverviewControls: Bool = true
+    @AppStorage("pinLedgerControls") private var pinLedgerControls: Bool = true
+    @AppStorage("pinReportsControls") private var pinReportsControls: Bool = true
 
     @State private var isExportingJSON = false
     @State private var isImportingJSON = false
@@ -134,6 +137,10 @@ struct SettingsView: View {
                         .onSubmit { hideKeyboard() }
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
+
+                    Toggle("固定總覽頁頂部區塊", isOn: $pinOverviewControls)
+                    Toggle("固定帳目頁頂部區塊", isOn: $pinLedgerControls)
+                    Toggle("固定報表頁頂部區塊", isOn: $pinReportsControls)
                 }
 
                 Section("資料安全") {

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -13,6 +13,7 @@ struct TransactionsListView: View {
     @State private var selectedDate: Date = Date()
     @State private var showingFilterSheet = false
     @State private var searchText = ""
+    @AppStorage("pinLedgerControls") private var pinLedgerControls: Bool = true
     
     @State private var transactionToEdit: FinancialTransaction?
     
@@ -56,157 +57,221 @@ struct TransactionsListView: View {
         let renderState = makeRenderState()
 
         NavigationStack {
-            VStack(spacing: 0) {
-                // MARK: - 1. 日期選擇器 (固定)
-                HStack {
-                    Spacer()
-                    Button(action: { showingFilterSheet = true }) {
-                        HStack {
-                            Image(systemName: "line.3.horizontal.decrease.circle.fill")
-                            Text(filterDisplayString).bold()
-                            Image(systemName: "chevron.down").font(.caption)
-                        }
-                        .padding(.vertical, 6)
-                        .padding(.horizontal, 16)
-                        .background(Color.blue.opacity(0.1))
-                        .foregroundColor(.blue)
-                        .clipShape(Capsule())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("ledger.dateFilter.button")
-                    Spacer()
+            ledgerContent(renderState: renderState)
+        }
+        .sheet(isPresented: $showingFilterSheet) {
+            DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
+        }
+        .sheet(isPresented: $showingAddShortcut) {
+            AddShortcutView()
+        }
+        .sheet(item: $transactionToEdit) { tx in
+            transactionEditor(for: tx, renderState: renderState)
+        }
+        // 捷徑確認彈窗
+        .alert("確認快速記帳？", isPresented: $showingShortcutConfirm) {
+            Button("確認", role: .none) { executeShortcut() }
+            Button("取消", role: .cancel) { }
+        } message: {
+            if let sc = pendingShortcut {
+                Text("\(sc.name)\n\(sc.type == .expense ? "支出" : "收入") \(sc.amount.formatted()) \(sc.account?.currency ?? "")")
+            }
+        }
+        .confirmationDialog(
+            "刪除捷徑？",
+            isPresented: $showingShortcutDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("刪除", role: .destructive) {
+                if let shortcut = shortcutToDelete {
+                    modelContext.delete(shortcut)
                 }
+                shortcutToDelete = nil
+            }
+            Button("取消", role: .cancel) {
+                shortcutToDelete = nil
+            }
+        } message: {
+            Text(shortcutToDelete?.name ?? "")
+        }
+        .alert("無法刪除", isPresented: Binding(
+            get: { deletionErrorMessage != nil },
+            set: { if !$0 { deletionErrorMessage = nil } }
+        )) {
+            Button("好", role: .cancel) { deletionErrorMessage = nil }
+        } message: {
+            Text(deletionErrorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private func ledgerContent(renderState: TransactionsRenderState) -> some View {
+        Group {
+            if pinLedgerControls {
+                VStack(spacing: 0) {
+                    pinnedLedgerControls
+                    ledgerList(renderState: renderState, includeScrollableControls: false)
+                }
+            } else {
+                ledgerList(renderState: renderState, includeScrollableControls: true)
+            }
+        }
+        .prominentInlineTitle("帳目明細")
+        .modifier(LedgerSearchModifier(isEnabled: pinLedgerControls, text: $searchText))
+    }
+
+    @ViewBuilder
+    private func transactionEditor(for tx: FinancialTransaction, renderState: TransactionsRenderState) -> some View {
+        if tx.type == .transfer {
+            if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
+                EditAdvanceTransferView(originalTransaction: tx)
+            } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+                AddDebtView(existingForgivenessTransaction: tx)
+            } else {
+                EditTransferView(originalTransaction: tx)
+            }
+        } else {
+            EditTransactionView(transaction: tx)
+        }
+    }
+
+    private var pinnedLedgerControls: some View {
+        VStack(spacing: 0) {
+            dateFilterControl
                 .padding(.vertical, 8)
                 .background(Color(uiColor: .systemBackground))
 
-                Divider()
+            Divider()
 
-                // MARK: - 2. 捷徑列 (Shortcuts Bar)
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 12) {
-                        // 新增按鈕
-                        Button(action: { showingAddShortcut = true }) {
-                            VStack(spacing: 4) {
-                                Image(systemName: "plus")
-                                    .font(.headline)
-                                    .frame(width: 44, height: 44)
-                                    .background(Color.blue.opacity(0.1))
-                                    .clipShape(Circle())
-                                Text("捷徑")
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        
-                        // 捷徑列表
-                        ForEach(shortcuts) { shortcut in
-                            shortcutTile(shortcut)
-                        }
-                    }
-                    .padding(.horizontal)
-                    .padding(.vertical, 8)
-                }
+            shortcutsBar
                 .background(Color(uiColor: .systemBackground))
-                
-                Divider()
-                
-                // MARK: - 3. 列表內容 (List)
-                List {
-                    // 交易分組
-                    ForEach(renderState.groupedTransactions, id: \.title) { group in
-                        Section(header: Text(group.title)) {
-                            ForEach(group.items) { item in
-                                switch item {
-                                case .transaction(let transaction):
-                                    TransactionRow(
-                                        transaction: transaction,
-                                        transferCounterpart: renderState.transferCounterpartByID[transaction.id]
-                                    )
-                                        .accessibilityIdentifier("ledger.transaction.row")
-                                        .accessibilityValue(transaction.note)
-                                        .onTapGesture {
-                                            transactionToEdit = transaction
-                                        }
-                                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                            Button(role: .destructive) { deleteTransaction(transaction) } label: { Label("刪除", systemImage: "trash") }
-                                            Button {
-                                                transactionToEdit = transaction
-                                            } label: { Label("編輯", systemImage: "pencil") }.tint(.blue)
-                                        }
-                                case .advanceCaseSummary(let advanceCase):
-                                    NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
-                                        AdvanceCaseSummaryRow(advanceCase: advanceCase)
-                                    }
-                                }
+
+            Divider()
+        }
+    }
+
+    private func ledgerList(renderState: TransactionsRenderState, includeScrollableControls: Bool) -> some View {
+        List {
+            if includeScrollableControls {
+                Section {
+                    dateFilterControl
+                    shortcutsBar
+                    inlineSearchField
+                }
+                .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
+                .listRowBackground(Color.clear)
+            }
+
+            if renderState.ledgerItems.isEmpty {
+                Section {
+                    ContentUnavailableView("無交易紀錄", systemImage: "list.bullet.clipboard", description: Text("該區間或搜尋條件下無資料"))
+                        .frame(maxWidth: .infinity)
+                        .listRowBackground(Color.clear)
+                }
+            }
+
+            ForEach(renderState.groupedTransactions, id: \.title) { group in
+                Section(header: Text(group.title)) {
+                    ForEach(group.items) { item in
+                        switch item {
+                        case .transaction(let transaction):
+                            TransactionRow(
+                                transaction: transaction,
+                                transferCounterpart: renderState.transferCounterpartByID[transaction.id]
+                            )
+                            .accessibilityIdentifier("ledger.transaction.row")
+                            .accessibilityValue(transaction.note)
+                            .onTapGesture {
+                                transactionToEdit = transaction
+                            }
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) { deleteTransaction(transaction) } label: { Label("刪除", systemImage: "trash") }
+                                Button {
+                                    transactionToEdit = transaction
+                                } label: { Label("編輯", systemImage: "pencil") }.tint(.blue)
+                            }
+                        case .advanceCaseSummary(let advanceCase):
+                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
+                                AdvanceCaseSummaryRow(advanceCase: advanceCase)
                             }
                         }
                     }
                 }
-                .listStyle(.insetGrouped)
-                .accessibilityIdentifier("ledger.list")
-            }
-            .prominentInlineTitle("帳目明細")
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "搜尋備註、分類、金額")
-            .sheet(isPresented: $showingFilterSheet) {
-                DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
-            }
-            .sheet(isPresented: $showingAddShortcut) {
-                AddShortcutView()
-            }
-            .sheet(item: $transactionToEdit) { tx in
-                if tx.type == .transfer {
-                    if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
-                        EditAdvanceTransferView(originalTransaction: tx)
-                    } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
-                        AddDebtView(existingForgivenessTransaction: tx)
-                    } else {
-                        EditTransferView(originalTransaction: tx)
-                    }
-                } else {
-                    EditTransactionView(transaction: tx)
-                }
-            }
-            .overlay {
-                if renderState.ledgerItems.isEmpty {
-                    ContentUnavailableView("無交易紀錄", systemImage: "list.bullet.clipboard", description: Text("該區間或搜尋條件下無資料"))
-                }
-            }
-            // 捷徑確認彈窗
-            .alert("確認快速記帳？", isPresented: $showingShortcutConfirm) {
-                Button("確認", role: .none) { executeShortcut() }
-                Button("取消", role: .cancel) { }
-            } message: {
-                if let sc = pendingShortcut {
-                    Text("\(sc.name)\n\(sc.type == .expense ? "支出" : "收入") \(sc.amount.formatted()) \(sc.account?.currency ?? "")")
-                }
-            }
-            .confirmationDialog(
-                "刪除捷徑？",
-                isPresented: $showingShortcutDeleteConfirm,
-                titleVisibility: .visible
-            ) {
-                Button("刪除", role: .destructive) {
-                    if let shortcut = shortcutToDelete {
-                        modelContext.delete(shortcut)
-                    }
-                    shortcutToDelete = nil
-                }
-                Button("取消", role: .cancel) {
-                    shortcutToDelete = nil
-                }
-            } message: {
-                Text(shortcutToDelete?.name ?? "")
-            }
-            .alert("無法刪除", isPresented: Binding(
-                get: { deletionErrorMessage != nil },
-                set: { if !$0 { deletionErrorMessage = nil } }
-            )) {
-                Button("好", role: .cancel) { deletionErrorMessage = nil }
-            } message: {
-                Text(deletionErrorMessage ?? "")
             }
         }
+        .listStyle(.insetGrouped)
+        .accessibilityIdentifier("ledger.list")
+    }
+
+    private var dateFilterControl: some View {
+        HStack {
+            Spacer()
+            Button(action: { showingFilterSheet = true }) {
+                HStack {
+                    Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                    Text(filterDisplayString).bold()
+                    Image(systemName: "chevron.down").font(.caption)
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 16)
+                .background(Color.blue.opacity(0.1))
+                .foregroundColor(.blue)
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("ledger.dateFilter.button")
+            Spacer()
+        }
+    }
+
+    private var shortcutsBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                Button(action: { showingAddShortcut = true }) {
+                    VStack(spacing: 4) {
+                        Image(systemName: "plus")
+                            .font(.headline)
+                            .frame(width: 44, height: 44)
+                            .background(Color.blue.opacity(0.1))
+                            .clipShape(Circle())
+                        Text("捷徑")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .buttonStyle(.plain)
+
+                ForEach(shortcuts) { shortcut in
+                    shortcutTile(shortcut)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var inlineSearchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("搜尋備註、分類、金額", text: $searchText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(Color(uiColor: .secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
     }
     
     @ViewBuilder
@@ -503,6 +568,23 @@ private struct TransactionsRenderState {
 
     private static func isAssetAdjustment(note: String) -> Bool {
         note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix(TransactionSemantics.assetAdjustmentMarker)
+    }
+}
+
+private struct LedgerSearchModifier: ViewModifier {
+    let isEnabled: Bool
+    @Binding var text: String
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.searchable(
+                text: $text,
+                placement: .navigationBarDrawer(displayMode: .automatic),
+                prompt: "搜尋備註、分類、金額"
+            )
+        } else {
+            content
+        }
     }
 }
 

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -14326,6 +14326,90 @@
           }
         }
       }
+    },
+    "固定總覽頁頂部區塊": {
+      "localizations": {
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定總覽頁頂部區塊"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定总览页顶部区块"
+          }
+        },
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Overview top section"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要ページ上部セクションを固定"
+          }
+        }
+      }
+    },
+    "固定帳目頁頂部區塊": {
+      "localizations": {
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定帳目頁頂部區塊"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定账目页顶部区块"
+          }
+        },
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Ledger top section"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録ページ上部セクションを固定"
+          }
+        }
+      }
+    },
+    "固定報表頁頂部區塊": {
+      "localizations": {
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定報表頁頂部區塊"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定报表页顶部区块"
+          }
+        },
+        "en-GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Reports top section"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レポートページ上部セクションを固定"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/MainActivity.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import org.duckdns.lhfser.aiaccounting.ui.AIAccountingRoot
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.theme.AIAccountingTheme
 import org.duckdns.lhfser.aiaccounting.widget.SummaryWidgetProvider
 import org.duckdns.lhfser.aiaccounting.widget.WidgetSummaryStore
@@ -34,7 +35,8 @@ class MainActivity : ComponentActivity() {
             AIAccountingTheme {
                 CompositionLocalProvider(
                     LocalRepository provides appContainer.repository,
-                    LocalCurrencyService provides appContainer.currencyService
+                    LocalCurrencyService provides appContainer.currencyService,
+                    LocalUiPreferences provides appContainer.uiPreferencesStore
                 ) {
                     AIAccountingRoot(
                         startOnOverview = isFirstLaunch,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/preferences/UiPreferencesStore.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/preferences/UiPreferencesStore.kt
@@ -1,0 +1,64 @@
+package org.duckdns.lhfser.aiaccounting.core.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class UiPreferences(
+    val pinOverviewControls: Boolean = true,
+    val pinLedgerControls: Boolean = true,
+    val pinReportsControls: Boolean = true
+)
+
+class UiPreferencesStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+    private val _state = MutableStateFlow(read())
+    val state: StateFlow<UiPreferences> = _state.asStateFlow()
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key != null && key in preferenceKeys) {
+            _state.value = read()
+        }
+    }
+
+    init {
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    fun setPinOverviewControls(value: Boolean) {
+        prefs.edit().putBoolean(KEY_PIN_OVERVIEW_CONTROLS, value).apply()
+        _state.value = read()
+    }
+
+    fun setPinLedgerControls(value: Boolean) {
+        prefs.edit().putBoolean(KEY_PIN_LEDGER_CONTROLS, value).apply()
+        _state.value = read()
+    }
+
+    fun setPinReportsControls(value: Boolean) {
+        prefs.edit().putBoolean(KEY_PIN_REPORTS_CONTROLS, value).apply()
+        _state.value = read()
+    }
+
+    private fun read(): UiPreferences {
+        return UiPreferences(
+            pinOverviewControls = prefs.getBoolean(KEY_PIN_OVERVIEW_CONTROLS, true),
+            pinLedgerControls = prefs.getBoolean(KEY_PIN_LEDGER_CONTROLS, true),
+            pinReportsControls = prefs.getBoolean(KEY_PIN_REPORTS_CONTROLS, true)
+        )
+    }
+
+    private companion object {
+        const val PREF_NAME = "ui_preferences"
+        const val KEY_PIN_OVERVIEW_CONTROLS = "pinOverviewControls"
+        const val KEY_PIN_LEDGER_CONTROLS = "pinLedgerControls"
+        const val KEY_PIN_REPORTS_CONTROLS = "pinReportsControls"
+        val preferenceKeys = setOf(
+            KEY_PIN_OVERVIEW_CONTROLS,
+            KEY_PIN_LEDGER_CONTROLS,
+            KEY_PIN_REPORTS_CONTROLS
+        )
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
@@ -3,6 +3,7 @@ package org.duckdns.lhfser.aiaccounting.data
 import android.content.Context
 import androidx.room.Room
 import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.preferences.UiPreferencesStore
 import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
 import org.duckdns.lhfser.aiaccounting.data.db.SeedData
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
@@ -26,5 +27,9 @@ class AppContainer(context: Context) {
 
     val currencyService: CurrencyService by lazy {
         CurrencyService(appContext)
+    }
+
+    val uiPreferencesStore: UiPreferencesStore by lazy {
+        UiPreferencesStore(appContext)
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AppProviders.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AppProviders.kt
@@ -2,6 +2,7 @@ package org.duckdns.lhfser.aiaccounting.ui
 
 import androidx.compose.runtime.staticCompositionLocalOf
 import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.preferences.UiPreferencesStore
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 
 val LocalRepository = staticCompositionLocalOf<AccountingRepository> {
@@ -10,4 +11,8 @@ val LocalRepository = staticCompositionLocalOf<AccountingRepository> {
 
 val LocalCurrencyService = staticCompositionLocalOf<CurrencyService> {
     error("CurrencyService not provided")
+}
+
+val LocalUiPreferences = staticCompositionLocalOf<UiPreferencesStore> {
+    error("UiPreferencesStore not provided")
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -45,6 +46,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
@@ -71,8 +73,11 @@ fun OverviewScreen(
 ) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
+    val uiPreferencesStore = LocalUiPreferences.current
     val context = LocalContext.current
     val scrollState = rememberScrollState()
+    val pinnedBodyScrollState = rememberScrollState()
+    val uiPreferences by uiPreferencesStore.state.collectAsState()
 
     val transactions by repository.transactions.collectAsState(initial = emptyList())
     val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
@@ -103,18 +108,8 @@ fun OverviewScreen(
         acc + currencyService.convert(outstandingAmount(advanceCase), advanceCase.advanceCase.currencyCode, baseCurrency)
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(scrollState)
-            .padding(
-                start = AppSpacing.screenHorizontal,
-                end = AppSpacing.screenHorizontal,
-                top = AppSpacing.screenVertical,
-                bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
-            ),
-        verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
-    ) {
+    @Composable
+    fun OverviewControls() {
         ParityTopSection(
             title = "總覽",
             subtitle = "今天是 ${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))} · ${filterDisplayString(filterType, selectedDate)}已記錄 $recordCount 筆收入/支出"
@@ -132,7 +127,10 @@ fun OverviewScreen(
                 onSelect = { filterType = it }
             )
         }
+    }
 
+    @Composable
+    fun OverviewBody() {
         PressableCard(
             modifier = Modifier.fillMaxWidth(),
             onClick = onQuickAdd,
@@ -214,6 +212,55 @@ fun OverviewScreen(
                 subtitle = "查看資產估算與各幣別餘額",
                 onClick = onOpenAccounts
             )
+        }
+    }
+
+    if (uiPreferences.pinOverviewControls) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = AppSpacing.screenHorizontal,
+                        end = AppSpacing.screenHorizontal,
+                        top = AppSpacing.screenVertical,
+                        bottom = AppSpacing.inline
+                    ),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+            ) {
+                OverviewControls()
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(pinnedBodyScrollState)
+                    .padding(
+                        start = AppSpacing.screenHorizontal,
+                        end = AppSpacing.screenHorizontal,
+                        top = AppSpacing.inline,
+                        bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+                    ),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+            ) {
+                OverviewBody()
+            }
+        }
+    } else {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(scrollState)
+                .padding(
+                    start = AppSpacing.screenHorizontal,
+                    end = AppSpacing.screenHorizontal,
+                    top = AppSpacing.screenVertical,
+                    bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
+                ),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
+        ) {
+            OverviewControls()
+            OverviewBody()
         }
     }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -62,6 +62,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
@@ -116,11 +117,13 @@ private data class BudgetAlert(
 fun ReportsScreen() {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
+    val uiPreferencesStore = LocalUiPreferences.current
     val context = LocalContext.current
 
     val transactions by repository.transactions.collectAsState(initial = emptyList())
     val categories by repository.categories.collectAsState(initial = emptyList())
     val budgets by repository.budgets.collectAsState(initial = emptyList())
+    val uiPreferences by uiPreferencesStore.state.collectAsState()
 
     var filterType by remember { mutableStateOf(ReportFilterType.Month) }
     var selectedDate by remember { mutableStateOf(LocalDate.now()) }
@@ -162,18 +165,19 @@ fun ReportsScreen() {
         buildBudgetAlerts(budgets, categories, filteredTransactions, currencyService)
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        ParityTopSection(
-            title = "報表",
-            modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
-            subtitle = "切換收支、分類與標籤，查看和 iOS 對齊的統計視圖。"
-        )
+    @Composable
+    fun ReportControls() {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
+            ParityTopSection(
+                title = "報表",
+                subtitle = "切換收支、分類與標籤，查看和 iOS 對齊的統計視圖。"
+            )
+
             ParityFilterCapsule(
                 label = filterLabel(filterType, selectedDate),
                 icon = Icons.Default.DateRange,
@@ -206,6 +210,12 @@ fun ReportsScreen() {
                 )
             }
         }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (uiPreferences.pinReportsControls) {
+            ReportControls()
+        }
 
         LazyColumn(
             modifier = Modifier.weight(1f),
@@ -217,6 +227,12 @@ fun ReportsScreen() {
             ),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.item)
         ) {
+            if (!uiPreferences.pinReportsControls) {
+                item(key = "report-controls") {
+                    ReportControls()
+                }
+            }
+
             if (chartMode == ReportChartMode.Tag && selectedTag != null) {
                 item {
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +41,7 @@ import kotlinx.coroutines.withContext
 import org.duckdns.lhfser.aiaccounting.core.ai.GeminiSettingsStore
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySettingRow
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
@@ -61,6 +63,7 @@ fun SettingsScreen(
 ) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
+    val uiPreferencesStore = LocalUiPreferences.current
     val context = LocalContext.current
     val geminiSettingsStore = remember(context) { GeminiSettingsStore(context) }
     val scope = rememberCoroutineScope()
@@ -71,6 +74,7 @@ fun SettingsScreen(
     var mainCurrency by remember { mutableStateOf(currencyService.mainCurrency) }
     var currencyMenuExpanded by remember { mutableStateOf(false) }
     var apiKey by remember { mutableStateOf(geminiSettingsStore.apiKey) }
+    val uiPreferences by uiPreferencesStore.state.collectAsState()
 
     val exportLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("application/json")
@@ -183,6 +187,36 @@ fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(18.dp),
                     visualTransformation = PasswordVisualTransformation()
+                )
+                ParitySettingRow(
+                    title = "固定總覽頁頂部區塊",
+                    subtitle = "固定標題與日期篩選；關閉後會跟內容一起捲動",
+                    trailing = {
+                        Switch(
+                            checked = uiPreferences.pinOverviewControls,
+                            onCheckedChange = uiPreferencesStore::setPinOverviewControls
+                        )
+                    }
+                )
+                ParitySettingRow(
+                    title = "固定帳目頁頂部區塊",
+                    subtitle = "固定日期、捷徑與搜尋；關閉後日期標題也不吸頂",
+                    trailing = {
+                        Switch(
+                            checked = uiPreferences.pinLedgerControls,
+                            onCheckedChange = uiPreferencesStore::setPinLedgerControls
+                        )
+                    }
+                )
+                ParitySettingRow(
+                    title = "固定報表頁頂部區塊",
+                    subtitle = "固定日期與統計模式切換",
+                    trailing = {
+                        Switch(
+                            checked = uiPreferences.pinReportsControls,
+                            onCheckedChange = uiPreferencesStore::setPinReportsControls
+                        )
+                    }
                 )
             }
         }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -59,6 +59,7 @@ import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySearchField
@@ -105,11 +106,13 @@ fun TransactionsScreen(
     onAddShortcut: () -> Unit
 ) {
     val repository = LocalRepository.current
+    val uiPreferencesStore = LocalUiPreferences.current
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val transactions by repository.transactions.collectAsState(initial = emptyList())
     val shortcuts by repository.shortcuts.collectAsState(initial = emptyList())
     val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
+    val uiPreferences by uiPreferencesStore.state.collectAsState()
 
     var pendingShortcut by remember { mutableStateOf<ShortcutWithDetails?>(null) }
     var showShortcutConfirm by remember { mutableStateOf(false) }
@@ -149,14 +152,15 @@ fun TransactionsScreen(
             .sortedByDescending { it.date }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        ParityTopSection(
-            title = "帳目明細",
-            modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
-            subtitle = "搜尋、篩選、編輯所有交易與代墊摘要。"
-        )
+    @Composable
+    fun LedgerControls(modifier: Modifier = Modifier) {
+        Column(modifier = modifier.fillMaxWidth()) {
+            ParityTopSection(
+                title = "帳目明細",
+                modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = 4.dp),
+                subtitle = "搜尋、篩選、編輯所有交易與代墊摘要。"
+            )
 
-        Column(modifier = Modifier.fillMaxWidth()) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -198,6 +202,12 @@ fun TransactionsScreen(
 
             HorizontalDivider()
         }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (uiPreferences.pinLedgerControls) {
+            LedgerControls()
+        }
 
         LazyColumn(
             modifier = Modifier.weight(1f),
@@ -209,6 +219,16 @@ fun TransactionsScreen(
             ),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.item)
         ) {
+            if (!uiPreferences.pinLedgerControls) {
+                item(key = "ledger-controls") {
+                    LedgerControls(
+                        modifier = Modifier
+                            .background(MaterialTheme.colorScheme.background)
+                            .padding(bottom = AppSpacing.inline)
+                    )
+                }
+            }
+
             if (ledgerItems.isEmpty()) {
                 item {
                     ParityEmptyState(
@@ -222,18 +242,13 @@ fun TransactionsScreen(
                 }
             } else {
                 dailySections.forEach { section ->
-                    stickyHeader {
-                        Surface(
-                            color = MaterialTheme.colorScheme.background,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text(
-                                text = formatHeaderDate(section.date),
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.SemiBold,
-                                modifier = Modifier.padding(vertical = 8.dp),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                    if (uiPreferences.pinLedgerControls) {
+                        stickyHeader {
+                            LedgerDateHeader(section.date)
+                        }
+                    } else {
+                        item(key = "section-${section.date}") {
+                            LedgerDateHeader(section.date)
                         }
                     }
                     items(section.items, key = { it.stableId }) { item ->
@@ -400,6 +415,22 @@ fun TransactionsScreen(
                 showDatePicker(context, customEndDate) { customEndDate = it }
             },
             onDismiss = { showFilterDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun LedgerDateHeader(date: LocalDate) {
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = formatHeaderDate(date),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(vertical = 8.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add local per-page pinned section preferences for Overview, Ledger, and Reports on iOS and Android
- Default all pinned controls to enabled, with Settings toggles/switches to opt out per page
- Keep the preference local only: no SwiftData/Room schema changes and no JSON backup schema changes
- Keep iOS string catalog complete for the new preference labels

## Validation
- xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest assembleDebug
- python3 -m json.tool Localizable.xcstrings
- Verified zh-Hant, zh-Hans, en-GB, and ja missing count remains 0
- Verified localisation placeholder consistency
