### PR TITLE
Reduce iOS transaction edit invalidations

### DIFF
--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -4,7 +4,7 @@ import SwiftData
 struct EditTransactionView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
-    @Bindable var transaction: FinancialTransaction
+    let transaction: FinancialTransaction
     @StateObject private var currencyService = CurrencyService.shared
     
     @Query(sort: \Account.sortOrder) private var accounts: [Account]
@@ -12,55 +12,66 @@ struct EditTransactionView: View {
     @Query(sort: \Tag.name) private var tags: [Tag]
     
     @State private var amountString: String = ""
+    @State private var selectedType: TransactionType = .expense
+    @State private var selectedAccount: Account?
+    @State private var selectedCategory: Category?
+    @State private var selectedDate = Date()
+    @State private var note = ""
     @State private var selectedTags: Set<Tag> = []
     @State private var originalBudgetKey: BudgetHistoryAffectedKey?
     @State private var errorMessage: String?
+    @State private var didLoadDraft = false
     
     // 🔥 新增：焦點控制
     @FocusState private var isAmountFocused: Bool
 
     private var selectableAccounts: [Account] {
-        let allowed = TransactionSemantics.allowedAccounts(for: transaction.type, from: accounts)
-        guard let current = transaction.account else { return allowed }
+        let allowed = TransactionSemantics.allowedAccounts(for: selectedType, from: accounts)
+        guard let current = selectedAccount else { return allowed }
         if allowed.contains(where: { $0.id == current.id }) {
             return allowed
         }
         return [current] + allowed
+    }
+
+    private var amountBinding: Binding<String> {
+        Binding(
+            get: { amountString },
+            set: { amountString = sanitizePositiveDecimalInput($0) }
+        )
     }
     
     var body: some View {
         NavigationStack {
             Form {
                 Section("金額與類型") {
-                    if transaction.type == .transfer {
+                    if selectedType == .transfer {
                         LabeledContent("類型") {
                             Text("轉帳")
                                 .foregroundStyle(.secondary)
                         }
                     } else {
-                        Picker("類型", selection: $transaction.type) {
+                        Picker("類型", selection: $selectedType) {
                             Text("支出").tag(TransactionType.expense)
                             Text("收入").tag(TransactionType.income)
                         }
                         .pickerStyle(.segmented)
-                        .onChange(of: transaction.type) { _, newType in
-                            updateAmountSign()
-                            if let category = transaction.category, !category.kind.supports(newType) {
-                                transaction.category = nil
+                        .onChange(of: selectedType) { _, newType in
+                            if let category = selectedCategory, !category.kind.supports(newType) {
+                                selectedCategory = nil
                             }
-                            if let currentAccount = transaction.account,
+                            if let currentAccount = selectedAccount,
                                !TransactionSemantics.allowedAccounts(for: newType, from: accounts).contains(where: { $0.id == currentAccount.id }) {
-                                transaction.account = TransactionSemantics.allowedAccounts(for: newType, from: accounts).first
+                                selectedAccount = TransactionSemantics.allowedAccounts(for: newType, from: accounts).first
                             }
                         }
                     }
 
                     HStack {
-                        Text(transaction.account?.currency ?? "$")
-                        TextField("金額", text: $amountString)
+                        Text(selectedAccount?.currency ?? transaction.currencyCode)
+                        TextField("金額", text: amountBinding)
                             .keyboardType(.decimalPad)
                             .focused($isAmountFocused) // 🔥 綁定焦點
-                            .onChange(of: amountString) { _, _ in updateTransactionAmount() }
                             .accessibilityIdentifier("transactionEditor.amountField")
                     }
                     CurrencyRateHintView(
@@ -71,15 +82,15 @@ struct EditTransactionView: View {
                 }
 
                 Section("詳細資訊") {
-                    Picker("帳戶", selection: $transaction.account) {
+                    Picker("帳戶", selection: $selectedAccount) {
                         Text("無").tag(nil as Account?)
                         ForEach(selectableAccounts) { acc in
                             Text(acc.name).tag(acc as Account?)
                         }
                     }
 
-                    if transaction.type != .transfer {
-                        Picker("分類", selection: $transaction.category) {
+                    if selectedType != .transfer {
+                        Picker("分類", selection: $selectedCategory) {
                             Text("無").tag(nil as Category?)
                             ForEach(filteredCategories) { cat in
                                 HStack {
@@ -90,13 +101,13 @@ struct EditTransactionView: View {
                         }
                     }
 
-                    DatePicker("日期", selection: $transaction.date)
+                    DatePicker("日期", selection: $selectedDate)
                         .accessibilityIdentifier("transactionEditor.datePicker")
-                    TextField("備註", text: $transaction.note)
+                    TextField("備註", text: $note)
                         .accessibilityIdentifier("transactionEditor.noteField")
                 }
 
-                if transaction.type != .transfer {
+                if selectedType != .transfer {
                     Section("標籤") {
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack {
@@ -111,7 +122,6 @@ struct EditTransactionView: View {
                                         .onTapGesture {
                                             if isSelected { selectedTags.remove(tag) }
                                             else { selectedTags.insert(tag) }
-                                            transaction.tags = Array(selectedTags)
                                         }
                                 }
                             }
@@ -137,9 +147,7 @@ struct EditTransactionView: View {
                 }
             }
             .onAppear {
-                amountString = String(format: "%.2f", abs(NSDecimalNumber(decimal: transaction.amount).doubleValue))
-                selectedTags = Set(transaction.tags)
-                originalBudgetKey = BudgetHistoryService.affectedKey(for: transaction)
+                loadDraftIfNeeded()
                 Task { await currencyService.fetchRates() }
             }
             .alert("儲存失敗", isPresented: Binding(
@@ -155,7 +163,19 @@ struct EditTransactionView: View {
 
     private func saveChanges() {
         do {
+            guard let amount = positiveDecimal(from: amountString) else {
+                errorMessage = "請輸入有效金額。"
+                return
+            }
+
             let previousKey = originalBudgetKey
+            transaction.type = selectedType
+            transaction.account = selectedAccount
+            transaction.category = selectedType == .transfer ? nil : selectedCategory
+            transaction.date = selectedDate
+            transaction.note = note
+            transaction.tags = selectedType == .transfer ? [] : Array(selectedTags)
+            transaction.amount = signedAmount(from: amount)
             transaction.updatedAt = Date()
             try modelContext.save()
             let currentKey = BudgetHistoryService.affectedKey(for: transaction)
@@ -169,26 +189,49 @@ struct EditTransactionView: View {
             errorMessage = error.localizedDescription
         }
     }
-    
-    private func updateAmountSign() {
-        guard let val = Decimal(string: amountString) else { return }
-        if transaction.type == .transfer {
-            transaction.amount = transaction.amount >= 0 ? abs(val) : -abs(val)
-            return
-        }
-        transaction.amount = (transaction.type == .expense) ? -abs(val) : abs(val)
+
+    private func loadDraftIfNeeded() {
+        guard !didLoadDraft else { return }
+        didLoadDraft = true
+        selectedType = transaction.type
+        selectedAccount = transaction.account
+        selectedCategory = transaction.category
+        selectedDate = transaction.date
+        note = transaction.note
+        amountString = NSDecimalNumber(decimal: abs(transaction.amount)).stringValue
+        selectedTags = Set(transaction.tags)
+        originalBudgetKey = BudgetHistoryService.affectedKey(for: transaction)
     }
-    
-    private func updateTransactionAmount() {
-        guard let val = Decimal(string: amountString) else { return }
-        if transaction.type == .transfer {
-            transaction.amount = transaction.amount >= 0 ? abs(val) : -abs(val)
-            return
+
+    private func signedAmount(from amount: Decimal) -> Decimal {
+        if selectedType == .transfer {
+            return transaction.amount >= 0 ? abs(amount) : -abs(amount)
         }
-        transaction.amount = (transaction.type == .expense) ? -abs(val) : abs(val)
+        return selectedType == .expense ? -abs(amount) : abs(amount)
     }
     
     private var filteredCategories: [Category] {
-        categories.filter { $0.kind.supports(transaction.type) }
+        categories.filter { $0.kind.supports(selectedType) }
+    }
+
+    private func positiveDecimal(from rawValue: String) -> Decimal? {
+        guard let value = Decimal(string: rawValue), value > 0 else { return nil }
+        return value
+    }
+
+    private func sanitizePositiveDecimalInput(_ rawValue: String) -> String {
+        var output = ""
+        var hasDecimalSeparator = false
+
+        for character in rawValue {
+            if character.isNumber {
+                output.append(character)
+            } else if character == "." && !hasDecimalSeparator {
+                hasDecimalSeparator = true
+                output.append(character)
+            }
+        }
+
+        return output
     }
 }


### PR DESCRIPTION
## Summary
- Change iOS normal transaction editing to use local draft state instead of mutating the SwiftData model on every field change
- Apply amount/type/account/category/date/note/tags only when the user taps Done
- Keep budget history sync on save while avoiding list/query invalidations during typing

## Test Plan
- xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO