### PR TITLE
Refresh Android parity documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,45 @@
 
 Language: **English** | [繁體中文](./README.zh-Hant.md) | [简体中文](./README.zh-Hans.md)
 
-AI Accounting is a personal finance app project.
+AI Accounting is a personal finance app for multi-currency bookkeeping, account tracking, budgeting, advances, debt management, and backups.
 
-- iOS app is production-ready (SwiftUI + SwiftData).
-- Android app currently has a scaffold baseline (Jetpack Compose) for phased parity implementation.
+- iOS is the product source of truth and the primary SwiftUI + SwiftData implementation.
+- Android is an active Kotlin + Jetpack Compose implementation that follows the iOS information architecture and parity checklist.
+- Android keeps one platform-specific extension: the home-screen widget.
 
-## iOS Features (Current)
+## Core Features
 
-- Multi-account bookkeeping (cash, bank, credit card, debt)
-- Multi-currency transactions (currency per transaction)
-- Fully editable transfer flows (including multi-leg transfer groups)
-- Advance tracking and repayment management
+- Multi-account bookkeeping for cash, bank, credit card, and debt accounts
+- Multi-currency income, expense, transfer, advance, and debt flows
+- Fully editable transfer flows, including grouped and same-account cross-currency transfers
+- Advance tracking with repayment management and settlement centre views
+- Debt management with borrow, repay, and debt-forgiveness semantics
 - Income/expense charts with category/tag drill-down
-- Full JSON backup/restore and CSV export
-- Optional AI receipt scanning with Gemini API key
+- Budgets, overspending alerts, and AI-assisted budget suggestions
+- Data health checks, JSON backup/restore, WebDAV remote backup, and CSV export
+- Optional AI receipt scanning with a user-provided Gemini API key
 
-## Android Status (Scaffold)
+## Platform Status
 
-- App shell with Compose entry screen
-- Widget stub (`SummaryWidgetProvider`)
-- Unit-test scaffold
-- CI workflow baseline
+### iOS
 
-See: `android/README.md`
+- Production-focused SwiftUI app with SwiftData persistence
+- Four maintained localisations: Traditional Chinese, Simplified Chinese, British English, and Japanese
+- Simulator CI build and string-catalog validation on pull requests
 
-## In-App User Guide (iOS)
+### Android
+
+- Kotlin + Jetpack Compose app with the same main tabs and core finance flows as iOS
+- Room-backed local data layer, parity test vectors, and Android CI build/unit tests
+- Android-only widget for quick summary visibility
+- Ongoing parity work is tracked in [`docs/specs/android-ios-parity.md`](./docs/specs/android-ios-parity.md)
+
+## In-App User Guide
 
 - You can open the guide from `Settings > User Guide`.
 - On first launch, the app shows the guide automatically.
 
-## Localization
+## Localisation
 
 iOS UI currently supports:
 
@@ -43,7 +52,7 @@ iOS UI currently supports:
 ## Tech Stack
 
 - iOS: SwiftUI, SwiftData, Charts, `generative-ai-swift`
-- Android: Kotlin, Jetpack Compose (scaffold phase)
+- Android: Kotlin, Jetpack Compose, Room, WorkManager, Android widgets
 
 ## Requirements
 
@@ -59,7 +68,7 @@ iOS UI currently supports:
 2. Select a simulator or device.
 3. Run with `Cmd + R`.
 
-### Android (Scaffold)
+### Android
 
 ```bash
 cd android
@@ -78,14 +87,15 @@ GitHub Actions on `push` / `pull_request` to `main`:
 
 ## Data Compatibility
 
-- Backup JSON contract: `docs/specs/data-model.md`
-- Cross-platform parity vectors: `docs/specs/parity-test-vectors.md`
+- Backup JSON contract: [`docs/specs/data-model.md`](./docs/specs/data-model.md)
+- Cross-platform parity vectors: [`docs/specs/parity-test-vectors.md`](./docs/specs/parity-test-vectors.md)
+- Manual validation matrix: [`docs/VALIDATION_MATRIX.md`](./docs/VALIDATION_MATRIX.md)
 
 ## Privacy and Secrets
 
 - Gemini API key is provided by each user inside the app.
-- API key is stored in iOS Keychain.
-- The repository does not include default API keys, tokens, or private keys.
+- API key is stored in iOS Keychain and Android secure storage.
+- The repository does not include default API keys, tokens, personal backups, or private keys.
 
 ## Open-Source Documents
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -2,31 +2,40 @@
 
 语言： [English](./README.md) | [繁體中文](./README.zh-Hant.md) | **简体中文**
 
-AI 记账是个人财务管理项目。
+AI 记账是个人财务管理 App，支持多币种记账、账户管理、预算、代垫、债务管理与备份。
 
-- iOS 版本是当前主线，功能完整并持续迭代。
-- Android 版本目前处于骨架阶段（Jetpack Compose），用于后续与 iOS 对齐。
+- iOS 是产品 source of truth，也是主要 SwiftUI + SwiftData 实现。
+- Android 是持续维护中的 Kotlin + Jetpack Compose 版本，按 iOS 的信息架构与功能语义对齐。
+- Android 保留一个平台专属能力：桌面小组件。
 
-## iOS 主要功能
+## 核心功能
 
 - 多账户记账：现金 / 银行 / 信用卡 / 借贷账户
-- 多币种交易：每笔交易可使用独立币种
-- 转账流程支持完整编辑（含多腿转账分组）
-- 代垫追踪与还款管理
+- 多币种收入、支出、转账、代垫与债务流程
+- 完整可编辑转账流程（含多腿转账分组与同账户跨币种转账）
+- 代垫追踪、还款管理与结算中心
+- 债务管理：借入、还款、免除债务
 - 收入/支出报表（分类与标签钻取）
-- JSON 全量备份/还原、CSV 导出
-- AI 小票扫描（可选填写 Gemini API Key）
+- 预算、超支提醒与 AI 预算建议
+- 数据健康检查、JSON 备份/还原、WebDAV 远程备份、CSV 导出
+- AI 小票扫描（用户自行填写 Gemini API Key）
 
-## Android 状态（骨架）
+## 平台状态
 
-- Compose app shell
-- Widget stub（`SummaryWidgetProvider`）
-- Unit test scaffold
-- Android CI baseline
+### iOS
 
-详见：`android/README.md`
+- SwiftUI + SwiftData 版本，功能完整并持续迭代
+- 维护四语：繁体中文、简体中文、英式英文、日文
+- PR 会运行 iOS simulator build 与 string catalog 校验
 
-## App 内使用教学（iOS）
+### Android
+
+- Kotlin + Jetpack Compose 版本，主页与核心财务流程已按 iOS 对齐
+- Room 本地数据层、parity 测试向量、Android CI build / unit tests
+- Android-only summary widget
+- 对齐规格见 [`docs/specs/android-ios-parity.md`](./docs/specs/android-ios-parity.md)
+
+## App 内使用教学
 
 - 可在 `设置 > 使用教学` 打开。
 - 首次使用 App 时，系统会自动显示教学页。
@@ -41,7 +50,7 @@ AI 记账是个人财务管理项目。
 ## 技术栈
 
 - iOS：SwiftUI、SwiftData、Charts、`generative-ai-swift`
-- Android：Kotlin、Jetpack Compose（骨架阶段）
+- Android：Kotlin、Jetpack Compose、Room、WorkManager、Android widgets
 
 ## 环境要求
 
@@ -57,12 +66,15 @@ AI 记账是个人财务管理项目。
 2. 选择 Simulator 或 iPhone 设备
 3. 使用 `Cmd + R` 运行
 
-### Android（骨架）
+### Android
 
 ```bash
-gradle -p android :app:assembleDebug
-gradle -p android :app:testDebugUnitTest
+cd android
+./gradlew :app:assembleDebug
+./gradlew :app:testDebugUnitTest
 ```
+
+APK 构建流程：[`docs/ANDROID_APK_BUILD.md`](./docs/ANDROID_APK_BUILD.md)
 
 ## CI
 
@@ -73,14 +85,15 @@ GitHub Actions 会在 `push` / `pull_request` 到 `main` 时执行：
 
 ## 数据兼容性
 
-- 跨平台数据契约：`docs/specs/data-model.md`
-- 跨平台 parity 测试向量：`docs/specs/parity-test-vectors.md`
+- 跨平台数据契约：[`docs/specs/data-model.md`](./docs/specs/data-model.md)
+- 跨平台 parity 测试向量：[`docs/specs/parity-test-vectors.md`](./docs/specs/parity-test-vectors.md)
+- 手动验证矩阵：[`docs/VALIDATION_MATRIX.md`](./docs/VALIDATION_MATRIX.md)
 
 ## 隐私与密钥
 
 - Gemini API Key 由用户在 App 内自行设置
-- API Key 存储在 iOS Keychain（不会写入仓库）
-- 仓库不包含任何默认 API Key、token 或私钥
+- API Key 存储在 iOS Keychain 与 Android secure storage
+- 仓库不包含任何默认 API Key、token、私人备份或私钥
 
 ## 开源文件
 
@@ -89,6 +102,7 @@ GitHub Actions 会在 `push` / `pull_request` 到 `main` 时执行：
 - 贡献指南： [English](./CONTRIBUTING.md) | [繁體中文](./CONTRIBUTING.zh-Hant.md) | [简体中文](./CONTRIBUTING.zh-Hans.md)
 - Pull Request 模板： [`.github/pull_request_template.md`](./.github/pull_request_template.md)
 - CI 检查清单： [`docs/CI_CHECKLIST.md`](./docs/CI_CHECKLIST.md)
+- Android APK 构建流程： [`docs/ANDROID_APK_BUILD.md`](./docs/ANDROID_APK_BUILD.md)
 
 ## 免责声明
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -2,31 +2,40 @@
 
 語言： [English](./README.md) | **繁體中文** | [简体中文](./README.zh-Hans.md)
 
-AI 記帳是個人財務管理專案。
+AI 記帳是個人財務管理 App，支援多幣別記帳、帳戶管理、預算、代墊、債務管理與備份。
 
-- iOS 版本目前為主線，功能完整且持續迭代。
-- Android 版本目前為骨架階段（Jetpack Compose），用於後續與 iOS 對齊。
+- iOS 是產品 source of truth，也是主要 SwiftUI + SwiftData 實作。
+- Android 是持續維護中的 Kotlin + Jetpack Compose 版本，按 iOS 的資訊架構與功能語義對齊。
+- Android 保留一個平台專屬能力：桌面小工具。
 
-## iOS 主要功能
+## 核心功能
 
 - 多帳戶記帳：現金 / 銀行 / 信用卡 / 借貸帳戶
-- 多幣別交易：每筆交易可使用獨立幣別
-- 完整可編輯轉帳流程（含多腳轉帳群組）
-- 代墊追蹤與還款管理
+- 多幣別收入、支出、轉帳、代墊與債務流程
+- 完整可編輯轉帳流程（含多腳轉帳群組與同帳戶跨幣種轉帳）
+- 代墊追蹤、還款管理與結算中心
+- 債務管理：借入、還款、免除債務
 - 收入/支出報表（分類與標籤鑽取）
-- JSON 全機備份/還原、CSV 匯出
-- AI 收據掃描（可選填 Gemini API Key）
+- 預算、超支提醒與 AI 預算建議
+- 資料健康檢查、JSON 備份/還原、WebDAV 遠端備份、CSV 匯出
+- AI 收據掃描（使用者自行填寫 Gemini API Key）
 
-## Android 狀態（骨架）
+## 平台狀態
 
-- Compose app shell
-- Widget stub（`SummaryWidgetProvider`）
-- Unit test scaffold
-- Android CI baseline
+### iOS
 
-詳見：`android/README.md`
+- SwiftUI + SwiftData 版本，功能完整且持續迭代
+- 維護四語：繁體中文、簡體中文、英式英文、日文
+- PR 會跑 iOS simulator build 與 string catalog 驗證
 
-## App 內使用教學（iOS）
+### Android
+
+- Kotlin + Jetpack Compose 版本，主頁與核心財務流程已按 iOS 對齊
+- Room 本地資料層、parity 測試向量、Android CI build / unit tests
+- Android-only summary widget
+- 對齊規格見 [`docs/specs/android-ios-parity.md`](./docs/specs/android-ios-parity.md)
+
+## App 內使用教學
 
 - 可在 `設定 > 使用教學` 開啟。
 - 首次使用 App 時，系統會自動顯示教學頁。
@@ -41,7 +50,7 @@ AI 記帳是個人財務管理專案。
 ## 技術棧
 
 - iOS：SwiftUI、SwiftData、Charts、`generative-ai-swift`
-- Android：Kotlin、Jetpack Compose（骨架階段）
+- Android：Kotlin、Jetpack Compose、Room、WorkManager、Android widgets
 
 ## 環境需求
 
@@ -57,11 +66,12 @@ AI 記帳是個人財務管理專案。
 2. 選擇 Simulator 或 iPhone 裝置
 3. `Cmd + R` 執行
 
-### Android（骨架）
+### Android
 
 ```bash
-gradle -p android :app:assembleDebug
-gradle -p android :app:testDebugUnitTest
+cd android
+./gradlew :app:assembleDebug
+./gradlew :app:testDebugUnitTest
 ```
 
 APK 建置流程：[`docs/ANDROID_APK_BUILD.md`](./docs/ANDROID_APK_BUILD.md)
@@ -75,14 +85,15 @@ GitHub Actions 會在 `push` / `pull_request` 到 `main` 時執行：
 
 ## 資料相容性
 
-- 跨平台資料契約：`docs/specs/data-model.md`
-- 跨平台 parity 測試向量：`docs/specs/parity-test-vectors.md`
+- 跨平台資料契約：[`docs/specs/data-model.md`](./docs/specs/data-model.md)
+- 跨平台 parity 測試向量：[`docs/specs/parity-test-vectors.md`](./docs/specs/parity-test-vectors.md)
+- 手動驗證矩陣：[`docs/VALIDATION_MATRIX.md`](./docs/VALIDATION_MATRIX.md)
 
 ## 隱私與金鑰
 
 - Gemini API Key 由使用者在 App 內設定
-- API Key 儲存在 iOS Keychain（不寫入 repo）
-- 專案不包含任何預設 API Key、token 或私鑰
+- API Key 儲存在 iOS Keychain 與 Android secure storage
+- 專案不包含任何預設 API Key、token、私人備份或私鑰
 
 ## 開源文件
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,25 +1,31 @@
-# Android Scaffold
+# Android App
 
-This folder contains the Android app baseline for AI Accounting.
+This folder contains the Android implementation of AI Accounting. Android follows the iOS app as the product source of truth while using native Kotlin, Jetpack Compose, Room, WorkManager, and Android widget APIs.
 
 ## Current Scope
 
-- Compose app shell with 4 tabs: Overview / Transactions / Reports / Settings
-- First-launch behavior: open Overview on first launch, default to Transactions afterward
-- Widget with app-driven preview content and refresh hook (`SummaryWidgetProvider`)
-- Kotlin parity core for cross-platform data behavior
-- Unit tests for parity vectors from `/docs/specs/parity-test-vectors.md`
+- Five main tabs aligned with iOS: Overview / Ledger / Reports / Accounts / Settings
+- First-launch behaviour: open Overview on first launch, then default to Ledger for returning users
+- Core bookkeeping flows for income, expense, transfer, debt, advances, budgets, reports, accounts, and backups
+- Settlement centre, data health checks, recurring transactions, WebDAV backup, and local preferences
+- Optional receipt scan review flow and Gemini API key settings
+- Android-only summary widget with app-driven preview content and refresh hook (`SummaryWidgetProvider`)
+- Unit tests for parity vectors from `../docs/specs/parity-test-vectors.md`
 
 ## Implemented Core Modules
 
-- `core/model`: canonical enums and entities aligned with `/docs/specs/data-model.md`
-- `core/report`: income/expense totals, transfer exclusion, category-kind filtering
+- `core/model`: canonical enums and entities aligned with `../docs/specs/data-model.md`
+- `core/report`: income/expense totals, transfer exclusion, category-kind filtering, and report summaries
 - `core/advance`: participant repayment progress and outstanding totals
-- `core/backup`: legacy backup defaults compatibility helpers
+- `core/backup`: JSON backup compatibility and legacy defaults
+- `core/currency`: currency formatting, conversion, and rate-source helpers
+- `data`: Room database, DAO, repository, secure settings, and import/export support
+- `ui`: Compose screens and parity UI components aligned with the iOS information architecture
+- `widget`: Android summary widget provider and update plumbing
 
 ## Build & Test
 
-Use Gradle wrapper from this folder:
+Use the Gradle wrapper from this folder:
 
 ```bash
 cd android
@@ -29,10 +35,17 @@ cd android
 
 Detailed APK build guide: [`../docs/ANDROID_APK_BUILD.md`](../docs/ANDROID_APK_BUILD.md)
 
+## APK Location
+
+After `assembleDebug`, the debug APK is written to:
+
+```text
+android/app/build/outputs/apk/debug/app-debug.apk
+```
+
 ## Release Signing
 
-To create a Play-uploadable release bundle, add a local `android/keystore.properties`
-file with:
+To create a Play-uploadable release bundle, add a local `android/keystore.properties` file with:
 
 ```properties
 storeFile=/absolute/path/to/upload-keystore.jks
@@ -41,8 +54,7 @@ keyAlias=your-key-alias
 keyPassword=your-key-password
 ```
 
-The release signing config is only activated when this file exists, so CI and local
-debug builds stay unaffected.
+The release signing config is only activated when this file exists, so CI and local debug builds stay unaffected.
 
 ## Environment Prerequisite
 
@@ -54,3 +66,5 @@ If Android SDK is not auto-detected, set one of:
 ```properties
 sdk.dir=/Users/<your-user>/Library/Android/sdk
 ```
+
+`local.properties` and `keystore.properties` are local-only files and must not be committed.

--- a/docs/CI_CHECKLIST.md
+++ b/docs/CI_CHECKLIST.md
@@ -3,7 +3,7 @@
 Status: Active  
 Last updated: 2026-04-18
 
-This checklist is the baseline for PR quality gates for dual-platform delivery.
+This checklist is the baseline for PR quality gates for dual-platform delivery. Treat Android as a maintained implementation when deciding affected-platform validation.
 
 ## 1. Required GitHub Checks
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -26,19 +26,23 @@ This document describes the current file layout for `AI 記帳`.
 - `AI 記帳/Views/Common/`: shared cross-feature UI (`DateFilterView`, title helpers).
 - `AI 記帳/Views/Shortcuts/`: quick-entry shortcut editor.
 
-## Android Source (Scaffold Phase)
+## Android Source
 
 - `android/settings.gradle.kts`: Android project settings.
 - `android/build.gradle.kts`: plugin declarations.
 - `android/app/build.gradle.kts`: app module config.
 - `android/app/src/main/java/.../MainActivity.kt`: Compose entry activity.
-- `android/app/src/main/java/.../widget/`: widget provider scaffold.
-- `android/README.md`: Android scaffold notes and local commands.
+- `android/app/src/main/java/.../core/`: Android domain models and pure parity logic.
+- `android/app/src/main/java/.../data/`: Room database, repositories, import/export, secure settings, and WebDAV support.
+- `android/app/src/main/java/.../ui/`: Compose screens, navigation, and parity UI components.
+- `android/app/src/main/java/.../widget/`: Android-only summary widget provider.
+- `android/app/src/test/`: Android unit tests and parity fixtures.
+- `android/README.md`: Android build, test, and local setup notes.
 
 ## CI and Automation
 
 - `.github/workflows/ios-ci.yml`: iOS build and string catalog validation.
-- `.github/workflows/android-ci.yml`: Android scaffold build and unit tests.
+- `.github/workflows/android-ci.yml`: Android build and unit tests.
 - `.github/pull_request_template.md`: PR quality and compatibility checklist.
 
 ## Repository Docs

--- a/docs/VALIDATION_MATRIX.md
+++ b/docs/VALIDATION_MATRIX.md
@@ -3,7 +3,7 @@
 Status: Active  
 Last updated: 2026-03-23
 
-This matrix is the shared validation baseline before merging dual-platform work.
+This matrix is the shared validation baseline before merging dual-platform work. Android is treated as an active app implementation, so validation should cover both parity behaviour and Android-specific surfaces such as the widget where relevant.
 
 ## Regression Fixture
 
@@ -44,6 +44,7 @@ xcodebuild -project 'AI 記帳.xcodeproj' \
 | iOS | Simulator | Advance: others advanced me | Create -> edit -> repayment -> delete stays consistent |
 | iOS | Physical device | Backup export/import | Exported JSON re-imports cleanly |
 | Android | Emulator | Import fixture JSON | Data imports successfully with no crash |
+| Android | Emulator | Main tabs parity smoke | Overview, Ledger, Reports, Accounts, and Settings open with the expected controls |
 | Android | Emulator | Account delete | Predictable result with and without linked transactions |
 | Android | Samsung A53 | Advance split repayment | Two receive accounts can be recorded and shown correctly |
 | Android | Samsung A53 | Advance merge repayment | Two source accounts can be recorded and shown correctly |

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -5,6 +5,13 @@
 - Android should match iOS page structure, wording, navigation rhythm, and core feature coverage.
 - The only accepted platform-specific extension is the Android widget.
 
+
+## Current Status
+- Android is an active Compose implementation with Room persistence, core finance flows, and parity validation.
+- iOS remains the source of truth for screen structure, copy, and flow semantics.
+- Parity waves 1-8 established the app shell, top-level screens, deep editor polish, guide flow, report/account alignment, and safe bottom spacing.
+- Remaining work should be tracked as specific parity deltas, not as a broad Android rewrite.
+
 ## Top-Level Screens
 
 ### Overview
@@ -64,8 +71,9 @@
 - Bottom tab and floating add button do not overlap hit targets.
 - Add sheet routes match iOS ordering and wording.
 - Receipt scan, debt entry, account detail all exist on Android.
-- Android build and unit tests pass after each parity wave.
-- iOS build passes after each parity wave to protect source-of-truth stability.
+- Android build and unit tests pass for parity-facing changes.
+- iOS build passes after source-of-truth changes to protect parity stability.
+- Documentation updates should distinguish completed parity waves from remaining deltas.
 
 
 ## Wave 2 Refinements


### PR DESCRIPTION
## Summary
- update root README files to describe Android as an active parity implementation instead of a scaffold
- refresh Android README with current build, module, and APK guidance
- update project structure, parity source-of-truth, validation matrix, and CI checklist wording

## Validation
- `./gradlew testDebugUnitTest assembleDebug`
- `xcodebuild -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- checked that `.DS_Store` files remain ignored and unstaged
