### PR TITLE
Add backup data safety regression tests

### DIFF
--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -84,6 +84,142 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(0, secondReport.errorCount)
     }
 
+    func testExportImport_preservesSameAccountCrossCurrencyTransferAndBudgetHistory_excludesUIPreferences() async throws {
+        UserDefaults.standard.set("All", forKey: "sharedDateFilterType")
+        UserDefaults.standard.set("2026-03-01T00:00:00Z", forKey: "sharedDateFilterCustomStartDate")
+        UserDefaults.standard.set("2026-03-31T23:59:59Z", forKey: "sharedDateFilterCustomEndDate")
+        UserDefaults.standard.set(false, forKey: "pinLedgerControls")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "sharedDateFilterType")
+            UserDefaults.standard.removeObject(forKey: "sharedDateFilterCustomStartDate")
+            UserDefaults.standard.removeObject(forKey: "sharedDateFilterCustomEndDate")
+            UserDefaults.standard.removeObject(forKey: "pinLedgerControls")
+        }
+
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+
+        let accountID = UUID(uuidString: "aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa")!
+        let categoryID = UUID(uuidString: "bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb")!
+        let groupID = UUID(uuidString: "cccccccc-3333-3333-3333-cccccccccccc")!
+        let outgoingID = UUID(uuidString: "dddddddd-4444-4444-4444-dddddddddddd")!
+        let incomingID = UUID(uuidString: "eeeeeeee-5555-5555-5555-eeeeeeeeeeee")!
+        let historyID = UUID(uuidString: "ffffffff-6666-6666-6666-ffffffffffff")!
+        let expenseID = UUID(uuidString: "99999999-7777-7777-7777-999999999999")!
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-15T12:34:00Z"))
+
+        let account = Account(
+            id: accountID,
+            name: "Multi-currency bank",
+            currency: "HKD",
+            type: .bank,
+            baseBalance: 0,
+            sortOrder: 0
+        )
+        let category = Category(
+            id: categoryID,
+            name: "Food",
+            icon: "fork.knife",
+            colorHex: "#FF8800",
+            kind: .expense
+        )
+        let outgoing = FinancialTransaction(
+            id: outgoingID,
+            amount: -100,
+            currencyCode: "HKD",
+            date: date,
+            note: "同帳戶跨幣種兌換",
+            type: .transfer,
+            linkedTransactionID: incomingID,
+            transferGroupID: groupID,
+            transferSide: .outgoing,
+            account: account
+        )
+        let incoming = FinancialTransaction(
+            id: incomingID,
+            amount: 92,
+            currencyCode: "CNY",
+            date: date,
+            note: "同帳戶跨幣種兌換",
+            type: .transfer,
+            linkedTransactionID: outgoingID,
+            transferGroupID: groupID,
+            transferSide: .incoming,
+            account: account
+        )
+        let expense = FinancialTransaction(
+            id: expenseID,
+            amount: -128.5,
+            currencyCode: "HKD",
+            date: date,
+            note: "Budget history sample",
+            type: .expense,
+            account: account,
+            category: category
+        )
+        let budget = CategoryMonthlyBudget(
+            monthKey: "2026-03",
+            amount: 3000,
+            currencyCode: "HKD",
+            isEnabled: true,
+            category: category
+        )
+        let history = BudgetMonthlyHistory(
+            id: historyID,
+            historyKey: "2026-03|\(categoryID.uuidString)",
+            monthKey: "2026-03",
+            categoryID: categoryID,
+            categoryNameSnapshot: "Food",
+            budgetAmount: 3000,
+            spentAmount: 128.5,
+            remainingAmount: 2871.5,
+            usageRatio: Decimal(string: "0.042833")!,
+            isOverBudget: false,
+            currencyCode: "HKD",
+            updatedAt: date
+        )
+
+        modelContext.insert(account)
+        modelContext.insert(category)
+        modelContext.insert(outgoing)
+        modelContext.insert(incoming)
+        modelContext.insert(expense)
+        modelContext.insert(budget)
+        modelContext.insert(history)
+        try modelContext.save()
+
+        let exported = BackupManager.shared.createBackupData(modelContext: modelContext)
+        XCTAssertEqual(3, exported.transactions.count)
+        XCTAssertEqual(1, exported.budgetHistory?.count)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let jsonData = try encoder.encode(exported)
+        let jsonString = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+        XCTAssertFalse(jsonString.contains("sharedDateFilter"))
+        XCTAssertFalse(jsonString.contains("pinLedgerControls"))
+
+        let secondContainer = try makeInMemoryContainer()
+        let secondContext = ModelContext(secondContainer)
+        let exportedURL = try writeBackup(exported, named: "same-account-cross-currency-roundtrip.json")
+        try await BackupManager.shared.restoreFromJSON(url: exportedURL, modelContext: secondContext)
+
+        let roundTrippedTransactions = try secondContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let transferGroup = roundTrippedTransactions.filter { $0.transferGroupID == groupID }
+        XCTAssertEqual(2, transferGroup.count)
+        XCTAssertEqual(Set([accountID]), Set(transferGroup.compactMap { $0.account?.id }))
+        XCTAssertEqual(Set(["HKD", "CNY"]), Set(transferGroup.map(\.currencyCode)))
+        XCTAssertEqual(incomingID, transferGroup.first(where: { $0.id == outgoingID })?.linkedTransactionID)
+        XCTAssertEqual(outgoingID, transferGroup.first(where: { $0.id == incomingID })?.linkedTransactionID)
+        XCTAssertEqual(.outgoing, transferGroup.first(where: { $0.id == outgoingID })?.transferSide)
+        XCTAssertEqual(.incoming, transferGroup.first(where: { $0.id == incomingID })?.transferSide)
+
+        let histories = try secondContext.fetch(FetchDescriptor<BudgetMonthlyHistory>())
+        XCTAssertEqual(1, histories.count)
+        XCTAssertEqual("2026-03|\(categoryID.uuidString)", histories.first?.historyKey)
+        XCTAssertEqual(Decimal(string: "128.5"), histories.first?.spentAmount)
+    }
+
     private func makeInMemoryContainer() throws -> ModelContainer {
         let schema = Schema([
             Account.self,

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -12,8 +12,10 @@ import org.duckdns.lhfser.aiaccounting.data.backup.BackupJsonAdapter
 import org.duckdns.lhfser.aiaccounting.data.backup.FullBackupData
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -145,6 +147,116 @@ class BackupRoundTripTest {
             assertFalse(secondReport.issues.any { it.title == "收入交易記到了借貸帳戶" })
             assertFalse(secondReport.issues.any { it.title == "收入捷徑綁到了借貸帳戶" })
             assertEquals(0, secondReport.errorCount)
+        } finally {
+            secondDatabase.close()
+        }
+    }
+
+    @Test
+    fun sameAccountCrossCurrencyTransferAndBudgetHistory_exportReimport_preservesDataAndExcludesUiPreferences() = runBlocking {
+        val accountId = UUID.fromString("aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa")
+        val categoryId = UUID.fromString("bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb")
+        val expenseId = UUID.fromString("cccccccc-3333-3333-3333-cccccccccccc")
+        val transferDate = Instant.parse("2026-03-15T12:34:00Z")
+        val expenseDate = Instant.parse("2026-03-20T08:00:00Z")
+
+        val account = AccountEntity(
+            id = accountId,
+            name = "Multi-currency bank",
+            currency = "HKD",
+            type = AccountType.Bank,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val category = CategoryEntity(
+            id = categoryId,
+            name = "Food",
+            icon = "fork.knife",
+            colorHex = "#FF8800",
+            kind = CategoryKind.Expense
+        )
+        database.accountDao().upsert(account)
+        database.categoryDao().upsert(category)
+
+        repository.createTransferOneToOne(
+            from = account,
+            to = account,
+            amountOut = BigDecimal("100"),
+            currencyOut = "HKD",
+            amountIn = BigDecimal("92"),
+            currencyIn = "CNY",
+            date = transferDate,
+            note = "同帳戶跨幣種兌換"
+        )
+        repository.upsertBudget(
+            CategoryMonthlyBudgetEntity(
+                id = UUID.randomUUID(),
+                monthKey = "2026-03",
+                amount = BigDecimal("3000"),
+                currencyCode = "HKD",
+                isEnabled = true,
+                createdAt = transferDate,
+                updatedAt = transferDate,
+                categoryId = categoryId
+            )
+        )
+        repository.upsertTransaction(
+            TransactionEntity(
+                id = expenseId,
+                amount = BigDecimal("-128.50"),
+                currencyCode = "HKD",
+                date = expenseDate,
+                note = "Budget history sample",
+                photoPath = null,
+                type = TransactionType.Expense,
+                linkedTransactionId = null,
+                transferGroupId = null,
+                transferSide = null,
+                createdAt = expenseDate,
+                updatedAt = expenseDate,
+                accountId = accountId,
+                categoryId = categoryId
+            ),
+            tagIds = emptyList()
+        )
+
+        val exportedJson = repository.exportBackupJson()
+        assertFalse(exportedJson.contains("sharedDateFilter"))
+        assertFalse(exportedJson.contains("dateFilterType"))
+        assertFalse(exportedJson.contains("pinLedgerControls"))
+
+        val exported = BackupJsonAdapter.gson.fromJson(exportedJson, FullBackupData::class.java)
+        val sameAccountTransfer = exported.transactions
+            .filter { it.type == "Transfer" }
+            .groupBy { it.transferGroupID }
+            .values
+            .single { it.size == 2 }
+        assertEquals(setOf(accountId), sameAccountTransfer.mapNotNull { it.accountID }.toSet())
+        assertEquals(setOf("HKD", "CNY"), sameAccountTransfer.map { it.currencyCode }.toSet())
+        assertEquals(setOf("Outgoing", "Incoming"), sameAccountTransfer.mapNotNull { it.transferSide }.toSet())
+        assertEquals(
+            "128.50",
+            exported.budgetHistory?.single()?.spentAmount?.setScale(2)?.toPlainString()
+        )
+
+        val secondDatabase = buildDatabase()
+        try {
+            val secondRepository = AccountingRepository(secondDatabase, currencyService)
+            secondRepository.importBackupJson(exportedJson, replaceExisting = true)
+            val roundTrip = BackupJsonAdapter.gson.fromJson(secondRepository.exportBackupJson(), FullBackupData::class.java)
+            val roundTripTransfer = roundTrip.transactions
+                .filter { it.type == "Transfer" }
+                .groupBy { it.transferGroupID }
+                .values
+                .single { it.size == 2 }
+
+            assertEquals(setOf(accountId), roundTripTransfer.mapNotNull { it.accountID }.toSet())
+            assertEquals(setOf("HKD", "CNY"), roundTripTransfer.map { it.currencyCode }.toSet())
+            assertEquals(
+                "128.50",
+                roundTrip.budgetHistory?.single()?.spentAmount?.setScale(2)?.toPlainString()
+            )
         } finally {
             secondDatabase.close()
         }


### PR DESCRIPTION
## Summary
- add iOS backup roundtrip regression coverage for same-account cross-currency transfers, budget history, and UI preference exclusion
- add Android Room/repository backup regression coverage for the same account/currency/budget-history contract
- keep this as test-only data safety coverage with no app behavior or schema changes

## Tests
- xcodebuild test -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest
- ./gradlew assembleDebug