### PR TITLE
Fix Android overview and settings chrome

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -143,6 +143,7 @@ fun AIAccountingRoot(
     val currentRoute = backStackEntry?.destination?.route
     val topLevelRoutes = remember { topLevelDestinations.map { it.route }.toSet() }
     val showTopLevelChrome = currentRoute in topLevelRoutes
+    val showFloatingAddButton = showTopLevelChrome && currentRoute != AppDestination.Settings.route
     val startDestination = if (startOnOverview) AppDestination.Overview.route else AppDestination.Transactions.route
 
     LaunchedEffect(currencyService.mainCurrency) {
@@ -203,7 +204,7 @@ fun AIAccountingRoot(
             }
         },
         floatingActionButton = {
-            if (showTopLevelChrome) {
+            if (showFloatingAddButton) {
                 ParityFloatingAddButton(
                     modifier = Modifier.padding(bottom = 6.dp),
                     onClick = { showAddSheet = true }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -163,7 +163,10 @@ fun OverviewScreen(
                     }
                     Button(
                         onClick = onOpenGuide,
-                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surface),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
                         modifier = Modifier
                             .weight(1f)
                             .height(48.dp)


### PR DESCRIPTION
## Summary
- Fix Android overview secondary guide button contrast.
- Hide the global FAB on Settings so it no longer covers preference switches.

## Tests
- ./gradlew testDebugUnitTest assembleDebug
- Android emulator visual QA on Medium_Phone_API_36.1