### PR TITLE
Polish settlement center workflows

### DIFF
--- a/AI 記帳/Views/Settlements/SettlementCenterView.swift
+++ b/AI 記帳/Views/Settlements/SettlementCenterView.swift
@@ -11,12 +11,14 @@ private enum SettlementCenterMode: String, CaseIterable, Identifiable {
 
 private struct SettlementPersonSummary: Identifiable {
     let id: UUID
+    let account: Account
     let name: String
     let balances: [SettlementCurrencyBalance]
     let netBalanceInMainCurrency: Decimal
     let advanceCaseCount: Int
     let repaymentCount: Int
     let forgivenessCount: Int
+    let latestActivityDate: Date?
 }
 
 private struct SettlementCurrencyBalance: Identifiable {
@@ -28,12 +30,31 @@ private struct SettlementCurrencyBalance: Identifiable {
 
 private struct SettlementTimelineItem: Identifiable {
     let id: String
+    let relatedAccountID: UUID?
     let date: Date
     let title: String
     let subtitle: String
     let amount: Decimal?
     let currencyCode: String
     let tint: Color
+}
+
+private struct SettlementTimelineFilter: Identifiable {
+    let accountID: UUID
+    let name: String
+
+    var id: UUID { accountID }
+}
+
+private struct SettlementDebtRoute: Identifiable, Hashable {
+    let accountID: UUID
+    let mode: AddDebtView.DebtMode
+    let forgivenessDirection: DebtForgivenessDirection?
+    let note: String
+
+    var id: String {
+        "\(accountID.uuidString)-\(mode.rawValue)-\(forgivenessDirection?.rawValue ?? "none")-\(note)"
+    }
 }
 
 struct SettlementCenterView: View {
@@ -43,6 +64,9 @@ struct SettlementCenterView: View {
     @StateObject private var currencyService = CurrencyService.shared
     @AppStorage("mainCurrency") private var mainCurrency: String = "HKD"
     @State private var mode: SettlementCenterMode = .people
+    @State private var selectedPerson: SettlementPersonSummary?
+    @State private var timelineFilter: SettlementTimelineFilter?
+    @State private var debtRoute: SettlementDebtRoute?
 
     private var activeDebtAccounts: [Account] {
         accounts.filter { $0.type == .debt && !$0.isArchived }
@@ -67,12 +91,14 @@ struct SettlementCenterView: View {
 
             return SettlementPersonSummary(
                 id: account.id,
+                account: account,
                 name: account.name,
                 balances: balances,
                 netBalanceInMainCurrency: netInMainCurrency,
                 advanceCaseCount: caseCount,
                 repaymentCount: repayments.count,
-                forgivenessCount: forgiveness.count
+                forgivenessCount: forgiveness.count,
+                latestActivityDate: latestActivityDate(for: account)
             )
         }
         .filter { !$0.balances.isEmpty || $0.advanceCaseCount > 0 || $0.repaymentCount > 0 || $0.forgivenessCount > 0 }
@@ -98,6 +124,7 @@ struct SettlementCenterView: View {
         var items: [SettlementTimelineItem] = advanceCases.map { advanceCase in
             SettlementTimelineItem(
                 id: "case-\(advanceCase.id.uuidString)",
+                relatedAccountID: nil,
                 date: advanceCase.date,
                 title: "建立代墊：\(advanceCase.title)",
                 subtitle: "\(advanceCase.participants.count) 位對象，未清 \(AdvanceService.outstandingAmount(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode)))",
@@ -110,6 +137,7 @@ struct SettlementCenterView: View {
         items += advanceCases.flatMap(\.repayments).map { repayment in
             SettlementTimelineItem(
                 id: "repayment-\(repayment.id.uuidString)",
+                relatedAccountID: repayment.participant?.debtAccount?.id,
                 date: repayment.date,
                 title: "代墊還款：\(repayment.participant?.name ?? "未命名對象")",
                 subtitle: repayment.advanceCase?.title ?? "未連結代墊單",
@@ -141,8 +169,9 @@ struct SettlementCenterView: View {
 
             return SettlementTimelineItem(
                 id: "debt-\(transaction.id.uuidString)",
+                relatedAccountID: transaction.account?.id,
                 date: transaction.date,
-                title: title,
+                title: debtTimelineTitle(for: transaction, fallback: title),
                 subtitle: transaction.account?.name ?? "借貸帳戶",
                 amount: transaction.amount,
                 currencyCode: transaction.currencyCode,
@@ -151,6 +180,11 @@ struct SettlementCenterView: View {
         }
 
         return items.sorted { $0.date > $1.date }
+    }
+
+    private var displayedTimelineItems: [SettlementTimelineItem] {
+        guard let timelineFilter else { return timelineItems }
+        return timelineItems.filter { $0.relatedAccountID == timelineFilter.accountID }
     }
 
     private var totalNetInMainCurrency: Decimal {
@@ -228,6 +262,78 @@ struct SettlementCenterView: View {
         .task {
             await currencyService.fetchRates()
         }
+        .confirmationDialog("結算動作", isPresented: Binding(
+            get: { selectedPerson != nil },
+            set: { if !$0 { selectedPerson = nil } }
+        ), titleVisibility: .visible) {
+            if let summary = selectedPerson, summary.netBalanceInMainCurrency > 0 {
+                Button("記錄對方還款") {
+                    selectedPerson = nil
+                    debtRoute = SettlementDebtRoute(
+                        accountID: summary.id,
+                        mode: .borrow,
+                        forgivenessDirection: nil,
+                        note: "對方還款"
+                    )
+                }
+                Button("免除對方欠款", role: .destructive) {
+                    selectedPerson = nil
+                    debtRoute = SettlementDebtRoute(
+                        accountID: summary.id,
+                        mode: .forgive,
+                        forgivenessDirection: .forgiveOthers,
+                        note: "免除對方欠款"
+                    )
+                }
+            } else if let summary = selectedPerson, summary.netBalanceInMainCurrency < 0 {
+                Button("記錄你還款") {
+                    selectedPerson = nil
+                    debtRoute = SettlementDebtRoute(
+                        accountID: summary.id,
+                        mode: .repay,
+                        forgivenessDirection: nil,
+                        note: "你還款"
+                    )
+                }
+                Button("記錄對方免除", role: .destructive) {
+                    selectedPerson = nil
+                    debtRoute = SettlementDebtRoute(
+                        accountID: summary.id,
+                        mode: .forgive,
+                        forgivenessDirection: .forgivenByOthers,
+                        note: "對方免除"
+                    )
+                }
+            }
+            Button("查看相關時間線") {
+                if let summary = selectedPerson {
+                    timelineFilter = SettlementTimelineFilter(accountID: summary.id, name: summary.name)
+                    mode = .timeline
+                    selectedPerson = nil
+                }
+            }
+            Button("取消", role: .cancel) {}
+        } message: {
+            if let summary = selectedPerson {
+                Text("\(summary.name)：\(directionText(for: summary.netBalanceInMainCurrency))")
+            }
+        }
+        .navigationDestination(isPresented: Binding(
+            get: { debtRoute != nil },
+            set: { if !$0 { debtRoute = nil } }
+        )) {
+            if let route = debtRoute,
+               let account = accounts.first(where: { $0.id == route.accountID }) {
+                AddDebtView(
+                    presetDebtAccount: account,
+                    presetMode: route.mode,
+                    presetForgivenessDirection: route.forgivenessDirection,
+                    presetNote: route.note
+                )
+            } else {
+                ContentUnavailableView("找不到對象", systemImage: "person.crop.circle.badge.exclamationmark")
+            }
+        }
     }
 
     @ViewBuilder
@@ -243,6 +349,9 @@ struct SettlementCenterView: View {
         } else {
             Section("按對象") {
                 ForEach(personSummaries) { summary in
+                    Button {
+                        selectedPerson = summary
+                    } label: {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
                             VStack(alignment: .leading, spacing: 3) {
@@ -271,12 +380,20 @@ struct SettlementCenterView: View {
                             settlementPill("免除 \(summary.forgivenessCount)")
                         }
 
+                        if let latest = summary.latestActivityDate {
+                            Text("最近：\(latest.formatted(date: .abbreviated, time: .shortened))")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+
                         ForEach(summary.balances.dropFirst()) { balance in
                             Text("\(balance.currencyCode): \(balance.amount.formatted(.currency(code: balance.currencyCode)))")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
                     }
+                    }
+                    .buttonStyle(.plain)
                     .padding(.vertical, 4)
                 }
             }
@@ -309,6 +426,14 @@ struct SettlementCenterView: View {
                             Text("\(advanceCase.participants.count) 位對象，總額 \(AdvanceService.totalAdvanced(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode)))")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                            Text(caseProgressText(for: advanceCase))
+                                .font(.caption)
+                                .foregroundStyle(AdvanceService.outstandingAmount(for: advanceCase) > 0 ? .orange : .secondary)
+                            if let top = topOutstandingParticipant(for: advanceCase) {
+                                Text("主要未清：\(top.name) \(max(top.owedAmount - top.repaidAmount, 0).formatted(.currency(code: advanceCase.currencyCode)))")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
                             Text(advanceCase.date.formatted(date: .abbreviated, time: .omitted))
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
@@ -321,7 +446,7 @@ struct SettlementCenterView: View {
 
     @ViewBuilder
     private var timelineSection: some View {
-        if timelineItems.isEmpty {
+        if displayedTimelineItems.isEmpty {
             Section {
                 ContentUnavailableView(
                     "沒有結算時間線",
@@ -330,8 +455,14 @@ struct SettlementCenterView: View {
                 )
             }
         } else {
-            Section("時間線") {
-                ForEach(timelineItems) { item in
+            Section(timelineFilter.map { "\($0.name) 的時間線" } ?? "時間線") {
+                if timelineFilter != nil {
+                    Button("顯示全部時間線") {
+                        timelineFilter = nil
+                    }
+                    .font(.caption)
+                }
+                ForEach(displayedTimelineItems) { item in
                     HStack(alignment: .top, spacing: 12) {
                         Circle()
                             .fill(item.tint)
@@ -378,6 +509,46 @@ struct SettlementCenterView: View {
             .filter { $0.value != 0 }
             .sorted { $0.key < $1.key }
             .map { SettlementCurrencyBalance(currencyCode: $0.key, amount: $0.value) }
+    }
+
+    private func latestActivityDate(for account: Account) -> Date? {
+        let transactionDates = transactions
+            .filter { $0.account?.id == account.id }
+            .map(\.date)
+        let repaymentDates = advanceCases
+            .flatMap(\.repayments)
+            .filter { $0.participant?.debtAccount?.id == account.id }
+            .map(\.date)
+        let caseDates = advanceCases
+            .filter { advanceCase in advanceCase.participants.contains { $0.debtAccount?.id == account.id } }
+            .map(\.date)
+        return (transactionDates + repaymentDates + caseDates).max()
+    }
+
+    private func caseProgressText(for advanceCase: AdvanceCase) -> String {
+        let total = AdvanceService.totalAdvanced(for: advanceCase)
+        let outstanding = AdvanceService.outstandingAmount(for: advanceCase)
+        guard total > 0 else { return "未清比例 0%" }
+        let percent = NSDecimalNumber(decimal: outstanding / total * 100).doubleValue
+        return String(format: "未清比例 %.0f%%", percent)
+    }
+
+    private func topOutstandingParticipant(for advanceCase: AdvanceCase) -> AdvanceParticipant? {
+        advanceCase.participants.max {
+            max($0.owedAmount - $0.repaidAmount, 0) < max($1.owedAmount - $1.repaidAmount, 0)
+        }
+    }
+
+    private func debtTimelineTitle(for transaction: FinancialTransaction, fallback: String) -> String {
+        let note = transaction.note
+        if TransactionSemantics.isDebtForgiveness(note: note) {
+            return fallback
+        }
+        if note.contains("對方還款") { return "對方還款" }
+        if note.contains("你還款") || note.contains("還款給") { return "你還款" }
+        if note.contains("借入至") { return "你借入" }
+        if note.contains("借出") { return "你借出" }
+        return transaction.amount < 0 ? "你借入 / 對方還款" : "你還款 / 你借出"
     }
 
     private func settlementPill(_ text: String) -> some View {

--- a/AI 記帳/Views/Transactions/AddDebtView.swift
+++ b/AI 記帳/Views/Transactions/AddDebtView.swift
@@ -8,6 +8,10 @@ struct AddDebtView: View {
 
     @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
     private let existingForgivenessTransactionID: UUID?
+    private let presetDebtAccountID: UUID?
+    private let presetMode: DebtMode?
+    private let presetForgivenessDirection: DebtForgivenessDirection?
+    private let presetNote: String?
 
     private var debtAccounts: [Account] {
         allAccounts.filter { $0.type == .debt && !$0.isArchived }.sorted { $0.name < $1.name }
@@ -18,8 +22,8 @@ struct AddDebtView: View {
     }
 
     enum DebtMode: String, CaseIterable {
-        case borrow = "借入 (我欠人)"
-        case repay = "還款 (還給人)"
+        case borrow = "借入 / 收款"
+        case repay = "借出 / 還款"
         case forgive = "免除債務"
     }
 
@@ -72,8 +76,18 @@ struct AddDebtView: View {
 
     @FocusState private var isAmountFocused: Bool
 
-    init(existingForgivenessTransaction: FinancialTransaction? = nil) {
+    init(
+        existingForgivenessTransaction: FinancialTransaction? = nil,
+        presetDebtAccount: Account? = nil,
+        presetMode: DebtMode? = nil,
+        presetForgivenessDirection: DebtForgivenessDirection? = nil,
+        presetNote: String? = nil
+    ) {
         self.existingForgivenessTransactionID = existingForgivenessTransaction?.id
+        self.presetDebtAccountID = presetDebtAccount?.id
+        self.presetMode = presetMode
+        self.presetForgivenessDirection = presetForgivenessDirection
+        self.presetNote = presetNote
     }
 
     var body: some View {
@@ -82,7 +96,7 @@ struct AddDebtView: View {
                 Section {
                     Picker("操作", selection: $mode) {
                         ForEach(DebtMode.allCases, id: \.self) { option in
-                            Text(option.rawValue).tag(option)
+                            Text(debtModeTitle(option)).tag(option)
                         }
                     }
                     .pickerStyle(.segmented)
@@ -124,7 +138,7 @@ struct AddDebtView: View {
                     }
 
                     if mode != .forgive && entryMode != .split {
-                        Picker(mode == .borrow ? "存入帳戶" : "付款帳戶", selection: $selectedMyAccount) {
+                        Picker(mode == .borrow ? "入帳帳戶" : "付款帳戶", selection: $selectedMyAccount) {
                             Text("請選擇帳戶").tag(nil as Account?)
                             ForEach(myAccounts) { acc in
                                 Text(acc.name).tag(acc as Account?)
@@ -195,6 +209,7 @@ struct AddDebtView: View {
                 if selectedDebtAccount == nil {
                     selectedDebtAccount = debtAccounts.first
                 }
+                applyPresetIfNeeded()
                 if let acc = selectedMyAccount {
                     selectedCurrency = acc.currency
                 }
@@ -350,10 +365,10 @@ struct AddDebtView: View {
 
                 if mode == .borrow {
                     Text("對象：\(debtAcc.name)")
-                    Text("動作：借入（我方資產增加）")
+                    Text("動作：\(debtModeTitle(.borrow))")
                 } else if mode == .repay {
                     Text("對象：\(debtAcc.name)")
-                    Text("動作：還款（我方資產減少）")
+                    Text("動作：\(debtModeTitle(.repay))")
                 } else {
                     Text("對象：\(debtAcc.name)")
                     Text("動作：\(forgivenessDirection.displayTitle)")
@@ -486,7 +501,7 @@ struct AddDebtView: View {
         let txID1 = UUID()
         let txID2 = UUID()
         let transferGroupID = UUID()
-        let finalMemo = memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? mode.rawValue : memo
+        let finalMemo = memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? debtModeTitle(mode) : memo
 
         if mode == .borrow {
             let debtTx = FinancialTransaction(
@@ -638,9 +653,9 @@ struct AddDebtView: View {
     private var debtAccountLabel: String {
         switch mode {
         case .borrow:
-            return "跟誰借"
+            return selectedDebtBalance > 0 ? "誰還你" : "跟誰借"
         case .repay:
-            return "還給誰"
+            return selectedDebtBalance > 0 ? "借給誰" : "還給誰"
         case .forgive:
             switch forgivenessDirection {
             case .forgivenByOthers:
@@ -663,5 +678,41 @@ struct AddDebtView: View {
             return cleaned[..<range.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return cleaned
+    }
+
+    private var selectedDebtBalance: Decimal {
+        guard let selectedDebtAccount else { return 0 }
+        return selectedDebtAccount.baseBalance + selectedDebtAccount.transactions.reduce(Decimal.zero) { $0 + $1.amount }
+    }
+
+    private func debtModeTitle(_ debtMode: DebtMode) -> String {
+        switch debtMode {
+        case .borrow:
+            return selectedDebtBalance > 0 ? "收款（對方還你）" : "借入（你向對方借）"
+        case .repay:
+            return selectedDebtBalance > 0 ? "借出（對方欠你更多）" : "還款（你還給對方）"
+        case .forgive:
+            return "免除債務"
+        }
+    }
+
+    private func applyPresetIfNeeded() {
+        if let presetMode {
+            mode = presetMode
+        }
+        if let presetForgivenessDirection {
+            forgivenessDirection = presetForgivenessDirection
+        }
+        if let presetDebtAccountID,
+           selectedDebtAccount?.id != presetDebtAccountID,
+           let presetAccount = debtAccounts.first(where: { $0.id == presetDebtAccountID }) {
+            selectedDebtAccount = presetAccount
+            if mode == .forgive {
+                selectedCurrency = presetAccount.currency
+            }
+        }
+        if note.isEmpty, let presetNote {
+            note = presetNote
+        }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -1,5 +1,6 @@
 package org.duckdns.lhfser.aiaccounting.ui
 
+import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -98,7 +99,10 @@ private sealed class AppDestination(
     data object AdvanceAdd : AppDestination("advance/add", "新增代墊")
     data object AdvanceDetail : AppDestination("advance/{caseId}", "代墊明細")
     data object ReceiptScan : AppDestination("receipt/scan", "掃描單據")
-    data object DebtAdd : AppDestination("debt/add", "借貸管理")
+    data object DebtAdd : AppDestination(
+        "debt/add?debtAccountId={debtAccountId}&mode={mode}&forgivenessDirection={forgivenessDirection}&note={note}",
+        "借貸管理"
+    )
     data object AccountDetail : AppDestination("accounts/{accountId}", "帳戶明細")
     data object Guide : AppDestination("guide", "使用教學")
 
@@ -313,8 +317,22 @@ fun AIAccountingRoot(
             composable(AppDestination.ReceiptScan.route) {
                 ReceiptScanScreen(onDone = { navController.popBackStack() })
             }
-            composable(AppDestination.DebtAdd.route) {
-                DebtEntryScreen(onDone = { navController.popBackStack() })
+            composable(
+                AppDestination.DebtAdd.route,
+                arguments = listOf(
+                    navArgument("debtAccountId") { type = NavType.StringType; nullable = true; defaultValue = null },
+                    navArgument("mode") { type = NavType.StringType; nullable = true; defaultValue = null },
+                    navArgument("forgivenessDirection") { type = NavType.StringType; nullable = true; defaultValue = null },
+                    navArgument("note") { type = NavType.StringType; nullable = true; defaultValue = null }
+                )
+            ) { entry ->
+                DebtEntryScreen(
+                    presetDebtAccountId = entry.arguments?.getString("debtAccountId"),
+                    presetMode = entry.arguments?.getString("mode"),
+                    presetForgivenessDirection = entry.arguments?.getString("forgivenessDirection"),
+                    presetNote = entry.arguments?.getString("note"),
+                    onDone = { navController.popBackStack() }
+                )
             }
             composable(
                 "debt/edit/{transactionId}",
@@ -331,7 +349,14 @@ fun AIAccountingRoot(
             composable(AppDestination.Settlements.route) {
                 SettlementCenterScreen(
                     onOpenAdvanceCase = { caseId -> navController.navigate("advance/$caseId") },
-                    onOpenDebt = { navController.navigate(AppDestination.DebtAdd.route) }
+                    onOpenDebt = { navController.navigate("debt/add") },
+                    onOpenDebtAction = { accountId, mode, forgivenessDirection, note ->
+                        val encodedNote = Uri.encode(note)
+                        val direction = forgivenessDirection.orEmpty()
+                        navController.navigate(
+                            "debt/add?debtAccountId=$accountId&mode=$mode&forgivenessDirection=$direction&note=$encodedNote"
+                        )
+                    }
                 )
             }
             composable(
@@ -503,7 +528,7 @@ private fun AddActionSheet(
                 title = "債務管理",
                 subtitle = "借入、還款或免除債務",
                 icon = Icons.Default.AccountBalanceWallet
-            ) { onAction(AppDestination.DebtAdd.route) }
+            ) { onAction("debt/add") }
             ParityActionSheetRow(
                 title = "新增代墊單（多人分帳）",
                 subtitle = "建立多人代墊並追蹤後續還款",
@@ -522,7 +547,7 @@ private fun resolveTitle(backStackEntry: NavBackStackEntry?): String {
         route == AppDestination.IncomeAdd.route -> "新增收入"
         route == AppDestination.TransferAdd.route -> "轉帳"
         route == AppDestination.ReceiptScan.route -> "掃描單據"
-        route == AppDestination.DebtAdd.route -> "借貸管理"
+        route.startsWith("debt/add") -> "借貸管理"
         route.startsWith("debt/edit") -> "編輯免除債務"
         route == AppDestination.AdvanceAdd.route -> "新增代墊"
         route.startsWith("advance/") -> "代墊明細"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
@@ -55,10 +55,10 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.util.UUID
 
-private enum class DebtMode(val label: String) {
-    Borrow("借入 (我欠人)"),
-    Repay("還款 (還給人)"),
-    Forgive("免除債務")
+private enum class DebtMode(val routeValue: String, val fallbackLabel: String) {
+    Borrow("borrow", "借入 / 收款"),
+    Repay("repay", "借出 / 還款"),
+    Forgive("forgive", "免除債務")
 }
 
 private enum class DebtEntryMode(val label: String) {
@@ -83,6 +83,10 @@ private data class DebtMergeLeg(
 @Composable
 fun DebtEntryScreen(
     transactionId: String? = null,
+    presetDebtAccountId: String? = null,
+    presetMode: String? = null,
+    presetForgivenessDirection: String? = null,
+    presetNote: String? = null,
     onDone: () -> Unit
 ) {
     val repository = LocalRepository.current
@@ -92,6 +96,7 @@ fun DebtEntryScreen(
     val scrollState = rememberScrollState()
 
     val accounts by repository.accounts.collectAsState(initial = emptyList())
+    val transactions by repository.transactions.collectAsState(initial = emptyList())
     val debtAccounts = remember(accounts) { TransactionSemantics.debtAccounts(accounts).sortedBy { it.name } }
     val myAccounts = remember(accounts) { TransactionSemantics.ownAccounts(accounts).sortedBy { it.sortOrder } }
 
@@ -107,6 +112,14 @@ fun DebtEntryScreen(
     var splitLegs by remember { mutableStateOf(listOf(DebtSplitLeg())) }
     var mergeLegs by remember { mutableStateOf(listOf(DebtMergeLeg())) }
     var validationMessage by remember { mutableStateOf<String?>(null) }
+    var didApplyPreset by remember { mutableStateOf(false) }
+
+    val selectedDebtBalance = remember(selectedDebtAccount, transactions) {
+        val account = selectedDebtAccount ?: return@remember BigDecimal.ZERO
+        account.baseBalance + transactions
+            .filter { it.transaction.accountId == account.id }
+            .fold(BigDecimal.ZERO) { acc, item -> acc + item.transaction.amount }
+    }
 
     LaunchedEffect(currencyService.mainCurrency) {
         currencyService.fetchRates()
@@ -124,6 +137,20 @@ fun DebtEntryScreen(
         } else {
             selectedCurrency = selectedMyAccount?.currency ?: selectedCurrency
         }
+    }
+
+    LaunchedEffect(debtAccounts, presetDebtAccountId, presetMode, presetForgivenessDirection, presetNote) {
+        if (didApplyPreset) return@LaunchedEffect
+        val presetAccountId = presetDebtAccountId?.let(UUID::fromString)
+        if (presetAccountId != null) {
+            selectedDebtAccount = debtAccounts.firstOrNull { it.id == presetAccountId } ?: selectedDebtAccount
+        }
+        mode = debtModeFromRoute(presetMode) ?: mode
+        forgivenessDirection = forgivenessDirectionFromRoute(presetForgivenessDirection) ?: forgivenessDirection
+        if (note.isBlank() && !presetNote.isNullOrBlank()) {
+            note = presetNote
+        }
+        didApplyPreset = true
     }
 
     LaunchedEffect(mode, selectedDebtAccount, selectedMyAccount) {
@@ -176,7 +203,7 @@ fun DebtEntryScreen(
             ParitySegmentedControl(
                 options = DebtMode.values().toList(),
                 selected = mode,
-                label = { it.label },
+                label = { debtModeTitle(it, selectedDebtBalance) },
                 onSelect = { mode = it }
             )
             if (mode == DebtMode.Forgive) {
@@ -214,8 +241,8 @@ fun DebtEntryScreen(
                 )
                 AccountMenuPicker(
                     label = when (mode) {
-                        DebtMode.Borrow -> "跟誰借"
-                        DebtMode.Repay -> "還給誰"
+                        DebtMode.Borrow -> if (selectedDebtBalance.signum() > 0) "誰還你" else "跟誰借"
+                        DebtMode.Repay -> if (selectedDebtBalance.signum() > 0) "借給誰" else "還給誰"
                         DebtMode.Forgive -> "借貸對象"
                     },
                     options = debtAccounts,
@@ -335,8 +362,8 @@ fun DebtEntryScreen(
             title = "交易預覽",
             value = totalAmountPreview(mode, entryMode, amountInput, splitLegs, mergeLegs),
             supporting = when (mode) {
-                DebtMode.Borrow -> "借入會讓借貸帳戶出帳、你的帳戶入帳"
-                DebtMode.Repay -> "還款會讓你的帳戶出帳、借貸帳戶入帳"
+                DebtMode.Borrow -> if (selectedDebtBalance.signum() > 0) "收款會讓你的帳戶入帳、對方欠款減少" else "借入會讓你的帳戶入帳、你欠對方增加"
+                DebtMode.Repay -> if (selectedDebtBalance.signum() > 0) "借出會讓你的帳戶出帳、對方欠你增加" else "還款會讓你的帳戶出帳、你欠對方減少"
                 DebtMode.Forgive -> forgivenessDirection.label
             }
         )
@@ -379,7 +406,7 @@ fun DebtEntryScreen(
                         repository.upsertTransaction(transaction, emptyList())
                         onDone()
                     } else {
-                        val transactions = buildDebtTransactions(
+                        val debtTransactions = buildDebtTransactions(
                             mode = mode,
                             entryMode = entryMode,
                             debtAccount = debtAccount,
@@ -391,11 +418,11 @@ fun DebtEntryScreen(
                             splitLegs = splitLegs,
                             mergeLegs = mergeLegs
                         )
-                        if (transactions == null) {
+                        if (debtTransactions == null) {
                             validationMessage = "請輸入完整金額並選擇需要的帳戶。"
                             return@launch
                         }
-                        repository.upsertTransactions(transactions)
+                        repository.upsertTransactions(debtTransactions)
                         onDone()
                     }
                 }
@@ -573,7 +600,7 @@ private fun createDebtPair(
     date: Instant,
     memo: String
 ): List<TransactionEntity> {
-    val finalMemo = memo.trim().ifBlank { mode.label }
+    val finalMemo = memo.trim().ifBlank { mode.fallbackLabel }
     val groupId = UUID.randomUUID()
     val firstId = UUID.randomUUID()
     val secondId = UUID.randomUUID()
@@ -664,6 +691,22 @@ private fun totalAmountPreview(
         else -> mergeLegs.mapNotNull { it.amount.toBigDecimalOrNull() }.takeIf { it.size == mergeLegs.size }?.fold(BigDecimal.ZERO, BigDecimal::add)
     }
     return total?.toPlainString() ?: "尚未完成輸入"
+}
+
+private fun debtModeTitle(mode: DebtMode, selectedDebtBalance: BigDecimal): String {
+    return when (mode) {
+        DebtMode.Borrow -> if (selectedDebtBalance.signum() > 0) "收款（對方還你）" else "借入（你向對方借）"
+        DebtMode.Repay -> if (selectedDebtBalance.signum() > 0) "借出（對方欠你更多）" else "還款（你還給對方）"
+        DebtMode.Forgive -> "免除債務"
+    }
+}
+
+private fun debtModeFromRoute(value: String?): DebtMode? {
+    return DebtMode.values().firstOrNull { it.routeValue == value }
+}
+
+private fun forgivenessDirectionFromRoute(value: String?): DebtForgivenessDirection? {
+    return DebtForgivenessDirection.values().firstOrNull { it.name == value }
 }
 
 private fun sanitizeAmount(input: String): String {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Groups
@@ -62,7 +63,8 @@ private data class SettlementPersonSummary(
     val netInMainCurrency: BigDecimal,
     val advanceCaseCount: Int,
     val repaymentCount: Int,
-    val forgivenessCount: Int
+    val forgivenessCount: Int,
+    val latestActivityDate: Instant?
 )
 
 private data class SettlementCurrencyBalance(
@@ -72,6 +74,7 @@ private data class SettlementCurrencyBalance(
 
 private data class TimelineItem(
     val id: String,
+    val relatedAccountId: UUID?,
     val date: Instant,
     val title: String,
     val subtitle: String,
@@ -83,7 +86,8 @@ private data class TimelineItem(
 @Composable
 fun SettlementCenterScreen(
     onOpenAdvanceCase: (String) -> Unit,
-    onOpenDebt: () -> Unit
+    onOpenDebt: () -> Unit,
+    onOpenDebtAction: (accountId: String, mode: String, forgivenessDirection: String?, note: String) -> Unit
 ) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
@@ -95,6 +99,8 @@ fun SettlementCenterScreen(
     val mainCurrency = currencyService.mainCurrency
     val rateSnapshot = currencyService.rates
     var mode by rememberSaveable { mutableStateOf(SettlementMode.People) }
+    var selectedPerson by remember { mutableStateOf<SettlementPersonSummary?>(null) }
+    var timelineFilter by remember { mutableStateOf<SettlementPersonSummary?>(null) }
 
     val personSummaries = remember(accounts, transactions, advanceCases, mainCurrency, rateSnapshot) {
         buildPersonSummaries(accounts, transactions, advanceCases, currencyService, mainCurrency)
@@ -110,6 +116,9 @@ fun SettlementCenterScreen(
     }
     val timelineItems = remember(transactions, advanceCases) {
         buildTimelineItems(transactions, advanceCases)
+    }
+    val displayedTimelineItems = remember(timelineItems, timelineFilter) {
+        timelineFilter?.let { filter -> timelineItems.filter { it.relatedAccountId == filter.account.id } } ?: timelineItems
     }
     val shareText = remember(personSummaries, totalNet, mainCurrency) {
         buildShareText(personSummaries, totalNet, mainCurrency)
@@ -172,7 +181,11 @@ fun SettlementCenterScreen(
                     }
                 } else {
                     items(personSummaries, key = { it.account.id }) { summary ->
-                        PersonSummaryCard(summary = summary, mainCurrency = mainCurrency)
+                        PersonSummaryCard(
+                            summary = summary,
+                            mainCurrency = mainCurrency,
+                            onClick = { selectedPerson = summary }
+                        )
                     }
                 }
             }
@@ -195,7 +208,7 @@ fun SettlementCenterScreen(
                 }
             }
             SettlementMode.Timeline -> {
-                if (timelineItems.isEmpty()) {
+                if (displayedTimelineItems.isEmpty()) {
                     item {
                         ParityEmptyState(
                             title = "沒有結算時間線",
@@ -204,7 +217,14 @@ fun SettlementCenterScreen(
                         )
                     }
                 } else {
-                    items(timelineItems, key = { it.id }) { item ->
+                    if (timelineFilter != null) {
+                        item {
+                            TextButton(onClick = { timelineFilter = null }) {
+                                Text("顯示全部時間線")
+                            }
+                        }
+                    }
+                    items(displayedTimelineItems, key = { it.id }) { item ->
                         TimelineCard(item = item)
                     }
                 }
@@ -226,12 +246,51 @@ fun SettlementCenterScreen(
             }
         }
     }
+
+    selectedPerson?.let { summary ->
+        AlertDialog(
+            onDismissRequest = { selectedPerson = null },
+            title = { Text(summary.account.name) },
+            text = { Text("${directionText(summary.netInMainCurrency)} · ${summary.netInMainCurrency.asCurrencyText(mainCurrency)}") },
+            confirmButton = {
+                Column {
+                    if (summary.netInMainCurrency.signum() > 0) {
+                        TextButton(onClick = {
+                            selectedPerson = null
+                            onOpenDebtAction(summary.account.id.toString(), "borrow", null, "對方還款")
+                        }) { Text("記錄對方還款") }
+                        TextButton(onClick = {
+                            selectedPerson = null
+                            onOpenDebtAction(summary.account.id.toString(), "forgive", "ForgiveOthers", "免除對方欠款")
+                        }) { Text("免除對方欠款") }
+                    } else if (summary.netInMainCurrency.signum() < 0) {
+                        TextButton(onClick = {
+                            selectedPerson = null
+                            onOpenDebtAction(summary.account.id.toString(), "repay", null, "你還款")
+                        }) { Text("記錄你還款") }
+                        TextButton(onClick = {
+                            selectedPerson = null
+                            onOpenDebtAction(summary.account.id.toString(), "forgive", "ForgivenByOthers", "對方免除")
+                        }) { Text("記錄對方免除") }
+                    }
+                    TextButton(onClick = {
+                        timelineFilter = summary
+                        mode = SettlementMode.Timeline
+                        selectedPerson = null
+                    }) { Text("查看相關時間線") }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { selectedPerson = null }) { Text("取消") }
+            }
+        )
+    }
 }
 
 @Composable
-private fun PersonSummaryCard(summary: SettlementPersonSummary, mainCurrency: String) {
+private fun PersonSummaryCard(summary: SettlementPersonSummary, mainCurrency: String, onClick: () -> Unit) {
     val primaryBalance = summary.balances.firstOrNull()
-    PressableCard(modifier = Modifier.fillMaxWidth(), onClick = {}) {
+    PressableCard(modifier = Modifier.fillMaxWidth(), onClick = onClick) {
         Column(
             modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 15.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
@@ -269,6 +328,13 @@ private fun PersonSummaryCard(summary: SettlementPersonSummary, mainCurrency: St
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+            if (summary.latestActivityDate != null) {
+                Text(
+                    "最近：${summary.latestActivityDate.toDateText()}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }
@@ -293,6 +359,10 @@ private fun CaseSummaryCard(advanceCase: AdvanceCaseWithDetails, onClick: () -> 
                 }
             }
             Text("總額 ${total.asCurrencyText(advanceCase.advanceCase.currencyCode)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(caseProgressText(advanceCase), style = MaterialTheme.typography.bodySmall, color = amountColor(outstanding))
+            topOutstandingParticipantText(advanceCase)?.let {
+                Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
         }
     }
 }
@@ -354,13 +424,15 @@ private fun buildPersonSummaries(
         }
         val caseCount = participantsByAccount[account.id].orEmpty().map { it.first.advanceCase.id }.toSet().size
         val repaymentCount = repaymentsByAccount[account.id].orEmpty().size
+        val latestActivityDate = latestActivityDate(account, transactions, advanceCases)
         SettlementPersonSummary(
             account = account,
             balances = balances,
             netInMainCurrency = netInMain,
             advanceCaseCount = caseCount,
             repaymentCount = repaymentCount,
-            forgivenessCount = forgivenessByAccount[account.id] ?: 0
+            forgivenessCount = forgivenessByAccount[account.id] ?: 0,
+            latestActivityDate = latestActivityDate
         )
     }
         .filter { it.netInMainCurrency != BigDecimal.ZERO || it.advanceCaseCount > 0 || it.repaymentCount > 0 || it.forgivenessCount > 0 }
@@ -403,6 +475,7 @@ private fun buildTimelineItems(
     advanceCases.forEach { advanceCase ->
         items += TimelineItem(
             id = "case-${advanceCase.advanceCase.id}",
+            relatedAccountId = null,
             date = advanceCase.advanceCase.date,
             title = "建立代墊：${advanceCase.advanceCase.title}",
             subtitle = "${advanceCase.participants.size} 位對象，未清 ${outstandingAmount(advanceCase).asCurrencyText(advanceCase.advanceCase.currencyCode)}",
@@ -414,6 +487,7 @@ private fun buildTimelineItems(
             val participant = advanceCase.participants.firstOrNull { it.id == repayment.participantId }
             items += TimelineItem(
                 id = "repayment-${repayment.id}",
+                relatedAccountId = participant?.debtAccountId,
                 date = repayment.date,
                 title = "代墊還款：${participant?.name ?: "未命名對象"}",
                 subtitle = advanceCase.advanceCase.title,
@@ -431,11 +505,16 @@ private fun buildTimelineItems(
         if (!isForgiveness && transaction.transferGroupId != null && transaction.transferGroupId in advanceGroupIds) return@forEach
         items += TimelineItem(
             id = "debt-${transaction.id}",
+            relatedAccountId = transaction.accountId,
             date = transaction.date,
             title = when {
                 isForgiveness -> TransactionSemantics.debtForgivenessDisplayTitle(transaction.note)
-                transaction.amount.signum() < 0 -> "債務增加"
-                else -> "債務減少"
+                transaction.note.contains("對方還款") -> "對方還款"
+                transaction.note.contains("你還款") || transaction.note.contains("還款給") -> "你還款"
+                transaction.note.contains("借入至") -> "你借入"
+                transaction.note.contains("借出") -> "你借出"
+                transaction.amount.signum() < 0 -> "你借入 / 對方還款"
+                else -> "你還款 / 你借出"
             },
             subtitle = tx.account.name,
             amount = transaction.amount,
@@ -461,6 +540,43 @@ private fun totalAdvanced(advanceCase: AdvanceCaseWithDetails): BigDecimal {
     return advanceCase.advanceCase.myShareAmount + advanceCase.participants.fold(BigDecimal.ZERO) { acc, participant ->
         acc + participant.owedAmount
     }
+}
+
+private fun caseProgressText(advanceCase: AdvanceCaseWithDetails): String {
+    val total = totalAdvanced(advanceCase)
+    if (total <= BigDecimal.ZERO) return "未清比例 0%"
+    val percent = outstandingAmount(advanceCase)
+        .multiply(BigDecimal(100))
+        .divide(total, 0, java.math.RoundingMode.HALF_UP)
+    return "未清比例 ${percent.toPlainString()}%"
+}
+
+private fun topOutstandingParticipantText(advanceCase: AdvanceCaseWithDetails): String? {
+    val participant = advanceCase.participants.maxByOrNull { (it.owedAmount - it.repaidAmount).max(BigDecimal.ZERO) }
+    val outstanding = participant?.let { (it.owedAmount - it.repaidAmount).max(BigDecimal.ZERO) } ?: return null
+    if (outstanding <= BigDecimal.ZERO) return null
+    return "主要未清：${participant.name} ${outstanding.asCurrencyText(advanceCase.advanceCase.currencyCode)}"
+}
+
+private fun latestActivityDate(
+    account: AccountEntity,
+    transactions: List<TransactionWithDetails>,
+    advanceCases: List<AdvanceCaseWithDetails>
+): Instant? {
+    val dates = mutableListOf<Instant>()
+    dates += transactions.filter { it.transaction.accountId == account.id }.map { it.transaction.date }
+    advanceCases.forEach { advanceCase ->
+        if (advanceCase.participants.any { it.debtAccountId == account.id }) {
+            dates += advanceCase.advanceCase.date
+        }
+        advanceCase.repayments.forEach { repayment ->
+            val participant = advanceCase.participants.firstOrNull { it.id == repayment.participantId }
+            if (participant?.debtAccountId == account.id) {
+                dates += repayment.date
+            }
+        }
+    }
+    return dates.maxOrNull()
 }
 
 private fun buildShareText(


### PR DESCRIPTION
## Summary
- add bidirectional settlement wording and person-level actions for iOS and Android
- route settlement actions into existing debt entry flows with preselected person, mode, forgiveness direction, and note
- add filtered settlement timelines plus case outstanding progress/top participant details

## Tests
- xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest assembleDebug