### PR TITLE
Allow optional WebDAV backup encryption

### DIFF
--- a/AI 記帳/Services/RemoteBackupService.swift
+++ b/AI 記帳/Services/RemoteBackupService.swift
@@ -7,6 +7,27 @@ struct WebDAVCredentials {
     let username: String
     let password: String
     let passphrase: String
+
+    var hasPassphrase: Bool {
+        !passphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+enum RemoteBackupFormat: String, Hashable {
+    case encrypted
+    case plainJSON
+    case unknown
+
+    var displayName: String {
+        switch self {
+        case .encrypted:
+            "已加密"
+        case .plainJSON:
+            "未加密"
+        case .unknown:
+            "未知格式"
+        }
+    }
 }
 
 struct RemoteBackupFile: Identifiable, Hashable {
@@ -15,6 +36,7 @@ struct RemoteBackupFile: Identifiable, Hashable {
     let url: URL
     let size: Int?
     let modifiedAt: Date?
+    let format: RemoteBackupFormat
 }
 
 struct RemoteBackupPreview {
@@ -35,9 +57,11 @@ private struct EncryptedBackupEnvelope: Codable {
 enum RemoteBackupError: LocalizedError {
     case invalidURL
     case invalidCredentials
+    case missingPassphrase
     case invalidResponse
     case httpStatus(Int)
     case invalidEnvelope
+    case unsupportedBackupFormat
     case decryptFailed
     case keyDerivationFailed
 
@@ -46,13 +70,17 @@ enum RemoteBackupError: LocalizedError {
         case .invalidURL:
             "WebDAV URL 無效。"
         case .invalidCredentials:
-            "請先填寫 WebDAV URL、帳戶、密碼與加密 passphrase。"
+            "請先填寫 WebDAV URL、帳戶與密碼。"
+        case .missingPassphrase:
+            "此操作需要加密 passphrase。"
         case .invalidResponse:
             "WebDAV 回應無效。"
         case .httpStatus(let status):
             "WebDAV 回應錯誤：HTTP \(status)。"
         case .invalidEnvelope:
             "遠端備份格式無效。"
+        case .unsupportedBackupFormat:
+            "遠端備份格式不支援。"
         case .decryptFailed:
             "無法解密備份，請確認 passphrase 是否正確。"
         case .keyDerivationFailed:
@@ -65,6 +93,7 @@ final class RemoteBackupService {
     static let shared = RemoteBackupService()
 
     private let backupExtension = "aibackup"
+    private let plainBackupExtension = "json"
     private let keyDerivationIterations: UInt32 = 120_000
     private let gcmTagByteCount = 16
 
@@ -90,17 +119,28 @@ final class RemoteBackupService {
         return parseBackupFiles(from: xml, baseURL: credentials.baseURL)
     }
 
-    func uploadBackup(jsonData: Data, credentials: WebDAVCredentials) async throws -> RemoteBackupFile {
-        let encrypted = try encrypt(jsonData, passphrase: credentials.passphrase)
-        let filename = "AIAccounting_Backup_\(Self.filenameDateFormatter.string(from: Date())).\(backupExtension)"
+    func uploadBackup(jsonData: Data, credentials: WebDAVCredentials, encrypt shouldEncrypt: Bool) async throws -> RemoteBackupFile {
+        if shouldEncrypt, !credentials.hasPassphrase {
+            throw RemoteBackupError.missingPassphrase
+        }
+
+        let payload = shouldEncrypt ? try encrypt(jsonData, passphrase: credentials.passphrase) : jsonData
+        let fileExtension = shouldEncrypt ? backupExtension : plainBackupExtension
+        let filename = "AIAccounting_Backup_\(Self.filenameDateFormatter.string(from: Date())).\(fileExtension)"
         let targetURL = credentials.baseURL.appendingPathComponent(filename)
         var request = try makeRequest(credentials: credentials, url: targetURL)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = encrypted
+        request.httpBody = payload
         let (_, response) = try await URLSession.shared.data(for: request)
         try validate(response: response, accepted: [200, 201, 204])
-        return RemoteBackupFile(name: filename, url: targetURL, size: encrypted.count, modifiedAt: Date())
+        return RemoteBackupFile(
+            name: filename,
+            url: targetURL,
+            size: payload.count,
+            modifiedAt: Date(),
+            format: shouldEncrypt ? .encrypted : .plainJSON
+        )
     }
 
     func downloadBackup(_ file: RemoteBackupFile, credentials: WebDAVCredentials) async throws -> Data {
@@ -108,7 +148,17 @@ final class RemoteBackupService {
         request.httpMethod = "GET"
         let (data, response) = try await URLSession.shared.data(for: request)
         try validate(response: response, accepted: [200])
-        return try decrypt(data, passphrase: credentials.passphrase)
+        switch detectedFormat(for: file, data: data) {
+        case .encrypted:
+            guard credentials.hasPassphrase else {
+                throw RemoteBackupError.missingPassphrase
+            }
+            return try decrypt(data, passphrase: credentials.passphrase)
+        case .plainJSON:
+            return data
+        case .unknown:
+            throw RemoteBackupError.unsupportedBackupFormat
+        }
     }
 
     func makePreview(from backup: FullBackupData) -> RemoteBackupPreview {
@@ -247,10 +297,37 @@ final class RemoteBackupService {
                 .replacingOccurrences(of: "&amp;", with: "&")
                 .removingPercentEncoding ?? rawHref
             let name = (decoded as NSString).lastPathComponent
-            guard name.hasSuffix(".\(backupExtension)") else { return nil }
-            return RemoteBackupFile(name: name, url: baseURL.appendingPathComponent(name), size: nil, modifiedAt: nil)
+            let format = formatFromFilename(name)
+            guard format != .unknown else { return nil }
+            return RemoteBackupFile(name: name, url: baseURL.appendingPathComponent(name), size: nil, modifiedAt: nil, format: format)
         }
         .sorted { $0.name > $1.name }
+    }
+
+    private func detectedFormat(for file: RemoteBackupFile, data: Data) -> RemoteBackupFormat {
+        let filenameFormat = formatFromFilename(file.name)
+        if filenameFormat != .unknown {
+            return filenameFormat
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        if (try? decoder.decode(EncryptedBackupEnvelope.self, from: data)) != nil {
+            return .encrypted
+        }
+        if (try? JSONSerialization.jsonObject(with: data)) != nil {
+            return .plainJSON
+        }
+        return .unknown
+    }
+
+    private func formatFromFilename(_ name: String) -> RemoteBackupFormat {
+        if name.hasSuffix(".\(backupExtension)") {
+            return .encrypted
+        }
+        if name.hasPrefix("AIAccounting_Backup_"), name.hasSuffix(".\(plainBackupExtension)") {
+            return .plainJSON
+        }
+        return .unknown
     }
 
     private func matches(pattern: String, in text: String) -> [String] {

--- a/AI 記帳/Views/Settings/RemoteBackupView.swift
+++ b/AI 記帳/Views/Settings/RemoteBackupView.swift
@@ -5,6 +5,8 @@ struct RemoteBackupView: View {
     @Environment(\.modelContext) private var modelContext
     @AppStorage("webdavBackupURL") private var webdavURL: String = ""
     @AppStorage("webdavBackupUsername") private var webdavUsername: String = ""
+    @AppStorage("encryptRemoteBackups") private var encryptRemoteBackups = true
+    @AppStorage("didConfirmPlainWebDAVBackup") private var didConfirmPlainWebDAVBackup = false
 
     @State private var webdavPassword: String = ""
     @State private var backupPassphrase: String = ""
@@ -14,11 +16,21 @@ struct RemoteBackupView: View {
     @State private var preview: RemoteBackupPreview?
     @State private var pendingRestoreBackup: FullBackupData?
     @State private var showingRestoreConfirm = false
+    @State private var showingPlainBackupConfirm = false
+    @State private var showingHTTPRiskConfirm = false
+    @State private var pendingHTTPAction: RemoteAction?
 
     private let service = RemoteBackupService.shared
     private let keychainServiceName = "org.duckdns.lhfser.AIMoney.webdav"
     private let passwordAccountName = "webdav_password"
     private let passphraseAccountName = "backup_passphrase"
+
+    private enum RemoteAction {
+        case testConnection
+        case uploadBackup
+        case refreshList
+        case loadPreview(RemoteBackupFile)
+    }
 
     var body: some View {
         List {
@@ -31,34 +43,39 @@ struct RemoteBackupView: View {
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled(true)
                 SecureField("WebDAV 密碼", text: $webdavPassword)
-                SecureField("備份加密 passphrase", text: $backupPassphrase)
+                Toggle("加密遠端備份（建議）", isOn: $encryptRemoteBackups)
+                SecureField(
+                    encryptRemoteBackups ? "備份加密 passphrase" : "加密 passphrase（還原加密備份時需要）",
+                    text: $backupPassphrase
+                )
+                Text(encryptRemoteBackups ? "上傳會使用 AES-GCM 加密，檔案副檔名為 .aibackup。" : "未加密備份會以 .json 上傳，雲端可直接讀取你的財務資料。")
+                    .font(.caption)
+                    .foregroundStyle(encryptRemoteBackups ? Color.secondary : Color.orange)
                 Button {
                     saveSecrets()
-                    run("連線測試成功") {
-                        try await service.testConnection(credentials: credentials())
-                    }
+                    perform(.testConnection)
                 } label: {
                     Label("測試連線", systemImage: "network")
                 }
-                .disabled(isBusy || !canUseRemoteBackup)
+                .disabled(isBusy || !canConnect)
             }
 
             Section("遠端備份") {
                 Button {
                     saveSecrets()
-                    uploadBackup()
+                    requestUploadBackup()
                 } label: {
-                    Label("加密並上傳目前備份", systemImage: "icloud.and.arrow.up")
+                    Label(encryptRemoteBackups ? "加密並上傳目前備份" : "未加密上傳目前備份", systemImage: "icloud.and.arrow.up")
                 }
-                .disabled(isBusy || !canUseRemoteBackup)
+                .disabled(isBusy || !canUpload)
 
                 Button {
                     saveSecrets()
-                    refreshList()
+                    perform(.refreshList)
                 } label: {
                     Label("重新載入遠端備份", systemImage: "arrow.clockwise")
                 }
-                .disabled(isBusy || !canUseRemoteBackup)
+                .disabled(isBusy || !canConnect)
 
                 if let message {
                     Text(message)
@@ -80,6 +97,9 @@ struct RemoteBackupView: View {
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(file.name)
                                         .foregroundStyle(.primary)
+                                    Text(file.format.displayName)
+                                        .font(.caption2)
+                                        .foregroundStyle(file.format == .plainJSON ? Color.orange : Color.secondary)
                                     if let size = file.size {
                                         Text("\(size) bytes")
                                             .font(.caption)
@@ -119,13 +139,43 @@ struct RemoteBackupView: View {
         } message: {
             Text("這會以遠端備份覆蓋目前資料庫。建議先確認你已有本地備份。")
         }
+        .alert("上傳未加密備份？", isPresented: $showingPlainBackupConfirm) {
+            Button("取消", role: .cancel) {}
+            Button("未加密上傳", role: .destructive) {
+                didConfirmPlainWebDAVBackup = true
+                perform(.uploadBackup)
+            }
+        } message: {
+            Text("未加密 JSON 會包含帳戶、交易、備註、分類和標籤等資料。只有在你信任這個雲端儲存位置時才建議使用。")
+        }
+        .alert("HTTP 連線不安全", isPresented: $showingHTTPRiskConfirm) {
+            Button("取消", role: .cancel) {
+                pendingHTTPAction = nil
+            }
+            Button("仍然繼續", role: .destructive) {
+                let action = pendingHTTPAction
+                pendingHTTPAction = nil
+                if let action {
+                    perform(action, allowInsecureHTTP: true)
+                }
+            }
+        } message: {
+            Text(encryptRemoteBackups ? "目前 WebDAV URL 使用 http://，傳輸途中可能被讀取或竄改。確定要繼續？" : "目前 WebDAV URL 使用 http://，而且你正在使用未加密備份；傳輸途中和雲端上都可能暴露財務資料。確定要繼續？")
+        }
     }
 
-    private var canUseRemoteBackup: Bool {
+    private var canConnect: Bool {
         !webdavURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
             !webdavUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-            !webdavPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-            !backupPassphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            !webdavPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var hasPassphrase: Bool {
+        !backupPassphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var canUpload: Bool {
+        canConnect && (!encryptRemoteBackups || hasPassphrase)
     }
 
     private func loadSecrets() {
@@ -138,12 +188,15 @@ struct RemoteBackupView: View {
         _ = KeychainService.shared.save(service: keychainServiceName, account: passphraseAccountName, value: backupPassphrase)
     }
 
-    private func credentials() throws -> WebDAVCredentials {
+    private func credentials(requirePassphrase: Bool = false) throws -> WebDAVCredentials {
         guard let url = URL(string: webdavURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             throw RemoteBackupError.invalidURL
         }
-        guard canUseRemoteBackup else {
+        guard canConnect else {
             throw RemoteBackupError.invalidCredentials
+        }
+        guard !requirePassphrase || hasPassphrase else {
+            throw RemoteBackupError.missingPassphrase
         }
         return WebDAVCredentials(
             baseURL: url,
@@ -153,8 +206,46 @@ struct RemoteBackupView: View {
         )
     }
 
+    private func requestUploadBackup() {
+        if !encryptRemoteBackups, !didConfirmPlainWebDAVBackup {
+            showingPlainBackupConfirm = true
+            return
+        }
+        perform(.uploadBackup)
+    }
+
+    private func perform(_ action: RemoteAction, allowInsecureHTTP: Bool = false) {
+        guard canConnect else {
+            message = RemoteBackupError.invalidCredentials.localizedDescription
+            return
+        }
+        if !allowInsecureHTTP, isInsecureHTTP {
+            pendingHTTPAction = action
+            showingHTTPRiskConfirm = true
+            return
+        }
+
+        switch action {
+        case .testConnection:
+            run("連線測試成功") {
+                try await service.testConnection(credentials: credentials())
+            }
+        case .uploadBackup:
+            uploadBackup()
+        case .refreshList:
+            refreshList()
+        case .loadPreview(let file):
+            loadPreview(file)
+        }
+    }
+
+    private var isInsecureHTTP: Bool {
+        webdavURL.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("http://")
+    }
+
     private func uploadBackup() {
-        run("上傳完成") {
+        let shouldEncrypt = encryptRemoteBackups
+        run(shouldEncrypt ? "加密上傳完成" : "未加密上傳完成") {
             let backup = await MainActor.run {
                 BackupManager.shared.createBackupData(modelContext: modelContext)
             }
@@ -162,7 +253,7 @@ struct RemoteBackupView: View {
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let data = try encoder.encode(backup)
-            _ = try await service.uploadBackup(jsonData: data, credentials: credentials())
+            _ = try await service.uploadBackup(jsonData: data, credentials: credentials(requirePassphrase: shouldEncrypt), encrypt: shouldEncrypt)
             let remoteFiles = try await service.listBackups(credentials: credentials())
             await MainActor.run {
                 files = remoteFiles
@@ -180,8 +271,8 @@ struct RemoteBackupView: View {
     }
 
     private func loadPreview(_ file: RemoteBackupFile) {
-        run("已下載並解密備份") {
-            let data = try await service.downloadBackup(file, credentials: credentials())
+        run("已下載並讀取備份") {
+            let data = try await service.downloadBackup(file, credentials: credentials(requirePassphrase: file.format == .encrypted))
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             let backup = try decoder.decode(FullBackupData.self, from: data)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/backup/RemoteBackupService.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/backup/RemoteBackupService.kt
@@ -30,14 +30,27 @@ data class WebDavCredentials(
     val password: String,
     val passphrase: String
 ) {
-    val isComplete: Boolean
-        get() = baseUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank() && passphrase.isNotBlank()
+    val isConnectionComplete: Boolean
+        get() = baseUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank()
+
+    val hasPassphrase: Boolean
+        get() = passphrase.isNotBlank()
+}
+
+enum class RemoteBackupFormat(val label: String) {
+    ENCRYPTED("已加密"),
+    PLAIN_JSON("未加密"),
+    UNKNOWN("未知格式")
 }
 
 data class RemoteBackupFile(
     val name: String,
-    val url: String
-)
+    val url: String,
+    val format: RemoteBackupFormat
+) {
+    val isEncrypted: Boolean
+        get() = format == RemoteBackupFormat.ENCRYPTED
+}
 
 data class RemoteBackupPreview(
     val title: String,
@@ -60,6 +73,7 @@ class RemoteBackupService(
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val xmlMediaType = "application/xml; charset=utf-8".toMediaType()
     private val backupExtension = "aibackup"
+    private val plainBackupExtension = "json"
 
     suspend fun testConnection(credentials: WebDavCredentials) = withContext(Dispatchers.IO) {
         val request = baseRequest(credentials, credentials.baseUrl)
@@ -83,25 +97,40 @@ class RemoteBackupService(
         }
     }
 
-    suspend fun uploadBackup(json: String, credentials: WebDavCredentials): RemoteBackupFile = withContext(Dispatchers.IO) {
-        val encrypted = encrypt(json.toByteArray(Charsets.UTF_8), credentials.passphrase)
-        val name = "AIAccounting_Backup_${filenameFormatter.format(Instant.now())}.$backupExtension"
+    suspend fun uploadBackup(json: String, credentials: WebDavCredentials, encryptBackup: Boolean): RemoteBackupFile = withContext(Dispatchers.IO) {
+        if (encryptBackup) {
+            require(credentials.hasPassphrase) { "此操作需要加密 passphrase" }
+        }
+        val payload = if (encryptBackup) encrypt(json.toByteArray(Charsets.UTF_8), credentials.passphrase) else json.toByteArray(Charsets.UTF_8)
+        val extension = if (encryptBackup) backupExtension else plainBackupExtension
+        val name = "AIAccounting_Backup_${filenameFormatter.format(Instant.now())}.$extension"
         val target = credentials.baseUrl.trimEnd('/') + "/" + name
         val request = baseRequest(credentials, target)
-            .put(encrypted.toRequestBody(jsonMediaType))
+            .put(payload.toRequestBody(jsonMediaType))
             .build()
         client.newCall(request).execute().use { response ->
             require(response.code in setOf(200, 201, 204)) { "WebDAV HTTP ${response.code}" }
         }
-        RemoteBackupFile(name = name, url = target)
+        RemoteBackupFile(
+            name = name,
+            url = target,
+            format = if (encryptBackup) RemoteBackupFormat.ENCRYPTED else RemoteBackupFormat.PLAIN_JSON
+        )
     }
 
     suspend fun downloadBackup(file: RemoteBackupFile, credentials: WebDavCredentials): String = withContext(Dispatchers.IO) {
         val request = baseRequest(credentials, file.url).get().build()
         client.newCall(request).execute().use { response ->
             require(response.code == 200) { "WebDAV HTTP ${response.code}" }
-            val encrypted = response.body?.bytes() ?: error("遠端備份內容為空")
-            decrypt(encrypted, credentials.passphrase).toString(Charsets.UTF_8)
+            val data = response.body?.bytes() ?: error("遠端備份內容為空")
+            when (detectFormat(file, data)) {
+                RemoteBackupFormat.ENCRYPTED -> {
+                    require(credentials.hasPassphrase) { "此操作需要加密 passphrase" }
+                    decrypt(data, credentials.passphrase).toString(Charsets.UTF_8)
+                }
+                RemoteBackupFormat.PLAIN_JSON -> data.toString(Charsets.UTF_8)
+                RemoteBackupFormat.UNKNOWN -> error("遠端備份格式不支援")
+            }
         }
     }
 
@@ -158,15 +187,35 @@ class RemoteBackupService(
                     .replace("&amp;", "&")
                 val name = href.substringAfterLast('/').ifBlank { return@mapNotNull null }
                 val decodedName = java.net.URLDecoder.decode(name, Charsets.UTF_8.name())
-                if (!decodedName.endsWith(".$backupExtension")) return@mapNotNull null
+                val format = formatFromName(decodedName)
+                if (format == RemoteBackupFormat.UNKNOWN) return@mapNotNull null
                 RemoteBackupFile(
                     name = decodedName,
-                    url = baseUrl.trimEnd('/') + "/" + decodedName
+                    url = baseUrl.trimEnd('/') + "/" + decodedName,
+                    format = format
                 )
             }
             .distinctBy { it.name }
             .sortedByDescending { it.name }
             .toList()
+    }
+
+    private fun detectFormat(file: RemoteBackupFile, data: ByteArray): RemoteBackupFormat {
+        if (file.format != RemoteBackupFormat.UNKNOWN) return file.format
+        val text = data.toString(Charsets.UTF_8)
+        return when {
+            runCatching { BackupJsonAdapter.gson.fromJson(text, EncryptedBackupEnvelope::class.java) }.getOrNull()?.algorithm == "AES.GCM.PBKDF2.HMACSHA256" -> RemoteBackupFormat.ENCRYPTED
+            runCatching { BackupJsonAdapter.gson.fromJson(text, FullBackupData::class.java) }.isSuccess -> RemoteBackupFormat.PLAIN_JSON
+            else -> RemoteBackupFormat.UNKNOWN
+        }
+    }
+
+    private fun formatFromName(name: String): RemoteBackupFormat {
+        return when {
+            name.endsWith(".$backupExtension") -> RemoteBackupFormat.ENCRYPTED
+            name.startsWith("AIAccounting_Backup_") && name.endsWith(".$plainBackupExtension") -> RemoteBackupFormat.PLAIN_JSON
+            else -> RemoteBackupFormat.UNKNOWN
+        }
     }
 
     private fun encrypt(data: ByteArray, passphrase: String): ByteArray {
@@ -235,6 +284,14 @@ class WebDavSettingsStore(context: Context) {
     var passphrase: String
         get() = prefs.getString("passphrase", null)?.let(cipher::decrypt).orEmpty()
         set(value) { prefs.edit().putString("passphrase", cipher.encrypt(value.trim())).apply() }
+
+    var encryptRemoteBackups: Boolean
+        get() = prefs.getBoolean("encrypt_remote_backups", true)
+        set(value) { prefs.edit().putBoolean("encrypt_remote_backups", value).apply() }
+
+    var didConfirmPlainWebDavBackup: Boolean
+        get() = prefs.getBoolean("did_confirm_plain_webdav_backup", false)
+        set(value) { prefs.edit().putBoolean("did_confirm_plain_webdav_backup", value).apply() }
 
     fun credentials(): WebDavCredentials {
         return WebDavCredentials(baseUrl = baseUrl, username = username, password = password, passphrase = passphrase)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -53,20 +54,26 @@ fun RemoteBackupScreen() {
     var username by remember { mutableStateOf(settingsStore.username) }
     var password by remember { mutableStateOf(settingsStore.password) }
     var passphrase by remember { mutableStateOf(settingsStore.passphrase) }
+    var encryptRemoteBackups by remember { mutableStateOf(settingsStore.encryptRemoteBackups) }
+    var didConfirmPlainBackup by remember { mutableStateOf(settingsStore.didConfirmPlainWebDavBackup) }
     var files by remember { mutableStateOf<List<RemoteBackupFile>>(emptyList()) }
     var preview by remember { mutableStateOf<RemoteBackupPreview?>(null) }
     var pendingRestore by remember { mutableStateOf<FullBackupData?>(null) }
     var message by remember { mutableStateOf<String?>(null) }
     var isBusy by remember { mutableStateOf(false) }
     var showRestoreConfirm by remember { mutableStateOf(false) }
+    var showPlainBackupConfirm by remember { mutableStateOf(false) }
     var showHttpRiskConfirm by remember { mutableStateOf(false) }
     var pendingHttpAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+    var pendingPlainBackupAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+    var httpWarningMentionsPlainBackup by remember { mutableStateOf(false) }
 
     fun saveSettings() {
         settingsStore.baseUrl = baseUrl
         settingsStore.username = username
         settingsStore.password = password
         settingsStore.passphrase = passphrase
+        settingsStore.encryptRemoteBackups = encryptRemoteBackups
     }
 
     fun credentials(): WebDavCredentials {
@@ -82,15 +89,50 @@ fun RemoteBackupScreen() {
         return url.trim().startsWith("http://", ignoreCase = true)
     }
 
-    fun runRemote(successMessage: String, allowInsecureHttp: Boolean = false, block: suspend () -> Unit) {
+    fun runRemote(
+        successMessage: String,
+        requirePassphrase: Boolean = false,
+        warnPlainBackup: Boolean = false,
+        isPlainBackupUpload: Boolean = false,
+        allowInsecureHttp: Boolean = false,
+        block: suspend () -> Unit
+    ) {
         if (isBusy) return
         val creds = credentials()
-        if (!creds.isComplete) {
-            message = "請先填寫 WebDAV URL、帳戶、密碼和加密 passphrase。"
+        if (!creds.isConnectionComplete) {
+            message = "請先填寫 WebDAV URL、帳戶和密碼。"
+            return
+        }
+        if (requirePassphrase && !creds.hasPassphrase) {
+            message = "此操作需要加密 passphrase。"
+            return
+        }
+        if (warnPlainBackup && !didConfirmPlainBackup) {
+            pendingPlainBackupAction = {
+                runRemote(
+                    successMessage = successMessage,
+                    requirePassphrase = requirePassphrase,
+                    warnPlainBackup = false,
+                    isPlainBackupUpload = isPlainBackupUpload,
+                    allowInsecureHttp = allowInsecureHttp,
+                    block = block
+                )
+            }
+            showPlainBackupConfirm = true
             return
         }
         if (!allowInsecureHttp && isInsecureHttp(creds.baseUrl)) {
-            pendingHttpAction = { runRemote(successMessage, allowInsecureHttp = true, block = block) }
+            httpWarningMentionsPlainBackup = isPlainBackupUpload
+            pendingHttpAction = {
+                runRemote(
+                    successMessage = successMessage,
+                    requirePassphrase = requirePassphrase,
+                    warnPlainBackup = warnPlainBackup,
+                    isPlainBackupUpload = isPlainBackupUpload,
+                    allowInsecureHttp = true,
+                    block = block
+                )
+            }
             showHttpRiskConfirm = true
             return
         }
@@ -150,11 +192,32 @@ fun RemoteBackupScreen() {
                 OutlinedTextField(
                     value = passphrase,
                     onValueChange = { passphrase = it },
-                    label = { Text("備份加密 passphrase") },
+                    label = { Text(if (encryptRemoteBackups) "備份加密 passphrase" else "加密 passphrase（還原加密備份時需要）") },
                     modifier = Modifier.fillMaxWidth(),
                     visualTransformation = PasswordVisualTransformation(),
                     singleLine = true
                 )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline)
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("加密遠端備份（建議）", style = MaterialTheme.typography.titleSmall)
+                        Text(
+                            if (encryptRemoteBackups) "上傳會使用 AES-GCM 加密，檔案副檔名為 .aibackup。"
+                            else "未加密備份會以 .json 上傳，雲端可直接讀取你的財務資料。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (encryptRemoteBackups) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.error
+                        )
+                    }
+                    Switch(
+                        checked = encryptRemoteBackups,
+                        onCheckedChange = {
+                            encryptRemoteBackups = it
+                            settingsStore.encryptRemoteBackups = it
+                        }
+                    )
+                }
                 Button(
                     onClick = {
                         runRemote("連線測試成功。") {
@@ -173,14 +236,20 @@ fun RemoteBackupScreen() {
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 Button(
                     onClick = {
-                        runRemote("加密上傳完成。") {
-                            service.uploadBackup(repository.exportBackupJson(), credentials())
+                        val shouldEncrypt = encryptRemoteBackups
+                        runRemote(
+                            successMessage = if (shouldEncrypt) "加密上傳完成。" else "未加密上傳完成。",
+                            requirePassphrase = shouldEncrypt,
+                            warnPlainBackup = !shouldEncrypt,
+                            isPlainBackupUpload = !shouldEncrypt
+                        ) {
+                            service.uploadBackup(repository.exportBackupJson(), credentials(), encryptBackup = shouldEncrypt)
                             files = service.listBackups(credentials())
                         }
                     },
                     modifier = Modifier.fillMaxWidth().height(50.dp)
                 ) {
-                    Text("加密並上傳目前備份")
+                    Text(if (encryptRemoteBackups) "加密並上傳目前備份" else "未加密上傳目前備份")
                 }
                 Button(
                     onClick = {
@@ -213,7 +282,7 @@ fun RemoteBackupScreen() {
                 PressableCard(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = {
-                        runRemote("已下載並解密備份。") {
+                        runRemote("已下載並讀取備份。", requirePassphrase = file.isEncrypted) {
                             val json = service.downloadBackup(file, credentials())
                             val backup = service.decodeBackup(json)
                             pendingRestore = backup
@@ -225,7 +294,14 @@ fun RemoteBackupScreen() {
                         modifier = Modifier.padding(AppSpacing.card).fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline)
                     ) {
-                        Text(file.name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.titleSmall)
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(file.name, style = MaterialTheme.typography.titleSmall)
+                            Text(
+                                file.format.label,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = if (file.isEncrypted) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.error
+                            )
+                        }
                         Text("預覽", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                     }
                 }
@@ -282,6 +358,41 @@ fun RemoteBackupScreen() {
         )
     }
 
+    if (showPlainBackupConfirm) {
+        AlertDialog(
+            onDismissRequest = {
+                showPlainBackupConfirm = false
+                pendingPlainBackupAction = null
+            },
+            title = { Text("上傳未加密備份？") },
+            text = { Text("未加密 JSON 會包含帳戶、交易、備註、分類和標籤等資料。只有在你信任這個雲端儲存位置時才建議使用。") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val action = pendingPlainBackupAction
+                        didConfirmPlainBackup = true
+                        settingsStore.didConfirmPlainWebDavBackup = true
+                        showPlainBackupConfirm = false
+                        pendingPlainBackupAction = null
+                        action?.invoke()
+                    }
+                ) {
+                    Text("未加密上傳", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showPlainBackupConfirm = false
+                        pendingPlainBackupAction = null
+                    }
+                ) {
+                    Text("取消")
+                }
+            }
+        )
+    }
+
     if (showHttpRiskConfirm) {
         AlertDialog(
             onDismissRequest = {
@@ -290,7 +401,13 @@ fun RemoteBackupScreen() {
             },
             title = { Text("HTTP 連線不安全") },
             text = {
-                Text("目前 WebDAV URL 使用 http://，傳輸途中可能被讀取或竄改。localhost / LAN 可以用作測試，但仍不建議放敏感備份。確定要繼續？")
+                Text(
+                    if (httpWarningMentionsPlainBackup) {
+                        "目前 WebDAV URL 使用 http://，而且你正在使用未加密備份；傳輸途中和雲端上都可能暴露財務資料。確定要繼續？"
+                    } else {
+                        "目前 WebDAV URL 使用 http://，傳輸途中可能被讀取或竄改。localhost / LAN 可以用作測試，但仍不建議放敏感備份。確定要繼續？"
+                    }
+                )
             },
             confirmButton = {
                 TextButton(


### PR DESCRIPTION
## Summary
- add an encrypt remote backups toggle on iOS and Android, defaulting on
- allow plain JSON WebDAV uploads when encryption is explicitly disabled
- keep legacy encrypted .aibackup restore support and label encrypted/plain remote files
- keep HTTP risk warnings, with stronger copy for unencrypted HTTP uploads

## Test Plan
- ./gradlew testDebugUnitTest assembleDebug
- xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO