### PR TITLE
Fix borrowed advance accounting semantics

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -78,6 +78,11 @@ enum AdvanceService {
             unresolvedCaseLinkCount + unresolvedParticipantLinkCount
         }
     }
+
+    struct LegacyBorrowedAdvanceRepairResult {
+        let repairedParticipantCount: Int
+        let removedInflatedAccountTransactionCount: Int
+    }
     
     private static let roundingTolerance = Decimal(string: "0.0001") ?? 0.0001
     
@@ -98,14 +103,17 @@ enum AdvanceService {
         currencyCode: String,
         myShareAmount: Decimal,
         note: String,
-        payerAccount: Account,
+        payerAccount: Account?,
         category: Category?,
         tags: [Tag],
         participants: [ParticipantInput],
         isBorrowedByMe: Bool = false,
         modelContext: ModelContext
     ) throws -> AdvanceCase {
-        guard payerAccount.type != .debt else {
+        if !isBorrowedByMe, payerAccount == nil {
+            throw AdvanceServiceError.invalidPayerAccount
+        }
+        if let payerAccount, payerAccount.type == .debt {
             throw AdvanceServiceError.invalidPayerAccount
         }
         guard !participants.isEmpty else {
@@ -145,7 +153,7 @@ enum AdvanceService {
         modelContext.insert(advanceCase)
         var budgetHistoryTransactions: [FinancialTransaction] = []
         
-        if myShareAmount > 0 {
+        if !isBorrowedByMe, myShareAmount > 0, let payerAccount {
             let expenseNote = finalNote.isEmpty
                 ? "\(finalTitle) (自己份額)"
                 : "\(finalNote) (自己份額)"
@@ -188,32 +196,27 @@ enum AdvanceService {
             let inTx: FinancialTransaction
 
             if isBorrowedByMe {
-                outTx = FinancialTransaction(
+                let expenseTx = FinancialTransaction(
                     id: outID,
                     amount: -abs(input.owedAmount),
                     currencyCode: currencyCode,
                     date: date,
-                    note: "\(transferMemo) (代墊給我 \(payerAccount.name))",
-                    type: .transfer,
-                    linkedTransactionID: inID,
+                    note: "\(transferMemo) (他人代墊我：\(input.debtAccount.name))",
+                    type: .expense,
+                    linkedTransactionID: nil,
                     transferGroupID: transferGroupID,
                     transferSide: .outgoing,
-                    account: input.debtAccount
+                    account: input.debtAccount,
+                    category: category,
+                    tags: tags
                 )
-
-                inTx = FinancialTransaction(
-                    id: inID,
-                    amount: abs(input.owedAmount),
-                    currencyCode: currencyCode,
-                    date: date,
-                    note: "\(transferMemo) (來自 \(input.debtAccount.name))",
-                    type: .transfer,
-                    linkedTransactionID: outID,
-                    transferGroupID: transferGroupID,
-                    transferSide: .incoming,
-                    account: payerAccount
-                )
+                modelContext.insert(expenseTx)
+                budgetHistoryTransactions.append(expenseTx)
+                continue
             } else {
+                guard let payerAccount else {
+                    throw AdvanceServiceError.invalidPayerAccount
+                }
                 outTx = FinancialTransaction(
                     id: outID,
                     amount: -abs(input.owedAmount),
@@ -252,6 +255,67 @@ enum AdvanceService {
             currencyService: CurrencyService.shared
         )
         return advanceCase
+    }
+
+    @MainActor
+    static func repairLegacyBorrowedAdvanceAccountInflation(modelContext: ModelContext) throws -> LegacyBorrowedAdvanceRepairResult {
+        let participants = try modelContext.fetch(FetchDescriptor<AdvanceParticipant>())
+        var repairedParticipantCount = 0
+        var removedInflatedAccountTransactionCount = 0
+        var repairedExpenseTransactions: [FinancialTransaction] = []
+
+        for participant in participants {
+            guard let groupID = participant.initialTransferGroupID,
+                  let debtAccount = participant.debtAccount,
+                  let advanceCase = participant.advanceCase
+            else { continue }
+
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.transferGroupID == groupID }
+            )
+            let group = try modelContext.fetch(descriptor)
+            guard let outgoing = group.first(where: { tx in
+                tx.account?.id == debtAccount.id && (tx.transferSide == .outgoing || tx.amount < 0)
+            }) else { continue }
+
+            let inflatedIncoming = group.filter { tx in
+                tx.id != outgoing.id &&
+                    tx.amount > 0 &&
+                    tx.account?.type != .debt
+            }
+            guard !inflatedIncoming.isEmpty else { continue }
+
+            outgoing.type = .expense
+            outgoing.amount = -abs(outgoing.amount)
+            outgoing.linkedTransactionID = nil
+            outgoing.transferSide = .outgoing
+            outgoing.category = advanceCase.expenseCategory
+            outgoing.note = "\(advanceCase.note.isEmpty ? advanceCase.title : advanceCase.note) (他人代墊我：\(debtAccount.name))"
+            outgoing.updatedAt = Date()
+            repairedExpenseTransactions.append(outgoing)
+
+            for tx in inflatedIncoming {
+                modelContext.delete(tx)
+                removedInflatedAccountTransactionCount += 1
+            }
+
+            advanceCase.payerAccount = nil
+            advanceCase.updatedAt = Date()
+            participant.updatedAt = Date()
+            repairedParticipantCount += 1
+        }
+
+        try modelContext.save()
+        try BudgetHistoryService.shared.syncAffected(
+            by: repairedExpenseTransactions,
+            modelContext: modelContext,
+            currencyService: CurrencyService.shared
+        )
+
+        return LegacyBorrowedAdvanceRepairResult(
+            repairedParticipantCount: repairedParticipantCount,
+            removedInflatedAccountTransactionCount: removedInflatedAccountTransactionCount
+        )
     }
     
     @MainActor
@@ -579,19 +643,22 @@ enum AdvanceService {
             predicate: #Predicate { $0.initialTransferGroupID == groupID }
         )
         if let participant = try modelContext.fetch(participantDescriptor).first {
-            if let incoming, let debtAccount = incoming.account {
+            if incoming == nil, outgoing?.type == .expense, let debtAccount = outgoing?.account {
+                participant.debtAccount = debtAccount
+                participant.name = debtAccount.name
+            } else if let incoming, let debtAccount = incoming.account {
                 participant.debtAccount = debtAccount
                 participant.name = debtAccount.name
             }
 
             if let advanceCase = participant.advanceCase {
-                if let outgoing {
+                if let outgoing, incoming != nil {
                     advanceCase.payerAccount = outgoing.account
                 }
-                if let incoming {
+                if let amountSource = incoming ?? outgoing {
                     let normalized = CurrencyService.shared.convert(
-                        amount: abs(incoming.amount),
-                        from: incoming.currencyCode,
+                        amount: abs(amountSource.amount),
+                        from: amountSource.currencyCode,
                         to: advanceCase.currencyCode
                     )
                     participant.owedAmount = normalized >= participant.repaidAmount

--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -370,12 +370,13 @@ enum DataHealthCheckService {
         transactions: [FinancialTransaction],
         into issues: inout [HealthIssue]
     ) {
-        let groupedTransfers = Dictionary(grouping: transactions.filter { $0.type == .transfer && $0.transferGroupID != nil }) {
+        let groupedTransfers = Dictionary(grouping: transactions.filter { $0.transferGroupID != nil }) {
             $0.transferGroupID!
         }
 
         var malformedInitialGroups = 0
         var initialMappingMismatches = 0
+        var legacyBorrowedAdvanceInflatedAccounts = 0
 
         for participant in participants {
             guard let groupID = participant.initialTransferGroupID else { continue }
@@ -386,31 +387,45 @@ enum DataHealthCheckService {
 
             let outgoing = group.filter { $0.transferSide == .outgoing || $0.amount < 0 }
             let incoming = group.filter { $0.transferSide == .incoming || $0.amount > 0 }
-            guard !outgoing.isEmpty && !incoming.isEmpty else {
-                malformedInitialGroups += 1
-                continue
-            }
 
             guard
-                let debtAccountID = participant.debtAccount?.id,
-                let payerAccountID = participant.advanceCase?.payerAccount?.id
+                let debtAccountID = participant.debtAccount?.id
             else {
                 continue
             }
 
             let outgoingAccountIDs = Set(outgoing.compactMap { $0.account?.id })
             let incomingAccountIDs = Set(incoming.compactMap { $0.account?.id })
-            guard !outgoingAccountIDs.isEmpty && !incomingAccountIDs.isEmpty else {
+            guard !outgoingAccountIDs.isEmpty else {
+                malformedInitialGroups += 1
+                continue
+            }
+
+            let newOthersAdvancedMeExpensePattern = outgoingAccountIDs.isSubset(of: [debtAccountID]) &&
+                incoming.isEmpty &&
+                outgoing.allSatisfy { $0.type == .expense }
+            if newOthersAdvancedMeExpensePattern {
+                continue
+            }
+
+            guard let payerAccountID = participant.advanceCase?.payerAccount?.id else {
+                malformedInitialGroups += 1
+                continue
+            }
+
+            guard !incomingAccountIDs.isEmpty else {
                 malformedInitialGroups += 1
                 continue
             }
 
             let iAdvancedOthersPattern = outgoingAccountIDs.isSubset(of: [payerAccountID]) &&
                 incomingAccountIDs.isSubset(of: [debtAccountID])
-            let othersAdvancedMePattern = outgoingAccountIDs.isSubset(of: [debtAccountID]) &&
+            let legacyOthersAdvancedMePattern = outgoingAccountIDs.isSubset(of: [debtAccountID]) &&
                 incomingAccountIDs.isSubset(of: [payerAccountID])
 
-            if !(iAdvancedOthersPattern || othersAdvancedMePattern) {
+            if legacyOthersAdvancedMePattern {
+                legacyBorrowedAdvanceInflatedAccounts += 1
+            } else if !iAdvancedOthersPattern {
                 initialMappingMismatches += 1
             }
         }
@@ -496,6 +511,17 @@ enum DataHealthCheckService {
                     title: "代墊還款方向不一致",
                     detail: "共有 \(repaymentMappingMismatches) 筆還款的轉出/轉入帳戶與對象/入帳帳戶不一致。",
                     recommendation: "請檢查還款方向與收款帳戶是否設定正確。"
+                )
+            )
+        }
+
+        if legacyBorrowedAdvanceInflatedAccounts > 0 {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "他人代墊我舊資料會虛增自己帳戶",
+                    detail: "共有 \(legacyBorrowedAdvanceInflatedAccounts) 位代墊對象使用舊版轉帳寫法，可能把他人代付誤記為自己的帳戶入帳。",
+                    recommendation: "請在資料健康檢查中執行「修復他人代墊我舊帳務」。"
                 )
             )
         }

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -266,12 +266,12 @@ struct AdvanceCaseDetailView: View {
                     value: AdvanceService.outstandingAmount(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode))
                 )
                 summaryRow(
-                    title: "付款帳戶",
-                    value: advanceCase.payerAccount?.name ?? "未指定"
+                    title: settlementDirection == .iAdvancedOthers ? "付款帳戶" : "付款來源",
+                    value: settlementDirection == .iAdvancedOthers ? (advanceCase.payerAccount?.name ?? "未指定") : "他人代付（不影響自己帳戶）"
                 )
                 summaryRow(
                     title: "帳務儲存",
-                    value: "借貸帳戶轉帳"
+                    value: settlementDirection == .iAdvancedOthers ? "借貸帳戶轉帳" : "借貸帳戶支出"
                 )
             }
             
@@ -559,12 +559,11 @@ struct AddAdvanceCaseView: View {
     }
     
     private var flowCategories: [Category] {
-        switch direction {
-        case .iAdvancedOthers:
-            categories.filter { $0.kind.supports(.expense) }
-        case .othersAdvancedMe:
-            categories.filter { $0.kind.supports(.income) }
-        }
+        categories.filter { $0.kind.supports(.expense) }
+    }
+
+    private var requiresPayerAccount: Bool {
+        direction == .iAdvancedOthers
     }
     
     var body: some View {
@@ -580,75 +579,78 @@ struct AddAdvanceCaseView: View {
 
                     TextField("代墊名稱 (例如：聚餐 2026-03-01)", text: $title)
                     DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
-                    Picker("付款帳戶", selection: $selectedPayerAccount) {
-                        Text("選擇帳戶").tag(nil as Account?)
-                        ForEach(myAccounts) { account in
-                            Text(account.name).tag(account as Account?)
-                        }
-                    }
-                    .onChange(of: selectedPayerAccount) { _, _ in
-                        if let account = selectedPayerAccount {
-                            selectedCurrency = account.currency
-                        }
-                    }
-                    
-                    HStack {
-                        Text("幣種")
-                        Spacer()
-                        Picker("幣種", selection: $selectedCurrency) {
-                            ForEach(currencies, id: \.self) { code in
-                                Text(code).tag(code)
+                    if requiresPayerAccount {
+                        Picker("付款帳戶", selection: $selectedPayerAccount) {
+                            Text("選擇帳戶").tag(nil as Account?)
+                            ForEach(myAccounts) { account in
+                                Text(account.name).tag(account as Account?)
                             }
                         }
-                    }
-                }
-                
-                Section("自己的份額") {
-                    TextField("0 (可留空)", text: Binding(
-                        get: { myShareString },
-                        set: { myShareString = sanitizePositiveDecimalInput($0) }
-                    ))
-                    .keyboardType(.decimalPad)
-                    
-                    Picker(direction == .iAdvancedOthers ? "支出分類" : "收入分類", selection: $selectedCategory) {
-                        Text("不設定").tag(nil as Category?)
-                        ForEach(flowCategories) { category in
-                            Text(category.name).tag(category as Category?)
+                        .onChange(of: selectedPayerAccount) { _, _ in
+                            if let account = selectedPayerAccount {
+                                selectedCurrency = account.currency
+                            }
                         }
+                    } else {
+                        Text("他人代你付款時，你自己的帳戶沒有變動；建立時只會記錄支出與你欠對方的債務。")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
 
-                    HStack {
-                        Text("標籤")
-                        Spacer()
-                        Button(action: { showingAddTag = true }) {
-                            Label("新增", systemImage: "plus")
-                                .font(.caption)
-                        }
-                    }
-
-                    ScrollView(.horizontal, showsIndicators: false) {
+                    if !requiresPayerAccount {
                         HStack {
-                            ForEach(tags) { tag in
-                                let isSelected = selectedTags.contains(tag)
-                                Text(tag.name)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
-                                    .background(isSelected ? Color.blue : Color.gray.opacity(0.2))
-                                    .foregroundStyle(isSelected ? .white : .primary)
-                                    .cornerRadius(16)
-                                    .onTapGesture {
-                                        if isSelected {
-                                            selectedTags.remove(tag)
-                                        } else {
-                                            selectedTags.insert(tag)
-                                        }
-                                    }
+                            Text("幣種")
+                            Spacer()
+                            Picker("幣種", selection: $selectedCurrency) {
+                                ForEach(currencies, id: \.self) { code in
+                                    Text(code).tag(code)
+                                }
+                            }
+                        }
+                    } else {
+                        HStack {
+                            Text("幣種")
+                            Spacer()
+                            Picker("幣種", selection: $selectedCurrency) {
+                                ForEach(currencies, id: \.self) { code in
+                                    Text(code).tag(code)
+                                }
                             }
                         }
                     }
                 }
                 
-                Section(direction == .iAdvancedOthers ? "代墊對象" : "借款對象") {
+                if direction == .iAdvancedOthers {
+                    Section("自己的份額") {
+                        TextField("0 (可留空)", text: Binding(
+                            get: { myShareString },
+                            set: { myShareString = sanitizePositiveDecimalInput($0) }
+                        ))
+                        .keyboardType(.decimalPad)
+                        
+                        Picker("支出分類", selection: $selectedCategory) {
+                            Text("不設定").tag(nil as Category?)
+                            ForEach(flowCategories) { category in
+                                Text(category.name).tag(category as Category?)
+                            }
+                        }
+                        
+                        tagSelectionView
+                    }
+                } else {
+                    Section("支出分類與標籤") {
+                        Picker("支出分類", selection: $selectedCategory) {
+                            Text("不設定").tag(nil as Category?)
+                            ForEach(flowCategories) { category in
+                                Text(category.name).tag(category as Category?)
+                            }
+                        }
+                        
+                        tagSelectionView
+                    }
+                }
+                
+                Section(direction == .iAdvancedOthers ? "代墊對象" : "我欠的人") {
                     if debtAccounts.isEmpty {
                         Text("尚未建立借貸/債務帳戶，可在此直接新增。")
                             .font(.caption)
@@ -658,6 +660,7 @@ struct AddAdvanceCaseView: View {
                             AdvanceParticipantDraftRow(
                                 draft: binding(for: draft),
                                 debtAccounts: debtAccounts,
+                                amountPlaceholder: direction == .iAdvancedOthers ? "代墊金額" : "我欠此人的金額",
                                 canRemove: participantDrafts.count > 1,
                                 onRemove: {
                                     participantDrafts.removeAll { $0.id == draft.id }
@@ -672,7 +675,7 @@ struct AddAdvanceCaseView: View {
                             Label("新增對象", systemImage: "plus.circle")
                         }
                     }
-
+                    
                     Button {
                         showingAddDebtAccount = true
                     } label: {
@@ -691,7 +694,7 @@ struct AddAdvanceCaseView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("儲存") { save() }
-                        .disabled(selectedPayerAccount == nil)
+                        .disabled(!canSave)
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
@@ -725,16 +728,61 @@ struct AddAdvanceCaseView: View {
                     selectedCurrency = first.currency
                 }
             }
-            .onChange(of: direction) { _, _ in
+            .onChange(of: direction) { _, newDirection in
                 if let selectedCategory, !flowCategories.contains(where: { $0.id == selectedCategory.id }) {
                     self.selectedCategory = nil
+                }
+                if newDirection == .othersAdvancedMe {
+                    myShareString = ""
+                    selectedPayerAccount = nil
+                } else if selectedPayerAccount == nil, let first = myAccounts.first {
+                    selectedPayerAccount = first
+                    selectedCurrency = first.currency
+                }
+            }
+        }
+    }
+
+    private var canSave: Bool {
+        !requiresPayerAccount || selectedPayerAccount != nil
+    }
+
+    private var tagSelectionView: some View {
+        Group {
+            HStack {
+                Text("標籤")
+                Spacer()
+                Button(action: { showingAddTag = true }) {
+                    Label("新增", systemImage: "plus")
+                        .font(.caption)
+                }
+            }
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(tags) { tag in
+                        let isSelected = selectedTags.contains(tag)
+                        Text(tag.name)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(isSelected ? Color.blue : Color.gray.opacity(0.2))
+                            .foregroundStyle(isSelected ? .white : .primary)
+                            .cornerRadius(16)
+                            .onTapGesture {
+                                if isSelected {
+                                    selectedTags.remove(tag)
+                                } else {
+                                    selectedTags.insert(tag)
+                                }
+                            }
+                    }
                 }
             }
         }
     }
     
     private func save() {
-        guard let payer = selectedPayerAccount else {
+        if requiresPayerAccount, selectedPayerAccount == nil {
             showError("請選擇付款帳戶。")
             return
         }
@@ -772,9 +820,9 @@ struct AddAdvanceCaseView: View {
                 title: title,
                 date: date,
                 currencyCode: selectedCurrency,
-                myShareAmount: myShare,
+                myShareAmount: direction == .othersAdvancedMe ? 0 : myShare,
                 note: note,
-                payerAccount: payer,
+                payerAccount: selectedPayerAccount,
                 category: selectedCategory,
                 tags: Array(selectedTags),
                 participants: participantInputs,
@@ -870,6 +918,7 @@ struct AddAdvanceCaseView: View {
 private struct AdvanceParticipantDraftRow: View {
     @Binding var draft: AddAdvanceCaseView.ParticipantDraft
     let debtAccounts: [Account]
+    let amountPlaceholder: String
     let canRemove: Bool
     let onRemove: () -> Void
     let sanitizeAmount: (String) -> String
@@ -883,7 +932,7 @@ private struct AdvanceParticipantDraftRow: View {
                 }
             }
 
-            TextField("代墊金額", text: Binding(
+            TextField(amountPlaceholder, text: Binding(
                 get: { draft.amountString },
                 set: { draft.amountString = sanitizeAmount($0) }
             ))
@@ -990,7 +1039,7 @@ struct AddAdvanceRepaymentView: View {
         case .iAdvancedOthers:
             return "自己的入帳標記"
         case .othersAdvancedMe:
-            return "自己的支出標記"
+            return "還款標記（不重複計入支出）"
         }
     }
     

--- a/AI 記帳/Views/Tools/DataHealthCheckView.swift
+++ b/AI 記帳/Views/Tools/DataHealthCheckView.swift
@@ -31,6 +31,15 @@ struct DataHealthCheckView: View {
                 Text("補齊舊資料缺少的連結欄位，讓整單連動刪除可更完整刪除相關交易。")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Button(isRunning ? "處理中..." : "修復他人代墊我舊帳務") {
+                    repairLegacyBorrowedAdvanceAccountInflation()
+                }
+                .disabled(isRunning)
+                
+                Text("移除舊版他人代墊我誤寫入自己帳戶的入帳，改為借貸帳戶支出。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             legacyDebtIncomeSection
@@ -207,6 +216,24 @@ struct DataHealthCheckView: View {
             alertMessage = "修復失敗：\(error.localizedDescription)"
         }
         
+        isRunning = false
+        showingAlert = true
+    }
+
+    private func repairLegacyBorrowedAdvanceAccountInflation() {
+        isRunning = true
+
+        do {
+            let result = try AdvanceService.repairLegacyBorrowedAdvanceAccountInflation(modelContext: modelContext)
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            alertMessage = """
+            已修復 \(result.repairedParticipantCount) 位代墊對象。
+            已移除 \(result.removedInflatedAccountTransactionCount) 筆誤寫入自己帳戶的入帳。
+            """
+        } catch {
+            alertMessage = "修復失敗：\(error.localizedDescription)"
+        }
+
         isRunning = false
         showingAlert = true
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/health/DataHealthChecker.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/health/DataHealthChecker.kt
@@ -381,13 +381,14 @@ object DataHealthChecker {
         issues: MutableList<HealthIssue>
     ) {
         val groupedTransfers = transactions
-            .filter { it.transaction.type == TransactionType.Transfer && it.transaction.transferGroupId != null }
+            .filter { it.transaction.transferGroupId != null }
             .groupBy { it.transaction.transferGroupId!! }
         val payerAccountByCaseId = cases.associate { it.advanceCase.id to it.advanceCase.payerAccountId }
         val participantById = participants.associateBy { it.id }
 
         var malformedInitialGroups = 0
         var initialMappingMismatches = 0
+        var legacyBorrowedAdvanceInflatedAccounts = 0
 
         participants.forEach { participant ->
             val groupId = participant.initialTransferGroupId ?: return@forEach
@@ -399,23 +400,34 @@ object DataHealthChecker {
 
             val outgoingAccountIds = group.accountIdsFor(TransferSide.Outgoing)
             val incomingAccountIds = group.accountIdsFor(TransferSide.Incoming)
-            if (outgoingAccountIds.isEmpty() || incomingAccountIds.isEmpty()) {
+            if (outgoingAccountIds.isEmpty()) {
                 malformedInitialGroups += 1
                 return@forEach
             }
 
-            val debtAccountId = participant.debtAccountId
+            val debtAccountId = participant.debtAccountId ?: return@forEach
+            val newOthersAdvancedMeExpensePattern = outgoingAccountIds == setOf(debtAccountId) &&
+                incomingAccountIds.isEmpty() &&
+                group.filter { it.transaction.transferSide == TransferSide.Outgoing || it.transaction.amount < BigDecimal.ZERO }
+                    .all { it.transaction.type == TransactionType.Expense }
+            if (newOthersAdvancedMeExpensePattern) {
+                return@forEach
+            }
+
             val payerAccountId = participant.advanceCaseId?.let { payerAccountByCaseId[it] }
-            if (debtAccountId == null || payerAccountId == null) {
+            if (payerAccountId == null || incomingAccountIds.isEmpty()) {
+                malformedInitialGroups += 1
                 return@forEach
             }
 
             val iAdvancedOthersPattern = outgoingAccountIds == setOf(payerAccountId) &&
                 incomingAccountIds == setOf(debtAccountId)
-            val othersAdvancedMePattern = outgoingAccountIds == setOf(debtAccountId) &&
+            val legacyOthersAdvancedMePattern = outgoingAccountIds == setOf(debtAccountId) &&
                 incomingAccountIds == setOf(payerAccountId)
 
-            if (!iAdvancedOthersPattern && !othersAdvancedMePattern) {
+            if (legacyOthersAdvancedMePattern) {
+                legacyBorrowedAdvanceInflatedAccounts += 1
+            } else if (!iAdvancedOthersPattern) {
                 initialMappingMismatches += 1
             }
         }
@@ -487,6 +499,15 @@ object DataHealthChecker {
                 title = "代墊還款方向不一致",
                 detail = "共有 $repaymentMappingMismatches 筆還款的轉出/轉入帳戶與對象/入帳帳戶不一致。",
                 recommendation = "請檢查還款方向與收款帳戶是否設定正確。"
+            )
+        }
+
+        if (legacyBorrowedAdvanceInflatedAccounts > 0) {
+            issues += HealthIssue(
+                severity = HealthSeverity.Warning,
+                title = "他人代墊我舊資料會虛增自己帳戶",
+                detail = "共有 $legacyBorrowedAdvanceInflatedAccounts 位代墊對象使用舊版轉帳寫法，可能把他人代付誤記為自己的帳戶入帳。",
+                recommendation = "請在資料健康檢查中執行「修復他人代墊我舊帳務」。"
             )
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -70,6 +70,11 @@ enum class LedgerDeletionResult {
     AdvanceInitialRequiresCase
 }
 
+data class LegacyBorrowedAdvanceRepairResult(
+    val repairedParticipantCount: Int,
+    val removedInflatedAccountTransactionCount: Int
+)
+
 private const val RECURRING_STATUS_PENDING = "Pending"
 private const val RECURRING_STATUS_CONFIRMED = "Confirmed"
 private const val RECURRING_STATUS_SKIPPED = "Skipped"
@@ -210,6 +215,70 @@ class AccountingRepository(
             shortcutDao.upsertAll(shortcuts.map { it.shortcut.copy(accountId = null) })
         }
         return shortcuts.size
+    }
+
+    suspend fun repairLegacyBorrowedAdvanceAccountInflation(): LegacyBorrowedAdvanceRepairResult {
+        return database.withTransaction {
+            val cases = advanceDao.getAllCasesWithDetails()
+            var repairedParticipantCount = 0
+            var removedInflatedAccountTransactionCount = 0
+
+            for (caseDetails in cases) {
+                for (participant in caseDetails.participants) {
+                    val groupId = participant.initialTransferGroupId ?: continue
+                    val debtAccountId = participant.debtAccountId ?: continue
+                    val group = transactionDao.getTransferGroup(groupId)
+                    val outgoing = group.firstOrNull { tx ->
+                        tx.transaction.accountId == debtAccountId &&
+                            (tx.transaction.transferSide == TransferSide.Outgoing || tx.transaction.amount < BigDecimal.ZERO)
+                    } ?: continue
+                    val inflatedIncoming = group.filter { tx ->
+                        tx.transaction.id != outgoing.transaction.id &&
+                            tx.transaction.amount > BigDecimal.ZERO &&
+                            tx.account?.type != org.duckdns.lhfser.aiaccounting.core.model.AccountType.Debt
+                    }
+                    if (inflatedIncoming.isEmpty()) continue
+
+                    val baseNote = caseDetails.advanceCase.note.ifBlank { caseDetails.advanceCase.title }
+                    transactionDao.upsert(
+                        outgoing.transaction.copy(
+                            amount = outgoing.transaction.amount.abs().negate(),
+                            note = "$baseNote (他人代墊我：${participant.name})",
+                            type = TransactionType.Expense,
+                            linkedTransactionId = null,
+                            transferSide = TransferSide.Outgoing,
+                            categoryId = caseDetails.advanceCase.expenseCategoryId,
+                            updatedAt = Instant.now()
+                        )
+                    )
+
+                    inflatedIncoming.forEach { tx ->
+                        transactionDao.clearTransactionTags(tx.transaction.id)
+                        transactionDao.delete(tx.transaction)
+                        removedInflatedAccountTransactionCount += 1
+                    }
+
+                    advanceDao.upsertCase(
+                        caseDetails.advanceCase.copy(
+                            payerAccountId = null,
+                            updatedAt = Instant.now()
+                        )
+                    )
+                    advanceDao.upsertParticipants(
+                        listOf(participant.copy(updatedAt = Instant.now()))
+                    )
+                    repairedParticipantCount += 1
+                }
+            }
+
+            if (repairedParticipantCount > 0) {
+                syncAllBudgetHistory()
+            }
+            LegacyBorrowedAdvanceRepairResult(
+                repairedParticipantCount = repairedParticipantCount,
+                removedInflatedAccountTransactionCount = removedInflatedAccountTransactionCount
+            )
+        }
     }
 
     suspend fun upsertAccount(account: AccountEntity) {
@@ -701,7 +770,7 @@ class AccountingRepository(
         currencyCode: String,
         myShareAmount: BigDecimal,
         note: String,
-        payerAccount: AccountEntity,
+        payerAccount: AccountEntity?,
         expenseCategory: CategoryEntity?,
         tagIds: List<UUID>,
         participants: List<AdvanceParticipantInput>,
@@ -714,7 +783,7 @@ class AccountingRepository(
             val finalNote = note.trim()
 
             var selfExpenseTransactionId: UUID? = null
-            if (myShareAmount > BigDecimal.ZERO) {
+            if (!isBorrowedByMe && myShareAmount > BigDecimal.ZERO && payerAccount != null) {
                 val expenseNote = if (finalNote.isBlank()) {
                     "$finalTitle (自己份額)"
                 } else {
@@ -756,7 +825,7 @@ class AccountingRepository(
                 selfExpenseTransactionId = selfExpenseTransactionId,
                 createdAt = now,
                 updatedAt = now,
-                payerAccountId = payerAccount.id,
+                payerAccountId = payerAccount?.id,
                 expenseCategoryId = expenseCategory?.id
             )
             advanceDao.upsertCase(advanceCase)
@@ -764,6 +833,7 @@ class AccountingRepository(
             val transferMemo = if (finalNote.isBlank()) finalTitle else finalNote
             val participantEntities = mutableListOf<AdvanceParticipantEntity>()
             val transferEntities = mutableListOf<TransactionEntity>()
+            val deferredTagRefs = mutableListOf<TransactionTagCrossRef>()
 
             participants.forEach { input ->
                 val transferGroupId = UUID.randomUUID()
@@ -784,43 +854,30 @@ class AccountingRepository(
                     )
                 )
 
-                val outTx: TransactionEntity
-                val inTx: TransactionEntity
                 if (isBorrowedByMe) {
-                    outTx = TransactionEntity(
+                    val expenseTx = TransactionEntity(
                         id = outId,
                         amount = input.owedAmount.abs().negate(),
                         currencyCode = currencyCode,
                         date = date,
-                        note = "$transferMemo (代墊給我 ${payerAccount.name})",
+                        note = "$transferMemo (他人代墊我：${input.debtAccount.name})",
                         photoPath = null,
-                        type = TransactionType.Transfer,
-                        linkedTransactionId = inId,
+                        type = TransactionType.Expense,
+                        linkedTransactionId = null,
                         transferGroupId = transferGroupId,
                         transferSide = TransferSide.Outgoing,
                         createdAt = now,
                         updatedAt = now,
                         accountId = input.debtAccount.id,
-                        categoryId = null
+                        categoryId = expenseCategory?.id
                     )
-                    inTx = TransactionEntity(
-                        id = inId,
-                        amount = input.owedAmount.abs(),
-                        currencyCode = currencyCode,
-                        date = date,
-                        note = "$transferMemo (來自 ${input.debtAccount.name})",
-                        photoPath = null,
-                        type = TransactionType.Transfer,
-                        linkedTransactionId = outId,
-                        transferGroupId = transferGroupId,
-                        transferSide = TransferSide.Incoming,
-                        createdAt = now,
-                        updatedAt = now,
-                        accountId = payerAccount.id,
-                        categoryId = null
-                    )
+                    transferEntities.add(expenseTx)
+                    if (tagIds.isNotEmpty()) {
+                        deferredTagRefs += tagIds.map { tagId -> TransactionTagCrossRef(outId, tagId) }
+                    }
                 } else {
-                    outTx = TransactionEntity(
+                    val payer = requireNotNull(payerAccount) { "請選擇付款帳戶" }
+                    val outTx = TransactionEntity(
                         id = outId,
                         amount = input.owedAmount.abs().negate(),
                         currencyCode = currencyCode,
@@ -833,15 +890,15 @@ class AccountingRepository(
                         transferSide = TransferSide.Outgoing,
                         createdAt = now,
                         updatedAt = now,
-                        accountId = payerAccount.id,
+                        accountId = payer.id,
                         categoryId = null
                     )
-                    inTx = TransactionEntity(
+                    val inTx = TransactionEntity(
                         id = inId,
                         amount = input.owedAmount.abs(),
                         currencyCode = currencyCode,
                         date = date,
-                        note = "$transferMemo (來自 ${payerAccount.name})",
+                        note = "$transferMemo (來自 ${payer.name})",
                         photoPath = null,
                         type = TransactionType.Transfer,
                         linkedTransactionId = outId,
@@ -852,13 +909,16 @@ class AccountingRepository(
                         accountId = input.debtAccount.id,
                         categoryId = null
                     )
+                    transferEntities.add(outTx)
+                    transferEntities.add(inTx)
                 }
-                transferEntities.add(outTx)
-                transferEntities.add(inTx)
             }
 
             advanceDao.upsertParticipants(participantEntities)
             transactionDao.upsertAll(transferEntities)
+            if (deferredTagRefs.isNotEmpty()) {
+                transactionDao.insertTransactionTags(deferredTagRefs)
+            }
             syncAllBudgetHistory()
             caseId
         }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
@@ -84,10 +84,8 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
     var showCreateDebtDialog by remember { mutableStateOf(false) }
     var newDebtName by remember { mutableStateOf("") }
 
-    val flowCategories = when (direction) {
-        AdvanceDirection.IAdvanceOthers -> categories.filter { it.kind.supports(org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Expense) }
-        AdvanceDirection.OthersAdvanceMe -> categories.filter { it.kind.supports(org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Income) }
-    }
+    val flowCategories = categories.filter { it.kind.supports(org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Expense) }
+    val requiresPayerAccount = direction == AdvanceDirection.IAdvanceOthers
 
     Column(
         modifier = Modifier
@@ -113,6 +111,13 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                 label = { it.label },
                 onSelect = { mode ->
                     direction = mode
+                    if (mode == AdvanceDirection.OthersAdvanceMe) {
+                        payerAccount = null
+                        myShare = ""
+                    } else if (payerAccount == null) {
+                        payerAccount = payerAccounts.firstOrNull()
+                        payerAccount?.let { currency = it.currency }
+                    }
                     if (expenseCategory != null && flowCategories.none { it.id == expenseCategory?.id }) {
                         expenseCategory = null
                     }
@@ -124,16 +129,29 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                 label = { Text("標題") },
                 modifier = Modifier.fillMaxWidth()
             )
-            AccountPicker(label = "付款帳戶", accounts = payerAccounts, selected = payerAccount) { acc ->
-                payerAccount = acc
-                if (acc != null) currency = acc.currency
+            if (requiresPayerAccount) {
+                AccountPicker(label = "付款帳戶", accounts = payerAccounts, selected = payerAccount) { acc ->
+                    payerAccount = acc
+                    if (acc != null) currency = acc.currency
+                }
+                AmountRow(
+                    label = "自己的份額",
+                    amount = myShare,
+                    onAmountChange = { myShare = sanitizeAmount(it) },
+                    currency = currency
+                )
+            } else {
+                Text(
+                    "他人代你付款時，你自己的帳戶沒有變動；建立時只會記錄支出與你欠對方的債務。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                CurrencyPicker(
+                    selected = currency,
+                    onSelect = { currency = it },
+                    buttonStyle = CurrencyButtonStyle.Tonal
+                )
             }
-            AmountRow(
-                label = "自己的份額",
-                amount = myShare,
-                onAmountChange = { myShare = sanitizeAmount(it) },
-                currency = currency
-            )
         }
 
         ParitySectionHeader(
@@ -144,7 +162,7 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
             CategoryPicker(
                 categories = flowCategories,
                 selected = expenseCategory,
-                label = if (direction == AdvanceDirection.IAdvanceOthers) "支出分類" else "收入分類"
+                label = "支出分類"
             ) {
                 expenseCategory = it
             }
@@ -152,7 +170,7 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
         }
 
         ParitySectionHeader(
-            title = if (direction == AdvanceDirection.IAdvanceOthers) "代墊對象" else "借款對象",
+            title = if (direction == AdvanceDirection.IAdvanceOthers) "代墊對象" else "我欠的人",
             detail = "每位對象都會保留獨立的金額與後續還款追蹤。",
             actionLabel = "新增對象",
             onAction = { participants = participants + ParticipantDraft() }
@@ -199,8 +217,9 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
         Button(
             onClick = {
                 scope.launch {
-                    val payer = payerAccount ?: return@launch
-                    val myShareValue = myShare.toBigDecimalOrNull() ?: BigDecimal.ZERO
+                    val payer = payerAccount
+                    if (requiresPayerAccount && payer == null) return@launch
+                    val myShareValue = if (direction == AdvanceDirection.OthersAdvanceMe) BigDecimal.ZERO else (myShare.toBigDecimalOrNull() ?: BigDecimal.ZERO)
                     val inputs = participants.mapNotNull { draft ->
                         val account = draft.debtAccount ?: return@mapNotNull null
                         val amount = draft.amount.toBigDecimalOrNull() ?: return@mapNotNull null

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DataHealthScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DataHealthScreen.kt
@@ -224,6 +224,49 @@ fun DataHealthScreen() {
             }
         }
 
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+            border = BorderStroke(0.6.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(AppSpacing.card),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text("他人代墊我舊帳務修復", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "移除舊版誤寫入自己帳戶的入帳，改成借貸帳戶支出；不會自動執行，需你手動確認。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Button(
+                    onClick = {
+                        scope.launch {
+                            isRunning = true
+                            statusMessage = null
+                            statusIsError = false
+                            try {
+                                val result = repository.repairLegacyBorrowedAdvanceAccountInflation()
+                                report = repository.buildDataHealthReport()
+                                legacyTransactions = repository.legacyDebtIncomeTransactions()
+                                legacyShortcuts = repository.legacyDebtIncomeShortcuts()
+                                statusMessage = "已修復 ${result.repairedParticipantCount} 位對象，移除 ${result.removedInflatedAccountTransactionCount} 筆誤入帳。"
+                            } catch (error: Exception) {
+                                statusMessage = error.message ?: "修復他人代墊我舊帳務失敗。"
+                                statusIsError = true
+                            } finally {
+                                isRunning = false
+                            }
+                        }
+                    },
+                    enabled = !isRunning
+                ) {
+                    Text(if (isRunning) "處理中..." else "修復他人代墊我舊帳務")
+                }
+            }
+        }
+
         report?.let { current ->
             SummaryCard(current)
             IssueSection("錯誤", HealthSeverity.Error, current)

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/DataHealthCheckerTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/DataHealthCheckerTest.kt
@@ -104,6 +104,62 @@ class DataHealthCheckerTest {
         assertTrue(report.infoCount >= 1)
     }
 
+
+    @Test
+    fun borrowedByMeExpenseInitialRecord_doesNotCreateWarnings() {
+        val initialGroup = UUID.randomUUID()
+        val caseId = UUID.randomUUID()
+
+        val snapshot = DataHealthSnapshot(
+            transactions = listOf(
+                expense(initialGroup, debtAccount.id, BigDecimal("-50"), TransferSide.Outgoing)
+            ),
+            categories = listOf(foodCategory),
+            budgets = emptyList(),
+            advanceCases = listOf(
+                AdvanceCaseWithDetails(
+                    advanceCase = AdvanceCaseEntity(
+                        id = caseId,
+                        title = "Taxi",
+                        date = now,
+                        currencyCode = "HKD",
+                        myShareAmount = BigDecimal.ZERO,
+                        note = "",
+                        selfExpenseTransactionId = null,
+                        createdAt = now,
+                        updatedAt = now,
+                        payerAccountId = null,
+                        expenseCategoryId = foodCategory.id
+                    ),
+                    payerAccount = null,
+                    expenseCategory = foodCategory,
+                    participants = emptyList(),
+                    repayments = emptyList()
+                )
+            ),
+            advanceParticipants = listOf(
+                AdvanceParticipantEntity(
+                    id = UUID.randomUUID(),
+                    name = debtAccount.name,
+                    owedAmount = BigDecimal("50"),
+                    repaidAmount = BigDecimal.ZERO,
+                    initialTransferGroupId = initialGroup,
+                    createdAt = now,
+                    updatedAt = now,
+                    advanceCaseId = caseId,
+                    debtAccountId = debtAccount.id
+                )
+            ),
+            advanceRepayments = emptyList(),
+            shortcuts = emptyList()
+        )
+
+        val report = DataHealthChecker.run(snapshot, now)
+
+        assertEquals(0, report.errorCount)
+        assertEquals(0, report.warningCount)
+    }
+
     @Test
     fun mismatchedInitialTransferDirection_reportsWarning() {
         val initialGroup = UUID.randomUUID()
@@ -157,6 +213,36 @@ class DataHealthCheckerTest {
         val report = DataHealthChecker.run(snapshot, now)
 
         assertTrue(report.issues.any { it.title == "代墊初始轉帳方向不一致" })
+    }
+
+
+    private fun expense(
+        groupId: UUID,
+        accountId: UUID,
+        amount: BigDecimal,
+        side: TransferSide
+    ): TransactionWithDetails {
+        return TransactionWithDetails(
+            transaction = TransactionEntity(
+                id = UUID.randomUUID(),
+                amount = amount,
+                currencyCode = "HKD",
+                date = now,
+                note = "",
+                photoPath = null,
+                type = TransactionType.Expense,
+                linkedTransactionId = null,
+                transferGroupId = groupId,
+                transferSide = side,
+                createdAt = now,
+                updatedAt = now,
+                accountId = accountId,
+                categoryId = foodCategory.id
+            ),
+            account = null,
+            category = foodCategory,
+            tags = emptyList()
+        )
     }
 
     private fun transfer(

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -58,7 +58,8 @@ class BackupRoundTripTest {
         repository.importBackupJson(fixtureJson, replaceExisting = true)
         val initialReport = repository.buildDataHealthReport()
         assertEquals(0, initialReport.errorCount)
-        assertEquals(0, initialReport.warningCount)
+        assertEquals(1, initialReport.warningCount)
+        assertTrue(initialReport.issues.any { it.title == "他人代墊我舊資料會虛增自己帳戶" })
 
         val exportedJson = repository.exportBackupJson()
         val exported = BackupJsonAdapter.gson.fromJson(exportedJson, FullBackupData::class.java)
@@ -87,7 +88,8 @@ class BackupRoundTripTest {
 
             val secondReport = secondRepository.buildDataHealthReport()
             assertEquals(0, secondReport.errorCount)
-            assertEquals(0, secondReport.warningCount)
+            assertEquals(1, secondReport.warningCount)
+            assertTrue(secondReport.issues.any { it.title == "他人代墊我舊資料會虛增自己帳戶" })
 
             val dinnerCase = secondRepository.getAdvanceCase(UUID.fromString("88888888-8888-8888-8888-888888888881"))
             val taxiCase = secondRepository.getAdvanceCase(UUID.fromString("88888888-8888-8888-8888-888888888882"))


### PR DESCRIPTION
## Summary\n- Change `他人代墊我` creation so it no longer requires or credits a personal account.\n- Record third-party-paid advances as expense transactions on the debt account, preserving budget/report impact on the original paid date.\n- Add iOS and Android health-check warnings plus manual repair actions for legacy records that inflated personal assets.\n- Update Android tests for the new semantics and legacy warning behaviour.\n\n## Verification\n- `xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`\n- `./gradlew testDebugUnitTest assembleDebug`\n\n## Notes\n- Does not modify SwiftData / Room schema or JSON backup format.\n- Local uncommitted `Localizable.xcstrings` and Xcode scheme changes were intentionally left out.\n