### PR TITLE
Unify Android date filter sheet

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/SharedDateFilterSheet.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/SharedDateFilterSheet.kt
@@ -1,0 +1,172 @@
+package org.duckdns.lhfser.aiaccounting.ui.components
+
+import android.app.DatePickerDialog
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
+import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SharedDateFilterSheet(
+    title: String,
+    description: String,
+    filterType: SharedDateFilterType,
+    selectedDate: LocalDate,
+    customStartDate: LocalDate,
+    customEndDate: LocalDate,
+    onSelectFilterType: (SharedDateFilterType) -> Unit,
+    onPickSelectedDate: () -> Unit,
+    onPickCustomStart: () -> Unit,
+    onPickCustomEnd: () -> Unit,
+    onDismiss: () -> Unit,
+    allSubtitle: String,
+    yearSubtitle: String,
+    monthSubtitle: String,
+    daySubtitle: String,
+    customSubtitle: String = "自訂開始與結束日期"
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        dragHandle = { ParitySheetHandle() }
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            SharedDateFilterType.entries.forEach { type ->
+                ParitySelectionSheetRow(
+                    title = type.label,
+                    subtitle = when (type) {
+                        SharedDateFilterType.All -> allSubtitle
+                        SharedDateFilterType.Year -> yearSubtitle
+                        SharedDateFilterType.Month -> monthSubtitle
+                        SharedDateFilterType.Day -> daySubtitle
+                        SharedDateFilterType.Custom -> customSubtitle
+                    },
+                    selected = filterType == type,
+                    onClick = { onSelectFilterType(type) }
+                )
+            }
+
+            when (filterType) {
+                SharedDateFilterType.Year,
+                SharedDateFilterType.Month,
+                SharedDateFilterType.Day -> {
+                    DatePickerRow(
+                        title = "基準日期",
+                        value = selectedDateLabel(filterType, selectedDate),
+                        action = "調整",
+                        onClick = onPickSelectedDate
+                    )
+                }
+                SharedDateFilterType.Custom -> {
+                    DatePickerRow(
+                        title = "開始日期",
+                        value = customStartDate.format(DateTimeFormatter.ISO_DATE),
+                        action = "選擇",
+                        onClick = onPickCustomStart
+                    )
+                    DatePickerRow(
+                        title = "結束日期",
+                        value = customEndDate.format(DateTimeFormatter.ISO_DATE),
+                        action = "選擇",
+                        onClick = onPickCustomEnd
+                    )
+                }
+                SharedDateFilterType.All -> Unit
+            }
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text("完成") }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+fun showSharedDatePicker(
+    context: Context,
+    initialDate: LocalDate,
+    onDateSelected: (LocalDate) -> Unit
+) {
+    DatePickerDialog(
+        context,
+        { _, year, month, day ->
+            onDateSelected(LocalDate.of(year, month + 1, day))
+        },
+        initialDate.year,
+        initialDate.monthValue - 1,
+        initialDate.dayOfMonth
+    ).show()
+}
+
+@Composable
+private fun DatePickerRow(
+    title: String,
+    value: String,
+    action: String,
+    onClick: () -> Unit
+) {
+    PressableCard(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick,
+        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        pressedContainerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(
+                    value,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text(action, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+private fun selectedDateLabel(type: SharedDateFilterType, date: LocalDate): String {
+    return when (type) {
+        SharedDateFilterType.Year -> "${date.year}年"
+        SharedDateFilterType.Month -> date.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
+        SharedDateFilterType.Day -> date.format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))
+        SharedDateFilterType.All,
+        SharedDateFilterType.Custom -> date.format(DateTimeFormatter.ISO_DATE)
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -1,6 +1,5 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
-import android.app.DatePickerDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,12 +19,10 @@ import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.PieChart
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -58,6 +55,8 @@ import org.duckdns.lhfser.aiaccounting.ui.components.ParitySummaryCard
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.components.SharedDateFilterSheet
+import org.duckdns.lhfser.aiaccounting.ui.components.showSharedDatePicker
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 
@@ -81,7 +80,6 @@ fun OverviewScreen(
     val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
 
     var showFilterDialog by remember { mutableStateOf(false) }
-    var showCustomDateDialog by remember { mutableStateOf(false) }
     val dateFilter = uiPreferences.dateFilter
     val filterType = dateFilter.type
     val selectedDate = dateFilter.selectedDate
@@ -123,13 +121,7 @@ fun OverviewScreen(
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
             ParityFilterCapsule(
                 label = filterDisplayString(filterType, selectedDate, customStartDate, customEndDate),
-                onClick = {
-                    when (filterType) {
-                        SharedDateFilterType.All -> Unit
-                        SharedDateFilterType.Custom -> showCustomDateDialog = true
-                        else -> showFilterDialog = true
-                    }
-                }
+                onClick = { showFilterDialog = true }
             )
             ParitySegmentedControl(
                 options = SharedDateFilterType.entries.toList(),
@@ -138,7 +130,7 @@ fun OverviewScreen(
                 onSelect = {
                     uiPreferencesStore.setDateFilterType(it)
                     if (it == SharedDateFilterType.Custom) {
-                        showCustomDateDialog = true
+                        showFilterDialog = true
                     }
                 }
             )
@@ -284,41 +276,28 @@ fun OverviewScreen(
     }
 
     if (showFilterDialog) {
-        DatePickerDialog(
-            context,
-            { _, year, month, day ->
-                uiPreferencesStore.setDateFilterSelectedDate(LocalDate.of(year, month + 1, day))
+        SharedDateFilterSheet(
+            title = "選擇區間",
+            description = "切換總覽摘要區間，會同步套用到帳目與報表。",
+            filterType = filterType,
+            selectedDate = selectedDate,
+            customStartDate = customStartDate,
+            customEndDate = customEndDate,
+            onSelectFilterType = uiPreferencesStore::setDateFilterType,
+            onPickSelectedDate = {
+                showSharedDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
             },
-            selectedDate.year,
-            selectedDate.monthValue - 1,
-            selectedDate.dayOfMonth
-        ).show()
-        showFilterDialog = false
-    }
-
-    if (showCustomDateDialog) {
-        AlertDialog(
-            onDismissRequest = { showCustomDateDialog = false },
-            title = { androidx.compose.material3.Text("自訂區間") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)) {
-                    TextButton(onClick = {
-                        showDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
-                    }) {
-                        androidx.compose.material3.Text("開始日期：${customStartDate.format(DateTimeFormatter.ISO_DATE)}")
-                    }
-                    TextButton(onClick = {
-                        showDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
-                    }) {
-                        androidx.compose.material3.Text("結束日期：${customEndDate.format(DateTimeFormatter.ISO_DATE)}")
-                    }
-                }
+            onPickCustomStart = {
+                showSharedDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
             },
-            confirmButton = {
-                TextButton(onClick = { showCustomDateDialog = false }) {
-                    androidx.compose.material3.Text("完成")
-                }
-            }
+            onPickCustomEnd = {
+                showSharedDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
+            },
+            onDismiss = { showFilterDialog = false },
+            allSubtitle = "查看所有時間的總覽摘要",
+            yearSubtitle = "聚焦本年收入、支出與代墊",
+            monthSubtitle = "查看本月重點摘要",
+            daySubtitle = "只看當日收入、支出與代墊"
         )
     }
 }
@@ -430,20 +409,4 @@ private fun filterDisplayString(
     customEndDate: LocalDate
 ): String {
     return sharedDateFilterLabel(type, selectedDate, customStartDate, customEndDate)
-}
-
-private fun showDatePicker(
-    context: android.content.Context,
-    initialDate: LocalDate,
-    onDateSelected: (LocalDate) -> Unit
-) {
-    DatePickerDialog(
-        context,
-        { _, year, month, day ->
-            onDateSelected(LocalDate.of(year, month + 1, day))
-        },
-        initialDate.year,
-        initialDate.monthValue - 1,
-        initialDate.dayOfMonth
-    ).show()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -1,6 +1,5 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
-import android.app.DatePickerDialog
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.ui.draw.clip
@@ -69,12 +68,13 @@ import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
-import org.duckdns.lhfser.aiaccounting.ui.components.ParitySelectionSheetRow
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySegmentedControl
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySheetHandle
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.components.SharedDateFilterSheet
+import org.duckdns.lhfser.aiaccounting.ui.components.showSharedDatePicker
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
@@ -301,22 +301,28 @@ fun ReportsScreen() {
     }
 
     if (showFilterDialog) {
-        ReportFilterSheet(
+        SharedDateFilterSheet(
+            title = "選擇區間",
+            description = "切換報表統計區間，日期選擇維持和 iOS 一樣的片段化流程。",
             filterType = filterType,
             selectedDate = selectedDate,
             customStartDate = customStartDate,
             customEndDate = customEndDate,
             onSelectFilterType = uiPreferencesStore::setDateFilterType,
-            onPickDate = {
-                showDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
+            onPickSelectedDate = {
+                showSharedDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
             },
             onPickCustomStart = {
-                showDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
+                showSharedDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
             },
             onPickCustomEnd = {
-                showDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
+                showSharedDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
             },
-            onDismiss = { showFilterDialog = false }
+            onDismiss = { showFilterDialog = false },
+            allSubtitle = "查看所有時間的累積統計",
+            yearSubtitle = "聚焦本年收入與支出",
+            monthSubtitle = "查看本月分類與標籤分佈",
+            daySubtitle = "只看當日收支"
         )
     }
 
@@ -330,126 +336,6 @@ fun ReportsScreen() {
         ) {
             ReportDetailSheet(detail = reportDetail ?: return@ModalBottomSheet)
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ReportFilterSheet(
-    filterType: SharedDateFilterType,
-    selectedDate: LocalDate,
-    customStartDate: LocalDate,
-    customEndDate: LocalDate,
-    onSelectFilterType: (SharedDateFilterType) -> Unit,
-    onPickDate: () -> Unit,
-    onPickCustomStart: () -> Unit,
-    onPickCustomEnd: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background,
-        dragHandle = { ParitySheetHandle() }
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Text("選擇區間", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Text(
-                "切換報表統計區間，日期選擇維持和 iOS 一樣的片段化流程。",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            SharedDateFilterType.entries.forEach { type ->
-                ParitySelectionSheetRow(
-                    title = type.label,
-                    subtitle = reportFilterSubtitle(type),
-                    selected = filterType == type,
-                    onClick = { onSelectFilterType(type) }
-                )
-            }
-
-            when (filterType) {
-                SharedDateFilterType.Year, SharedDateFilterType.Month, SharedDateFilterType.Day -> {
-                    PressableCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onPickDate,
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        pressedContainerColor = MaterialTheme.colorScheme.surface
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                                Text(selectedDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Text("調整", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                }
-                SharedDateFilterType.Custom -> {
-                    PressableCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onPickCustomStart,
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        pressedContainerColor = MaterialTheme.colorScheme.surface
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                Text("開始日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                                Text(customStartDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                    PressableCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onPickCustomEnd,
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        pressedContainerColor = MaterialTheme.colorScheme.surface
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                Text("結束日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                                Text(customEndDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                }
-                SharedDateFilterType.All -> Unit
-            }
-
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(onClick = onDismiss) { Text("完成") }
-            }
-            Spacer(modifier = Modifier.size(8.dp))
-        }
-    }
-}
-
-private fun reportFilterSubtitle(type: SharedDateFilterType): String {
-    return when (type) {
-        SharedDateFilterType.All -> "查看所有時間的累積統計"
-        SharedDateFilterType.Year -> "聚焦本年收入與支出"
-        SharedDateFilterType.Month -> "查看本月分類與標籤分佈"
-        SharedDateFilterType.Day -> "只看當日收支"
-        SharedDateFilterType.Custom -> "自訂開始與結束日期"
     }
 }
 
@@ -861,16 +747,4 @@ private fun buildBudgetAlerts(
             BudgetAlert(budget = budget, remaining = remaining, categoryName = name)
         } else null
     }
-}
-
-private fun showDatePicker(context: android.content.Context, initial: LocalDate, onPicked: (LocalDate) -> Unit) {
-    DatePickerDialog(
-        context,
-        { _, year, month, day ->
-            onPicked(LocalDate.of(year, month + 1, day))
-        },
-        initial.year,
-        initial.monthValue - 1,
-        initial.dayOfMonth
-    ).show()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -1,6 +1,5 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
-import android.app.DatePickerDialog
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -25,11 +24,9 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -52,7 +49,6 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
-import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
 import org.duckdns.lhfser.aiaccounting.core.preferences.resolveSharedDateRange
 import org.duckdns.lhfser.aiaccounting.core.preferences.sharedDateFilterLabel
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
@@ -66,12 +62,12 @@ import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySearchField
-import org.duckdns.lhfser.aiaccounting.ui.components.ParitySelectionSheetRow
-import org.duckdns.lhfser.aiaccounting.ui.components.ParitySheetHandle
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTokens
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityTopSection
 import org.duckdns.lhfser.aiaccounting.ui.components.PressableCard
+import org.duckdns.lhfser.aiaccounting.ui.components.SharedDateFilterSheet
+import org.duckdns.lhfser.aiaccounting.ui.components.showSharedDatePicker
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
@@ -397,22 +393,28 @@ fun TransactionsScreen(
     }
 
     if (showFilterDialog) {
-        TransactionFilterSheet(
+        SharedDateFilterSheet(
+            title = "篩選區間",
+            description = "選擇要在帳目頁固定顯示的日期範圍。",
             filterType = filterType,
             selectedDate = selectedDate,
             customStartDate = customStartDate,
             customEndDate = customEndDate,
             onSelectFilterType = uiPreferencesStore::setDateFilterType,
             onPickSelectedDate = {
-                showDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
+                showSharedDatePicker(context, selectedDate, uiPreferencesStore::setDateFilterSelectedDate)
             },
             onPickCustomStart = {
-                showDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
+                showSharedDatePicker(context, customStartDate, uiPreferencesStore::setDateFilterCustomStartDate)
             },
             onPickCustomEnd = {
-                showDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
+                showSharedDatePicker(context, customEndDate, uiPreferencesStore::setDateFilterCustomEndDate)
             },
-            onDismiss = { showFilterDialog = false }
+            onDismiss = { showFilterDialog = false },
+            allSubtitle = "查看所有帳目與代墊摘要",
+            yearSubtitle = "查看本年累積的收支紀錄",
+            monthSubtitle = "聚焦本月帳目與代墊摘要",
+            daySubtitle = "只查看指定日期的明細"
         )
     }
 }
@@ -430,136 +432,6 @@ private fun LedgerDateHeader(date: LocalDate) {
             modifier = Modifier.padding(vertical = 8.dp),
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun TransactionFilterSheet(
-    filterType: SharedDateFilterType,
-    selectedDate: LocalDate,
-    customStartDate: LocalDate,
-    customEndDate: LocalDate,
-    onSelectFilterType: (SharedDateFilterType) -> Unit,
-    onPickSelectedDate: () -> Unit,
-    onPickCustomStart: () -> Unit,
-    onPickCustomEnd: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background,
-        dragHandle = { ParitySheetHandle() }
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Text("篩選區間", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Text(
-                "選擇要在帳目頁固定顯示的日期範圍。",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            SharedDateFilterType.entries.forEach { type ->
-                ParitySelectionSheetRow(
-                    title = type.label,
-                    subtitle = transactionFilterSubtitle(type),
-                    selected = filterType == type,
-                    onClick = { onSelectFilterType(type) }
-                )
-            }
-
-            when (filterType) {
-                SharedDateFilterType.Month, SharedDateFilterType.Year, SharedDateFilterType.Day -> {
-                    PressableCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onPickSelectedDate,
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        pressedContainerColor = MaterialTheme.colorScheme.surface
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                Text("基準日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                                Text(
-                                    if (filterType == SharedDateFilterType.Year) {
-                                        "${selectedDate.year}年"
-                                    } else if (filterType == SharedDateFilterType.Day) {
-                                        selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月d日"))
-                                    } else {
-                                        selectedDate.format(DateTimeFormatter.ofPattern("yyyy年 M月"))
-                                    },
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            Text("調整", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                }
-                SharedDateFilterType.Custom -> {
-                    PressableCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onPickCustomStart,
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        pressedContainerColor = MaterialTheme.colorScheme.surface
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                Text("開始日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                                Text(customStartDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                    PressableCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = onPickCustomEnd,
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        pressedContainerColor = MaterialTheme.colorScheme.surface
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                Text("結束日期", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                                Text(customEndDate.format(DateTimeFormatter.ISO_DATE), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Text("選擇", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                        }
-                    }
-                }
-                SharedDateFilterType.All -> Unit
-            }
-
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(onClick = onDismiss) { Text("完成") }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-    }
-}
-
-private fun transactionFilterSubtitle(type: SharedDateFilterType): String {
-    return when (type) {
-        SharedDateFilterType.All -> "查看所有帳目與代墊摘要"
-        SharedDateFilterType.Year -> "查看本年累積的收支紀錄"
-        SharedDateFilterType.Month -> "聚焦本月帳目與代墊摘要"
-        SharedDateFilterType.Day -> "只查看指定日期的明細"
-        SharedDateFilterType.Custom -> "自訂開始與結束日期"
     }
 }
 
@@ -899,22 +771,6 @@ private fun buildLedgerItems(
 ): List<LedgerItem> {
     return (transactions.map { LedgerItem.TransactionEntry(it) } + advanceCases.map { LedgerItem.AdvanceSummary(it) })
         .sortedByDescending { it.date }
-}
-
-private fun showDatePicker(
-    context: android.content.Context,
-    initialDate: LocalDate,
-    onSelected: (LocalDate) -> Unit
-) {
-    DatePickerDialog(
-        context,
-        { _, year, month, day ->
-            onSelected(LocalDate.of(year, month + 1, day))
-        },
-        initialDate.year,
-        initialDate.monthValue - 1,
-        initialDate.dayOfMonth
-    ).show()
 }
 
 private fun formatHeaderDate(date: LocalDate): String {


### PR DESCRIPTION
## Summary
- Add a shared Android date filter bottom sheet component.
- Reuse the same sheet from overview, ledger, and reports.
- Replace the overview custom-range dialog with the shared date filter flow.

## Tests
- ./gradlew testDebugUnitTest assembleDebug

## Notes
- Local Localizable.xcstrings changes were intentionally not included.