### PR TITLE
Share date filters across main screens

### DIFF
--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -7,8 +7,10 @@ struct ChartsView: View {
     @Query(sort: \CategoryMonthlyBudget.monthKey, order: .reverse) private var budgets: [CategoryMonthlyBudget]
     @StateObject private var currencyService = CurrencyService.shared
     
-    @State private var filterType: FilterType = .month
-    @State private var selectedDate: Date = Date()
+    @AppStorage(DateFilterPreferenceKeys.filterType) private var filterTypeRaw: String = FilterType.month.rawValue
+    @AppStorage(DateFilterPreferenceKeys.selectedDate) private var selectedDateTimeInterval: Double = Date().timeIntervalSince1970
+    @AppStorage(DateFilterPreferenceKeys.customStartDate) private var customStartDateTimeInterval: Double = Date().timeIntervalSince1970
+    @AppStorage(DateFilterPreferenceKeys.customEndDate) private var customEndDateTimeInterval: Double = Date().timeIntervalSince1970
     @State private var showingFilterSheet = false
     @State private var chartMode: ChartMode = .category
     @State private var flowMode: FlowMode = .expense
@@ -105,7 +107,12 @@ struct ChartsView: View {
             }
             .prominentInlineTitle("報表")
             .sheet(isPresented: $showingFilterSheet) {
-                DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
+                DateFilterView(
+                    filterType: filterTypeBinding,
+                    selectedDate: selectedDateBinding,
+                    customStartDate: customStartDateBinding,
+                    customEndDate: customEndDateBinding
+                )
             }
             .sheet(item: $selectedReportDetail) { detail in
                 ReportTransactionListView(title: detail.title, transactions: detail.transactions)
@@ -285,6 +292,8 @@ struct ChartsView: View {
             currencyService: currencyService,
             filterType: filterType,
             selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
             chartMode: chartMode,
             flowMode: flowMode
         )
@@ -314,14 +323,56 @@ struct ChartsView: View {
     func totalAmount(data: [ChartData]) -> Decimal { data.reduce(0) { $0 + $1.amount } }
     
     var filterDisplayString: String {
-        switch filterType {
-        case .all: return "全部時間"
-        case .year: return "\(Calendar.current.component(.year, from: selectedDate))年"
-        case .month:
-            let f = DateFormatter(); f.dateFormat = "yyyy年 M月"; return f.string(from: selectedDate)
-        case .day:
-            let f = DateFormatter(); f.dateFormat = "M月d日"; return f.string(from: selectedDate)
-        }
+        filterType.displayString(
+            selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
+            allTitle: "全部時間"
+        )
+    }
+
+    private var filterType: FilterType {
+        FilterType(rawValue: filterTypeRaw) ?? .month
+    }
+
+    private var selectedDate: Date {
+        Date(timeIntervalSince1970: selectedDateTimeInterval)
+    }
+
+    private var customStartDate: Date {
+        Date(timeIntervalSince1970: customStartDateTimeInterval)
+    }
+
+    private var customEndDate: Date {
+        Date(timeIntervalSince1970: customEndDateTimeInterval)
+    }
+
+    private var filterTypeBinding: Binding<FilterType> {
+        Binding(
+            get: { FilterType(rawValue: filterTypeRaw) ?? .month },
+            set: { filterTypeRaw = $0.rawValue }
+        )
+    }
+
+    private var selectedDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: selectedDateTimeInterval) },
+            set: { selectedDateTimeInterval = $0.timeIntervalSince1970 }
+        )
+    }
+
+    private var customStartDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: customStartDateTimeInterval) },
+            set: { customStartDateTimeInterval = $0.timeIntervalSince1970 }
+        )
+    }
+
+    private var customEndDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: customEndDateTimeInterval) },
+            set: { customEndDateTimeInterval = $0.timeIntervalSince1970 }
+        )
     }
 }
 
@@ -338,6 +389,8 @@ private struct ChartsRenderState {
         currencyService: CurrencyService,
         filterType: FilterType,
         selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
         chartMode: ChartsView.ChartMode,
         flowMode: ChartsView.FlowMode
     ) {
@@ -345,6 +398,8 @@ private struct ChartsRenderState {
             from: transactions,
             filterType: filterType,
             selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
             flowMode: flowMode
         )
 
@@ -381,17 +436,18 @@ private struct ChartsRenderState {
         from transactions: [FinancialTransaction],
         filterType: FilterType,
         selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
         flowMode: ChartsView.FlowMode
     ) -> [FinancialTransaction] {
-        let calendar = Calendar.current
         return transactions.filter { tx in
             if tx.type != flowMode.transactionType { return false }
-            switch filterType {
-            case .all: return true
-            case .year: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .year)
-            case .month: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .month)
-            case .day: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .day)
-            }
+            return filterType.matches(
+                date: tx.date,
+                selectedDate: selectedDate,
+                customStartDate: customStartDate,
+                customEndDate: customEndDate
+            )
         }
     }
 

--- a/AI 記帳/Views/Common/DateFilterView.swift
+++ b/AI 記帳/Views/Common/DateFilterView.swift
@@ -6,6 +6,7 @@ enum FilterType: String, CaseIterable {
     case year = "按年份"
     case month = "按月份"
     case day = "按日"
+    case custom = "自訂區間"
 }
 
 struct DateFilterView: View {
@@ -14,6 +15,8 @@ struct DateFilterView: View {
     
     @Binding var filterType: FilterType
     @Binding var selectedDate: Date
+    @Binding var customStartDate: Date
+    @Binding var customEndDate: Date
     
     var body: some View {
         NavigationStack {
@@ -64,6 +67,16 @@ struct DateFilterView: View {
                     Section("選擇日期") {
                         DatePicker("選擇日期", selection: $selectedDate, displayedComponents: [.date])
                             .datePickerStyle(.graphical)
+                    }
+                } else if filterType == .custom {
+                    Section("自訂區間") {
+                        DatePicker("開始日期", selection: $customStartDate, displayedComponents: [.date])
+                        DatePicker("結束日期", selection: $customEndDate, displayedComponents: [.date])
+
+                        let range = normalizedCustomRange(start: customStartDate, end: customEndDate)
+                        Text("將顯示 \(range.start.formatted(date: .abbreviated, time: .omitted)) 至 \(range.end.formatted(date: .abbreviated, time: .omitted)) 的資料")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }

--- a/AI 記帳/Views/Common/SharedDateFilter.swift
+++ b/AI 記帳/Views/Common/SharedDateFilter.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+enum DateFilterPreferenceKeys {
+    static let filterType = "sharedDateFilterType"
+    static let selectedDate = "sharedDateFilterSelectedDate"
+    static let customStartDate = "sharedDateFilterCustomStartDate"
+    static let customEndDate = "sharedDateFilterCustomEndDate"
+}
+
+extension FilterType {
+    func displayString(
+        selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
+        allTitle: String
+    ) -> String {
+        let formatter = DateFormatter()
+        switch self {
+        case .all:
+            return allTitle
+        case .year:
+            return "\(Calendar.current.component(.year, from: selectedDate))年"
+        case .month:
+            formatter.dateFormat = "yyyy年 M月"
+            return formatter.string(from: selectedDate)
+        case .day:
+            formatter.dateFormat = "M月d日"
+            return formatter.string(from: selectedDate)
+        case .custom:
+            formatter.dateFormat = "yyyy-MM-dd"
+            let range = normalizedCustomRange(start: customStartDate, end: customEndDate)
+            return "\(formatter.string(from: range.start)) ~ \(formatter.string(from: range.end))"
+        }
+    }
+
+    func matches(
+        date: Date,
+        selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
+        calendar: Calendar = .current
+    ) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .year:
+            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .year)
+        case .month:
+            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .month)
+        case .day:
+            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .day)
+        case .custom:
+            let range = normalizedCustomRange(start: customStartDate, end: customEndDate)
+            let startOfDay = calendar.startOfDay(for: range.start)
+            let exclusiveEnd = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: range.end)) ?? range.end
+            return date >= startOfDay && date < exclusiveEnd
+        }
+    }
+}
+
+func normalizedCustomRange(start: Date, end: Date) -> (start: Date, end: Date) {
+    start <= end ? (start, end) : (end, start)
+}

--- a/AI 記帳/Views/Home/HomeDashboardView.swift
+++ b/AI 記帳/Views/Home/HomeDashboardView.swift
@@ -5,8 +5,10 @@ struct HomeDashboardView: View {
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
     @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
     @StateObject private var currencyService = CurrencyService.shared
-    @State private var filterType: FilterType = .month
-    @State private var selectedDate: Date = Date()
+    @AppStorage(DateFilterPreferenceKeys.filterType) private var filterTypeRaw: String = FilterType.month.rawValue
+    @AppStorage(DateFilterPreferenceKeys.selectedDate) private var selectedDateTimeInterval: Double = Date().timeIntervalSince1970
+    @AppStorage(DateFilterPreferenceKeys.customStartDate) private var customStartDateTimeInterval: Double = Date().timeIntervalSince1970
+    @AppStorage(DateFilterPreferenceKeys.customEndDate) private var customEndDateTimeInterval: Double = Date().timeIntervalSince1970
     @State private var showingFilterSheet = false
     @AppStorage("pinOverviewControls") private var pinOverviewControls: Bool = true
 
@@ -85,7 +87,12 @@ struct HomeDashboardView: View {
                 await currencyService.fetchRates()
             }
             .sheet(isPresented: $showingFilterSheet) {
-                DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
+                DateFilterView(
+                    filterType: filterTypeBinding,
+                    selectedDate: selectedDateBinding,
+                    customStartDate: customStartDateBinding,
+                    customEndDate: customEndDateBinding
+                )
             }
         }
     }
@@ -271,32 +278,64 @@ struct HomeDashboardView: View {
     }
 
     private var filterDisplayString: String {
-        let formatter = DateFormatter()
-        switch filterType {
-        case .all:
-            return "全部紀錄"
-        case .year:
-            return "\(Calendar.current.component(.year, from: selectedDate))年"
-        case .month:
-            formatter.dateFormat = "yyyy年 M月"
-            return formatter.string(from: selectedDate)
-        case .day:
-            formatter.dateFormat = "M月d日"
-            return formatter.string(from: selectedDate)
-        }
+        filterType.displayString(
+            selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
+            allTitle: "全部紀錄"
+        )
     }
 
     private func matchesFilter(date: Date) -> Bool {
-        let calendar = Calendar.current
-        switch filterType {
-        case .all:
-            return true
-        case .year:
-            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .year)
-        case .month:
-            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .month)
-        case .day:
-            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .day)
-        }
+        filterType.matches(
+            date: date,
+            selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate
+        )
+    }
+
+    private var filterType: FilterType {
+        FilterType(rawValue: filterTypeRaw) ?? .month
+    }
+
+    private var selectedDate: Date {
+        Date(timeIntervalSince1970: selectedDateTimeInterval)
+    }
+
+    private var customStartDate: Date {
+        Date(timeIntervalSince1970: customStartDateTimeInterval)
+    }
+
+    private var customEndDate: Date {
+        Date(timeIntervalSince1970: customEndDateTimeInterval)
+    }
+
+    private var filterTypeBinding: Binding<FilterType> {
+        Binding(
+            get: { FilterType(rawValue: filterTypeRaw) ?? .month },
+            set: { filterTypeRaw = $0.rawValue }
+        )
+    }
+
+    private var selectedDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: selectedDateTimeInterval) },
+            set: { selectedDateTimeInterval = $0.timeIntervalSince1970 }
+        )
+    }
+
+    private var customStartDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: customStartDateTimeInterval) },
+            set: { customStartDateTimeInterval = $0.timeIntervalSince1970 }
+        )
+    }
+
+    private var customEndDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: customEndDateTimeInterval) },
+            set: { customEndDateTimeInterval = $0.timeIntervalSince1970 }
+        )
     }
 }

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -9,8 +9,10 @@ struct TransactionsListView: View {
     @Query private var advanceParticipants: [AdvanceParticipant]
     @Query private var advanceRepayments: [AdvanceRepayment]
     
-    @State private var filterType: FilterType = .month
-    @State private var selectedDate: Date = Date()
+    @AppStorage(DateFilterPreferenceKeys.filterType) private var filterTypeRaw: String = FilterType.month.rawValue
+    @AppStorage(DateFilterPreferenceKeys.selectedDate) private var selectedDateTimeInterval: Double = Date().timeIntervalSince1970
+    @AppStorage(DateFilterPreferenceKeys.customStartDate) private var customStartDateTimeInterval: Double = Date().timeIntervalSince1970
+    @AppStorage(DateFilterPreferenceKeys.customEndDate) private var customEndDateTimeInterval: Double = Date().timeIntervalSince1970
     @State private var showingFilterSheet = false
     @State private var searchText = ""
     @AppStorage("pinLedgerControls") private var pinLedgerControls: Bool = true
@@ -60,7 +62,12 @@ struct TransactionsListView: View {
             ledgerContent(renderState: renderState)
         }
         .sheet(isPresented: $showingFilterSheet) {
-            DateFilterView(filterType: $filterType, selectedDate: $selectedDate)
+            DateFilterView(
+                filterType: filterTypeBinding,
+                selectedDate: selectedDateBinding,
+                customStartDate: customStartDateBinding,
+                customEndDate: customEndDateBinding
+            )
         }
         .sheet(isPresented: $showingAddShortcut) {
             AddShortcutView()
@@ -311,6 +318,8 @@ struct TransactionsListView: View {
             advanceRepayments: advanceRepayments,
             filterType: filterType,
             selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
             searchText: searchText
         )
     }
@@ -338,13 +347,56 @@ struct TransactionsListView: View {
     }
     
     var filterDisplayString: String {
-        let formatter = DateFormatter()
-        switch filterType {
-        case .all: return "全部紀錄"
-        case .year: return "\(Calendar.current.component(.year, from: selectedDate))年"
-        case .month: formatter.dateFormat = "yyyy年 M月"; return formatter.string(from: selectedDate)
-        case .day: formatter.dateFormat = "M月d日"; return formatter.string(from: selectedDate)
-        }
+        filterType.displayString(
+            selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
+            allTitle: "全部紀錄"
+        )
+    }
+
+    private var filterType: FilterType {
+        FilterType(rawValue: filterTypeRaw) ?? .month
+    }
+
+    private var selectedDate: Date {
+        Date(timeIntervalSince1970: selectedDateTimeInterval)
+    }
+
+    private var customStartDate: Date {
+        Date(timeIntervalSince1970: customStartDateTimeInterval)
+    }
+
+    private var customEndDate: Date {
+        Date(timeIntervalSince1970: customEndDateTimeInterval)
+    }
+
+    private var filterTypeBinding: Binding<FilterType> {
+        Binding(
+            get: { FilterType(rawValue: filterTypeRaw) ?? .month },
+            set: { filterTypeRaw = $0.rawValue }
+        )
+    }
+
+    private var selectedDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: selectedDateTimeInterval) },
+            set: { selectedDateTimeInterval = $0.timeIntervalSince1970 }
+        )
+    }
+
+    private var customStartDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: customStartDateTimeInterval) },
+            set: { customStartDateTimeInterval = $0.timeIntervalSince1970 }
+        )
+    }
+
+    private var customEndDateBinding: Binding<Date> {
+        Binding(
+            get: { Date(timeIntervalSince1970: customEndDateTimeInterval) },
+            set: { customEndDateTimeInterval = $0.timeIntervalSince1970 }
+        )
     }
     
     func calculateTotalEstimate() -> String {
@@ -406,6 +458,8 @@ private struct TransactionsRenderState {
         advanceRepayments: [AdvanceRepayment],
         filterType: FilterType,
         selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
         searchText: String
     ) {
         let initialAdvanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
@@ -417,12 +471,16 @@ private struct TransactionsRenderState {
             initialAdvanceGroupIDs: initialAdvanceGroupIDs,
             filterType: filterType,
             selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
             searchText: searchText
         )
         let filteredAdvanceCases = Self.filteredAdvanceCases(
             from: advanceCases,
             filterType: filterType,
             selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
             searchText: searchText
         )
         let ledgerItems = Self.ledgerItems(
@@ -444,9 +502,10 @@ private struct TransactionsRenderState {
         initialAdvanceGroupIDs: Set<UUID>,
         filterType: FilterType,
         selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
         searchText: String
     ) -> [FinancialTransaction] {
-        let calendar = Calendar.current
         let timeFiltered = transactions.filter { tx in
             if tx.type == .transfer && tx.amount > 0 && !TransactionSemantics.isDebtForgiveness(note: tx.note) { return false }
             if tx.type == .transfer,
@@ -458,12 +517,12 @@ private struct TransactionsRenderState {
             if let groupID = tx.transferGroupID, initialAdvanceGroupIDs.contains(groupID) {
                 return false
             }
-            switch filterType {
-            case .all: return true
-            case .year: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .year)
-            case .month: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .month)
-            case .day: return calendar.isDate(tx.date, equalTo: selectedDate, toGranularity: .day)
-            }
+            return filterType.matches(
+                date: tx.date,
+                selectedDate: selectedDate,
+                customStartDate: customStartDate,
+                customEndDate: customEndDate
+            )
         }
         let searched = searchText.isEmpty ? timeFiltered : timeFiltered.filter { tx in
             tx.note.localizedCaseInsensitiveContains(searchText) ||
@@ -478,16 +537,17 @@ private struct TransactionsRenderState {
         from advanceCases: [AdvanceCase],
         filterType: FilterType,
         selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
         searchText: String
     ) -> [AdvanceCase] {
-        let calendar = Calendar.current
         let timeFiltered = advanceCases.filter { advanceCase in
-            switch filterType {
-            case .all: return true
-            case .year: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .year)
-            case .month: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .month)
-            case .day: return calendar.isDate(advanceCase.date, equalTo: selectedDate, toGranularity: .day)
-            }
+            filterType.matches(
+                date: advanceCase.date,
+                selectedDate: selectedDate,
+                customStartDate: customStartDate,
+                customEndDate: customEndDate
+            )
         }
 
         guard !searchText.isEmpty else {
@@ -525,7 +585,7 @@ private struct TransactionsRenderState {
             case .all: formatter.dateFormat = "yyyy年"; return formatter.string(from: date)
             case .year: formatter.dateFormat = "M月"; return formatter.string(from: date)
             case .month: formatter.dateFormat = "d日 (EEEE)"; return formatter.string(from: date)
-            case .day: return "明細"
+            case .day, .custom: formatter.dateFormat = "M月d日 (EEEE)"; return formatter.string(from: date)
             }
         }
         let groupedDict = Dictionary(grouping: ledgerItems) { item in grouping(item.date) }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/preferences/SharedDateFilter.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/preferences/SharedDateFilter.kt
@@ -1,0 +1,77 @@
+package org.duckdns.lhfser.aiaccounting.core.preferences
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+enum class SharedDateFilterType(val label: String) {
+    All("全部"),
+    Year("本年"),
+    Month("本月"),
+    Day("今日"),
+    Custom("自訂區間")
+}
+
+data class SharedDateFilterState(
+    val type: SharedDateFilterType = SharedDateFilterType.Month,
+    val selectedDate: LocalDate = LocalDate.now(),
+    val customStartDate: LocalDate = LocalDate.now(),
+    val customEndDate: LocalDate = LocalDate.now()
+)
+
+fun sharedDateFilterLabel(
+    type: SharedDateFilterType,
+    selectedDate: LocalDate,
+    customStartDate: LocalDate,
+    customEndDate: LocalDate,
+    allLabel: String = "全部"
+): String {
+    return when (type) {
+        SharedDateFilterType.All -> allLabel
+        SharedDateFilterType.Year -> "${selectedDate.year}年"
+        SharedDateFilterType.Month -> selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
+        SharedDateFilterType.Day -> selectedDate.format(DateTimeFormatter.ofPattern("M月d日"))
+        SharedDateFilterType.Custom -> {
+            val (start, end) = normalizedCustomDateRange(customStartDate, customEndDate)
+            "${start.format(DateTimeFormatter.ISO_DATE)} ~ ${end.format(DateTimeFormatter.ISO_DATE)}"
+        }
+    }
+}
+
+fun resolveSharedDateRange(
+    type: SharedDateFilterType,
+    selectedDate: LocalDate,
+    customStartDate: LocalDate,
+    customEndDate: LocalDate
+): Pair<Instant?, Instant?> {
+    val zone = ZoneId.systemDefault()
+    return when (type) {
+        SharedDateFilterType.All -> null to null
+        SharedDateFilterType.Year -> {
+            val start = LocalDate.of(selectedDate.year, 1, 1).atStartOfDay(zone).toInstant()
+            val end = LocalDate.of(selectedDate.year + 1, 1, 1).atStartOfDay(zone).toInstant()
+            start to end
+        }
+        SharedDateFilterType.Month -> {
+            val start = selectedDate.withDayOfMonth(1).atStartOfDay(zone).toInstant()
+            val end = selectedDate.withDayOfMonth(1).plusMonths(1).atStartOfDay(zone).toInstant()
+            start to end
+        }
+        SharedDateFilterType.Day -> {
+            val start = selectedDate.atStartOfDay(zone).toInstant()
+            val end = selectedDate.plusDays(1).atStartOfDay(zone).toInstant()
+            start to end
+        }
+        SharedDateFilterType.Custom -> {
+            val (startDate, endDate) = normalizedCustomDateRange(customStartDate, customEndDate)
+            val start = startDate.atStartOfDay(zone).toInstant()
+            val end = endDate.plusDays(1).atStartOfDay(zone).toInstant()
+            start to end
+        }
+    }
+}
+
+fun normalizedCustomDateRange(start: LocalDate, end: LocalDate): Pair<LocalDate, LocalDate> {
+    return if (end.isBefore(start)) end to start else start to end
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/preferences/UiPreferencesStore.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/preferences/UiPreferencesStore.kt
@@ -2,6 +2,7 @@ package org.duckdns.lhfser.aiaccounting.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -9,7 +10,8 @@ import kotlinx.coroutines.flow.asStateFlow
 data class UiPreferences(
     val pinOverviewControls: Boolean = true,
     val pinLedgerControls: Boolean = true,
-    val pinReportsControls: Boolean = true
+    val pinReportsControls: Boolean = true,
+    val dateFilter: SharedDateFilterState = SharedDateFilterState()
 )
 
 class UiPreferencesStore(context: Context) {
@@ -42,12 +44,48 @@ class UiPreferencesStore(context: Context) {
         _state.value = read()
     }
 
+    fun setDateFilterType(value: SharedDateFilterType) {
+        prefs.edit().putString(KEY_DATE_FILTER_TYPE, value.name).apply()
+        _state.value = read()
+    }
+
+    fun setDateFilterSelectedDate(value: LocalDate) {
+        prefs.edit().putString(KEY_DATE_FILTER_SELECTED_DATE, value.toString()).apply()
+        _state.value = read()
+    }
+
+    fun setDateFilterCustomStartDate(value: LocalDate) {
+        prefs.edit().putString(KEY_DATE_FILTER_CUSTOM_START_DATE, value.toString()).apply()
+        _state.value = read()
+    }
+
+    fun setDateFilterCustomEndDate(value: LocalDate) {
+        prefs.edit().putString(KEY_DATE_FILTER_CUSTOM_END_DATE, value.toString()).apply()
+        _state.value = read()
+    }
+
     private fun read(): UiPreferences {
         return UiPreferences(
             pinOverviewControls = prefs.getBoolean(KEY_PIN_OVERVIEW_CONTROLS, true),
             pinLedgerControls = prefs.getBoolean(KEY_PIN_LEDGER_CONTROLS, true),
-            pinReportsControls = prefs.getBoolean(KEY_PIN_REPORTS_CONTROLS, true)
+            pinReportsControls = prefs.getBoolean(KEY_PIN_REPORTS_CONTROLS, true),
+            dateFilter = SharedDateFilterState(
+                type = readDateFilterType(),
+                selectedDate = readDate(KEY_DATE_FILTER_SELECTED_DATE),
+                customStartDate = readDate(KEY_DATE_FILTER_CUSTOM_START_DATE),
+                customEndDate = readDate(KEY_DATE_FILTER_CUSTOM_END_DATE)
+            )
         )
+    }
+
+    private fun readDateFilterType(): SharedDateFilterType {
+        val raw = prefs.getString(KEY_DATE_FILTER_TYPE, SharedDateFilterType.Month.name)
+        return SharedDateFilterType.entries.firstOrNull { it.name == raw } ?: SharedDateFilterType.Month
+    }
+
+    private fun readDate(key: String): LocalDate {
+        val raw = prefs.getString(key, null) ?: return LocalDate.now()
+        return runCatching { LocalDate.parse(raw) }.getOrDefault(LocalDate.now())
     }
 
     private companion object {
@@ -55,10 +93,18 @@ class UiPreferencesStore(context: Context) {
         const val KEY_PIN_OVERVIEW_CONTROLS = "pinOverviewControls"
         const val KEY_PIN_LEDGER_CONTROLS = "pinLedgerControls"
         const val KEY_PIN_REPORTS_CONTROLS = "pinReportsControls"
+        const val KEY_DATE_FILTER_TYPE = "dateFilterType"
+        const val KEY_DATE_FILTER_SELECTED_DATE = "dateFilterSelectedDate"
+        const val KEY_DATE_FILTER_CUSTOM_START_DATE = "dateFilterCustomStartDate"
+        const val KEY_DATE_FILTER_CUSTOM_END_DATE = "dateFilterCustomEndDate"
         val preferenceKeys = setOf(
             KEY_PIN_OVERVIEW_CONTROLS,
             KEY_PIN_LEDGER_CONTROLS,
-            KEY_PIN_REPORTS_CONTROLS
+            KEY_PIN_REPORTS_CONTROLS,
+            KEY_DATE_FILTER_TYPE,
+            KEY_DATE_FILTER_SELECTED_DATE,
+            KEY_DATE_FILTER_CUSTOM_START_DATE,
+            KEY_DATE_FILTER_CUSTOM_END_DATE
         )
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -20,10 +20,12 @@ import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.PieChart
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -38,10 +40,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
+import org.duckdns.lhfser.aiaccounting.core.preferences.resolveSharedDateRange
+import org.duckdns.lhfser.aiaccounting.core.preferences.sharedDateFilterLabel
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
@@ -55,13 +60,6 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
-
-private enum class OverviewFilterType(val label: String) {
-    All("全部"),
-    Year("本年"),
-    Month("本月"),
-    Day("今日")
-}
 
 @Composable
 fun OverviewScreen(
@@ -82,15 +80,22 @@ fun OverviewScreen(
     val transactions by repository.transactions.collectAsState(initial = emptyList())
     val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
 
-    var filterType by remember { mutableStateOf(OverviewFilterType.Month) }
-    var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     var showFilterDialog by remember { mutableStateOf(false) }
+    var showCustomDateDialog by remember { mutableStateOf(false) }
+    val dateFilter = uiPreferences.dateFilter
+    val filterType = dateFilter.type
+    val selectedDate = dateFilter.selectedDate
+    val customStartDate = dateFilter.customStartDate
+    val customEndDate = dateFilter.customEndDate
 
-    val filteredTransactions = remember(transactions, filterType, selectedDate) {
-        filterTransactions(transactions, filterType, selectedDate)
+    val (rangeStart, rangeEnd) = remember(filterType, selectedDate, customStartDate, customEndDate) {
+        resolveSharedDateRange(filterType, selectedDate, customStartDate, customEndDate)
     }
-    val filteredAdvanceCases = remember(advanceCases, filterType, selectedDate) {
-        filterAdvanceCases(advanceCases, filterType, selectedDate)
+    val filteredTransactions = remember(transactions, rangeStart, rangeEnd) {
+        filterTransactions(transactions, rangeStart, rangeEnd)
+    }
+    val filteredAdvanceCases = remember(advanceCases, rangeStart, rangeEnd) {
+        filterAdvanceCases(advanceCases, rangeStart, rangeEnd)
     }
 
     val baseCurrency = currencyService.mainCurrency
@@ -112,19 +117,30 @@ fun OverviewScreen(
     fun OverviewControls() {
         ParityTopSection(
             title = "總覽",
-            subtitle = "今天是 ${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))} · 目前區間：${filterDisplayString(filterType, selectedDate)} · 已記錄 $recordCount 筆收入/支出"
+            subtitle = "今天是 ${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))} · 目前區間：${sharedDateFilterLabel(filterType, selectedDate, customStartDate, customEndDate)} · 已記錄 $recordCount 筆收入/支出"
         )
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
             ParityFilterCapsule(
-                label = filterDisplayString(filterType, selectedDate),
-                onClick = { showFilterDialog = true }
+                label = filterDisplayString(filterType, selectedDate, customStartDate, customEndDate),
+                onClick = {
+                    when (filterType) {
+                        SharedDateFilterType.All -> Unit
+                        SharedDateFilterType.Custom -> showCustomDateDialog = true
+                        else -> showFilterDialog = true
+                    }
+                }
             )
             ParitySegmentedControl(
-                options = OverviewFilterType.values().toList(),
+                options = SharedDateFilterType.entries.toList(),
                 selected = filterType,
                 label = { it.label },
-                onSelect = { filterType = it }
+                onSelect = {
+                    uiPreferencesStore.setDateFilterType(it)
+                    if (it == SharedDateFilterType.Custom) {
+                        showCustomDateDialog = true
+                    }
+                }
             )
         }
     }
@@ -181,7 +197,7 @@ fun OverviewScreen(
 
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
             androidx.compose.material3.Text(
-                "${filterDisplayString(filterType, selectedDate)}重點（$baseCurrency）",
+                "${filterDisplayString(filterType, selectedDate, customStartDate, customEndDate)}重點（$baseCurrency）",
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.SemiBold
             )
@@ -271,13 +287,39 @@ fun OverviewScreen(
         DatePickerDialog(
             context,
             { _, year, month, day ->
-                selectedDate = LocalDate.of(year, month + 1, day)
+                uiPreferencesStore.setDateFilterSelectedDate(LocalDate.of(year, month + 1, day))
             },
             selectedDate.year,
             selectedDate.monthValue - 1,
             selectedDate.dayOfMonth
         ).show()
         showFilterDialog = false
+    }
+
+    if (showCustomDateDialog) {
+        AlertDialog(
+            onDismissRequest = { showCustomDateDialog = false },
+            title = { androidx.compose.material3.Text("自訂區間") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
+                    TextButton(onClick = {
+                        showDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
+                    }) {
+                        androidx.compose.material3.Text("開始日期：${customStartDate.format(DateTimeFormatter.ISO_DATE)}")
+                    }
+                    TextButton(onClick = {
+                        showDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
+                    }) {
+                        androidx.compose.material3.Text("結束日期：${customEndDate.format(DateTimeFormatter.ISO_DATE)}")
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showCustomDateDialog = false }) {
+                    androidx.compose.material3.Text("完成")
+                }
+            }
+        )
     }
 }
 
@@ -350,34 +392,26 @@ private fun EntryButton(
 
 private fun filterTransactions(
     transactions: List<TransactionWithDetails>,
-    filterType: OverviewFilterType,
-    selectedDate: LocalDate
+    rangeStart: Instant?,
+    rangeEnd: Instant?
 ): List<TransactionWithDetails> {
-    val zone = ZoneId.systemDefault()
     return transactions.filter { tx ->
-        val date = tx.transaction.date.atZone(zone).toLocalDate()
-        when (filterType) {
-            OverviewFilterType.All -> true
-            OverviewFilterType.Year -> date.year == selectedDate.year
-            OverviewFilterType.Month -> date.year == selectedDate.year && date.month == selectedDate.month
-            OverviewFilterType.Day -> date == selectedDate
+        when {
+            rangeStart == null || rangeEnd == null -> true
+            else -> tx.transaction.date >= rangeStart && tx.transaction.date < rangeEnd
         }
     }
 }
 
 private fun filterAdvanceCases(
     advanceCases: List<AdvanceCaseWithDetails>,
-    filterType: OverviewFilterType,
-    selectedDate: LocalDate
+    rangeStart: Instant?,
+    rangeEnd: Instant?
 ): List<AdvanceCaseWithDetails> {
-    val zone = ZoneId.systemDefault()
     return advanceCases.filter { advanceCase ->
-        val date = advanceCase.advanceCase.date.atZone(zone).toLocalDate()
-        when (filterType) {
-            OverviewFilterType.All -> true
-            OverviewFilterType.Year -> date.year == selectedDate.year
-            OverviewFilterType.Month -> date.year == selectedDate.year && date.month == selectedDate.month
-            OverviewFilterType.Day -> date == selectedDate
+        when {
+            rangeStart == null || rangeEnd == null -> true
+            else -> advanceCase.advanceCase.date >= rangeStart && advanceCase.advanceCase.date < rangeEnd
         }
     }
 }
@@ -389,11 +423,27 @@ private fun outstandingAmount(advanceCase: AdvanceCaseWithDetails): BigDecimal {
     }.setScale(2, RoundingMode.HALF_UP)
 }
 
-private fun filterDisplayString(type: OverviewFilterType, date: LocalDate): String {
-    return when (type) {
-        OverviewFilterType.All -> "全部"
-        OverviewFilterType.Year -> "${date.year}年"
-        OverviewFilterType.Month -> date.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
-        OverviewFilterType.Day -> date.format(DateTimeFormatter.ofPattern("M月d日"))
-    }
+private fun filterDisplayString(
+    type: SharedDateFilterType,
+    selectedDate: LocalDate,
+    customStartDate: LocalDate,
+    customEndDate: LocalDate
+): String {
+    return sharedDateFilterLabel(type, selectedDate, customStartDate, customEndDate)
+}
+
+private fun showDatePicker(
+    context: android.content.Context,
+    initialDate: LocalDate,
+    onDateSelected: (LocalDate) -> Unit
+) {
+    DatePickerDialog(
+        context,
+        { _, year, month, day ->
+            onDateSelected(LocalDate.of(year, month + 1, day))
+        },
+        initialDate.year,
+        initialDate.monthValue - 1,
+        initialDate.dayOfMonth
+    ).show()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -57,6 +57,9 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
+import org.duckdns.lhfser.aiaccounting.core.preferences.resolveSharedDateRange
+import org.duckdns.lhfser.aiaccounting.core.preferences.sharedDateFilterLabel
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
@@ -75,13 +78,6 @@ import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
-
-private enum class ReportFilterType(val label: String) {
-    All("全部時間"),
-    Year("本年"),
-    Month("本月"),
-    Day("今日")
-}
 
 private enum class ReportChartMode(val label: String) {
     Category("依分類"),
@@ -125,16 +121,19 @@ fun ReportsScreen() {
     val budgets by repository.budgets.collectAsState(initial = emptyList())
     val uiPreferences by uiPreferencesStore.state.collectAsState()
 
-    var filterType by remember { mutableStateOf(ReportFilterType.Month) }
-    var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     var showFilterDialog by remember { mutableStateOf(false) }
     var chartMode by remember { mutableStateOf(ReportChartMode.Category) }
     var flowMode by remember { mutableStateOf(ReportFlowMode.Expense) }
     var selectedTag by remember { mutableStateOf<String?>(null) }
     var reportDetail by remember { mutableStateOf<ReportDetail?>(null) }
+    val dateFilter = uiPreferences.dateFilter
+    val filterType = dateFilter.type
+    val selectedDate = dateFilter.selectedDate
+    val customStartDate = dateFilter.customStartDate
+    val customEndDate = dateFilter.customEndDate
 
-    val (rangeStart, rangeEnd) = remember(filterType, selectedDate) {
-        resolveDateRange(filterType, selectedDate)
+    val (rangeStart, rangeEnd) = remember(filterType, selectedDate, customStartDate, customEndDate) {
+        resolveSharedDateRange(filterType, selectedDate, customStartDate, customEndDate)
     }
     val filteredTransactions = remember(transactions, flowMode, rangeStart, rangeEnd) {
         filterTransactions(transactions, flowMode.type, rangeStart, rangeEnd)
@@ -179,7 +178,7 @@ fun ReportsScreen() {
             )
 
             ParityFilterCapsule(
-                label = filterLabel(filterType, selectedDate),
+                label = sharedDateFilterLabel(filterType, selectedDate, customStartDate, customEndDate, allLabel = "全部時間"),
                 icon = Icons.Default.DateRange,
                 onClick = { showFilterDialog = true }
             )
@@ -305,9 +304,17 @@ fun ReportsScreen() {
         ReportFilterSheet(
             filterType = filterType,
             selectedDate = selectedDate,
-            onSelectFilterType = { filterType = it },
+            customStartDate = customStartDate,
+            customEndDate = customEndDate,
+            onSelectFilterType = uiPreferencesStore::setDateFilterType,
             onPickDate = {
-                showDatePicker(context, selectedDate) { selectedDate = it }
+                showDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
+            },
+            onPickCustomStart = {
+                showDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
+            },
+            onPickCustomEnd = {
+                showDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
             },
             onDismiss = { showFilterDialog = false }
         )
@@ -329,10 +336,14 @@ fun ReportsScreen() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ReportFilterSheet(
-    filterType: ReportFilterType,
+    filterType: SharedDateFilterType,
     selectedDate: LocalDate,
-    onSelectFilterType: (ReportFilterType) -> Unit,
+    customStartDate: LocalDate,
+    customEndDate: LocalDate,
+    onSelectFilterType: (SharedDateFilterType) -> Unit,
     onPickDate: () -> Unit,
+    onPickCustomStart: () -> Unit,
+    onPickCustomEnd: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -353,7 +364,7 @@ private fun ReportFilterSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
-            ReportFilterType.values().forEach { type ->
+            SharedDateFilterType.entries.forEach { type ->
                 ParitySelectionSheetRow(
                     title = type.label,
                     subtitle = reportFilterSubtitle(type),
@@ -362,23 +373,66 @@ private fun ReportFilterSheet(
                 )
             }
 
-            PressableCard(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = onPickDate,
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                pressedContainerColor = MaterialTheme.colorScheme.surface
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                        Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                        Text(selectedDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            when (filterType) {
+                SharedDateFilterType.Year, SharedDateFilterType.Month, SharedDateFilterType.Day -> {
+                    PressableCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = onPickDate,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(selectedDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text("調整", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                        }
                     }
-                    Text("調整", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                 }
+                SharedDateFilterType.Custom -> {
+                    PressableCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = onPickCustomStart,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                Text("開始日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(customStartDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+                    PressableCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = onPickCustomEnd,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                                Text("結束日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                                Text(customEndDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+                }
+                SharedDateFilterType.All -> Unit
             }
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -389,12 +443,13 @@ private fun ReportFilterSheet(
     }
 }
 
-private fun reportFilterSubtitle(type: ReportFilterType): String {
+private fun reportFilterSubtitle(type: SharedDateFilterType): String {
     return when (type) {
-        ReportFilterType.All -> "查看所有時間的累積統計"
-        ReportFilterType.Year -> "聚焦本年收入與支出"
-        ReportFilterType.Month -> "查看本月分類與標籤分佈"
-        ReportFilterType.Day -> "只看當日收支"
+        SharedDateFilterType.All -> "查看所有時間的累積統計"
+        SharedDateFilterType.Year -> "聚焦本年收入與支出"
+        SharedDateFilterType.Month -> "查看本月分類與標籤分佈"
+        SharedDateFilterType.Day -> "只看當日收支"
+        SharedDateFilterType.Custom -> "自訂開始與結束日期"
     }
 }
 
@@ -677,37 +732,6 @@ private fun ReportDetailSheet(detail: ReportDetail) {
     }
 }
 
-private fun filterLabel(filterType: ReportFilterType, selectedDate: LocalDate): String {
-    return when (filterType) {
-        ReportFilterType.All -> "全部時間"
-        ReportFilterType.Year -> "${selectedDate.year}年"
-        ReportFilterType.Month -> selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
-        ReportFilterType.Day -> selectedDate.format(DateTimeFormatter.ofPattern("M月d日"))
-    }
-}
-
-private fun resolveDateRange(type: ReportFilterType, date: LocalDate): Pair<Instant?, Instant?> {
-    val zone = ZoneId.systemDefault()
-    return when (type) {
-        ReportFilterType.All -> null to null
-        ReportFilterType.Year -> {
-            val start = LocalDate.of(date.year, 1, 1).atStartOfDay(zone).toInstant()
-            val end = LocalDate.of(date.year + 1, 1, 1).atStartOfDay(zone).toInstant()
-            start to end
-        }
-        ReportFilterType.Month -> {
-            val start = date.withDayOfMonth(1).atStartOfDay(zone).toInstant()
-            val end = date.withDayOfMonth(1).plusMonths(1).atStartOfDay(zone).toInstant()
-            start to end
-        }
-        ReportFilterType.Day -> {
-            val start = date.atStartOfDay(zone).toInstant()
-            val end = date.plusDays(1).atStartOfDay(zone).toInstant()
-            start to end
-        }
-    }
-}
-
 private fun filterTransactions(
     transactions: List<TransactionWithDetails>,
     type: TransactionType,
@@ -814,7 +838,12 @@ private fun buildBudgetAlerts(
 ): List<BudgetAlert> {
     if (budgets.isEmpty()) return emptyList()
     val monthKey = DateTimeFormatter.ofPattern("yyyy-MM").format(LocalDate.now())
-    val range = resolveDateRange(ReportFilterType.Month, LocalDate.now())
+    val range = resolveSharedDateRange(
+        SharedDateFilterType.Month,
+        LocalDate.now(),
+        LocalDate.now(),
+        LocalDate.now()
+    )
     val (start, end) = range
     val monthTransactions = if (start != null && end != null) {
         transactions.filter { it.transaction.date >= start && it.transaction.date < end }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -52,6 +52,9 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
+import org.duckdns.lhfser.aiaccounting.core.preferences.resolveSharedDateRange
+import org.duckdns.lhfser.aiaccounting.core.preferences.sharedDateFilterLabel
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.ShortcutWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
@@ -72,12 +75,6 @@ import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
-
-private enum class DateFilterType(val label: String) {
-    Month("本月"),
-    Year("本年"),
-    Custom("自訂區間")
-}
 
 private sealed interface LedgerItem {
     val stableId: String
@@ -122,15 +119,16 @@ fun TransactionsScreen(
     var transactionToDelete by remember { mutableStateOf<TransactionWithDetails?>(null) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
-    var filterType by remember { mutableStateOf(DateFilterType.Month) }
-    var selectedDate by remember { mutableStateOf(LocalDate.now()) }
-    var customStartDate by remember { mutableStateOf(LocalDate.now()) }
-    var customEndDate by remember { mutableStateOf(LocalDate.now()) }
     var showFilterDialog by remember { mutableStateOf(false) }
     var searchText by remember { mutableStateOf("") }
+    val dateFilter = uiPreferences.dateFilter
+    val filterType = dateFilter.type
+    val selectedDate = dateFilter.selectedDate
+    val customStartDate = dateFilter.customStartDate
+    val customEndDate = dateFilter.customEndDate
 
     val (rangeStart, rangeEnd) = remember(filterType, selectedDate, customStartDate, customEndDate) {
-        resolveDateRange(filterType, selectedDate, customStartDate, customEndDate)
+        resolveSharedDateRange(filterType, selectedDate, customStartDate, customEndDate)
     }
     val initialAdvanceGroupIds = remember(advanceCases) {
         advanceCases.flatMap { it.participants.mapNotNull { participant -> participant.initialTransferGroupId } }.toSet()
@@ -169,7 +167,7 @@ fun TransactionsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 ParityFilterCapsule(
-                    label = filterLabel(filterType, selectedDate, customStartDate, customEndDate),
+                    label = sharedDateFilterLabel(filterType, selectedDate, customStartDate, customEndDate, allLabel = "全部紀錄"),
                     icon = Icons.Default.DateRange,
                     onClick = { showFilterDialog = true }
                 )
@@ -404,15 +402,15 @@ fun TransactionsScreen(
             selectedDate = selectedDate,
             customStartDate = customStartDate,
             customEndDate = customEndDate,
-            onSelectFilterType = { filterType = it },
+            onSelectFilterType = uiPreferencesStore::setDateFilterType,
             onPickSelectedDate = {
-                showDatePicker(context, selectedDate) { selectedDate = it }
+                showDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
             },
             onPickCustomStart = {
-                showDatePicker(context, customStartDate) { customStartDate = it }
+                showDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
             },
             onPickCustomEnd = {
-                showDatePicker(context, customEndDate) { customEndDate = it }
+                showDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
             },
             onDismiss = { showFilterDialog = false }
         )
@@ -438,11 +436,11 @@ private fun LedgerDateHeader(date: LocalDate) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TransactionFilterSheet(
-    filterType: DateFilterType,
+    filterType: SharedDateFilterType,
     selectedDate: LocalDate,
     customStartDate: LocalDate,
     customEndDate: LocalDate,
-    onSelectFilterType: (DateFilterType) -> Unit,
+    onSelectFilterType: (SharedDateFilterType) -> Unit,
     onPickSelectedDate: () -> Unit,
     onPickCustomStart: () -> Unit,
     onPickCustomEnd: () -> Unit,
@@ -466,7 +464,7 @@ private fun TransactionFilterSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
-            DateFilterType.values().forEach { type ->
+            SharedDateFilterType.entries.forEach { type ->
                 ParitySelectionSheetRow(
                     title = type.label,
                     subtitle = transactionFilterSubtitle(type),
@@ -476,7 +474,7 @@ private fun TransactionFilterSheet(
             }
 
             when (filterType) {
-                DateFilterType.Month, DateFilterType.Year -> {
+                SharedDateFilterType.Month, SharedDateFilterType.Year, SharedDateFilterType.Day -> {
                     PressableCard(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = onPickSelectedDate,
@@ -491,8 +489,10 @@ private fun TransactionFilterSheet(
                             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                                 Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                                 Text(
-                                    if (filterType == DateFilterType.Year) {
+                                    if (filterType == SharedDateFilterType.Year) {
                                         "${selectedDate.year}年"
+                                    } else if (filterType == SharedDateFilterType.Day) {
+                                        selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))
                                     } else {
                                         selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
                                     },
@@ -504,7 +504,7 @@ private fun TransactionFilterSheet(
                         }
                     }
                 }
-                DateFilterType.Custom -> {
+                SharedDateFilterType.Custom -> {
                     PressableCard(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = onPickCustomStart,
@@ -542,6 +542,7 @@ private fun TransactionFilterSheet(
                         }
                     }
                 }
+                SharedDateFilterType.All -> Unit
             }
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -552,11 +553,13 @@ private fun TransactionFilterSheet(
     }
 }
 
-private fun transactionFilterSubtitle(type: DateFilterType): String {
+private fun transactionFilterSubtitle(type: SharedDateFilterType): String {
     return when (type) {
-        DateFilterType.Month -> "聚焦本月帳目與代墊摘要"
-        DateFilterType.Year -> "查看本年累積的收支紀錄"
-        DateFilterType.Custom -> "自訂開始與結束日期"
+        SharedDateFilterType.All -> "查看所有帳目與代墊摘要"
+        SharedDateFilterType.Year -> "查看本年累積的收支紀錄"
+        SharedDateFilterType.Month -> "聚焦本月帳目與代墊摘要"
+        SharedDateFilterType.Day -> "只查看指定日期的明細"
+        SharedDateFilterType.Custom -> "自訂開始與結束日期"
     }
 }
 
@@ -840,51 +843,6 @@ private fun transferTintForNote(note: String): Color {
         compact.contains("(代墊給") || compact.contains("(代墊給我") -> Color(0xFFEF6C00)
         compact.contains("(還款至") || compact.contains("(還款給") -> Color(0xFF00897B)
         else -> MaterialTheme.colorScheme.onSurface
-    }
-}
-
-private fun filterLabel(
-    filterType: DateFilterType,
-    selectedDate: LocalDate,
-    customStart: LocalDate,
-    customEnd: LocalDate
-): String {
-    return when (filterType) {
-        DateFilterType.Month -> selectedDate.format(DateTimeFormatter.ofPattern("yyyy-MM"))
-        DateFilterType.Year -> selectedDate.year.toString()
-        DateFilterType.Custom -> {
-            val start = customStart
-            val end = customEnd
-            "${start.format(DateTimeFormatter.ISO_DATE)} ~ ${end.format(DateTimeFormatter.ISO_DATE)}"
-        }
-    }
-}
-
-private fun resolveDateRange(
-    filterType: DateFilterType,
-    selectedDate: LocalDate,
-    customStart: LocalDate,
-    customEnd: LocalDate
-): Pair<Instant?, Instant?> {
-    val zone = ZoneId.systemDefault()
-    return when (filterType) {
-        DateFilterType.Month -> {
-            val start = selectedDate.withDayOfMonth(1).atStartOfDay(zone).toInstant()
-            val end = selectedDate.withDayOfMonth(1).plusMonths(1).atStartOfDay(zone).toInstant()
-            start to end
-        }
-        DateFilterType.Year -> {
-            val start = LocalDate.of(selectedDate.year, 1, 1).atStartOfDay(zone).toInstant()
-            val end = LocalDate.of(selectedDate.year + 1, 1, 1).atStartOfDay(zone).toInstant()
-            start to end
-        }
-        DateFilterType.Custom -> {
-            val startDate = if (customEnd.isBefore(customStart)) customEnd else customStart
-            val endDate = if (customEnd.isBefore(customStart)) customStart else customEnd
-            val start = startDate.atStartOfDay(zone).toInstant()
-            val end = endDate.plusDays(1).atStartOfDay(zone).toInstant()
-            start to end
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a shared persisted date filter for iOS overview, ledger, and reports.
- Add the matching Android shared date filter state in local UI preferences.
- Support all/year/month/day/custom range consistently across the three period-based screens.

## Tests
- xcodebuild test -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest assembleDebug