### PR TITLE
Lock borrowed advance accounting semantics

### DIFF
--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -688,7 +688,7 @@ private struct AdvanceCaseSummaryRow: View {
     }
 
     private var summaryLine: String {
-        let payer = advanceCase.payerAccount?.name ?? "未指定付款帳戶"
+        let payer = advanceCase.payerAccount?.name ?? "他人代付（不影響自己帳戶）"
         return "\(advanceCase.participants.count) 人 · \(payer)"
     }
 }

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 @MainActor
 final class BackupCompatibilityTests: XCTestCase {
-    func testLegacyAdvanceFixture_roundTripsWithoutHealthIssues() async throws {
+    func testLegacyAdvanceFixture_roundTripsWithBorrowedAdvanceWarning() async throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)
 
@@ -13,7 +13,8 @@ final class BackupCompatibilityTests: XCTestCase {
 
         let initialReport = DataHealthCheckService.run(modelContext: modelContext)
         XCTAssertEqual(0, initialReport.errorCount)
-        XCTAssertEqual(0, initialReport.warningCount)
+        XCTAssertEqual(1, initialReport.warningCount)
+        XCTAssertTrue(initialReport.issues.contains { $0.title == "他人代墊我舊資料會虛增自己帳戶" })
 
         let exported = BackupManager.shared.createBackupData(modelContext: modelContext)
         XCTAssertEqual(5, exported.accounts.count)
@@ -31,7 +32,8 @@ final class BackupCompatibilityTests: XCTestCase {
 
         let secondReport = DataHealthCheckService.run(modelContext: secondContext)
         XCTAssertEqual(0, secondReport.errorCount)
-        XCTAssertEqual(0, secondReport.warningCount)
+        XCTAssertEqual(1, secondReport.warningCount)
+        XCTAssertTrue(secondReport.issues.contains { $0.title == "他人代墊我舊資料會虛增自己帳戶" })
 
         let cases = try secondContext.fetch(FetchDescriptor<AdvanceCase>())
         XCTAssertEqual(2, cases.count)
@@ -218,6 +220,138 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(1, histories.count)
         XCTAssertEqual("2026-03|\(categoryID.uuidString)", histories.first?.historyKey)
         XCTAssertEqual(Decimal(string: "128.5"), histories.first?.spentAmount)
+    }
+
+    func testBorrowedAdvanceCreation_recordsDebtExpenseWithoutInflatingOwnAccount() async throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let ownAccount = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        let category = Category(name: "Food", icon: "fork.knife", colorHex: "#FF8800", kind: .expense)
+        let tag = Tag(name: "Dinner")
+        modelContext.insert(ownAccount)
+        modelContext.insert(debtAccount)
+        modelContext.insert(category)
+        modelContext.insert(tag)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "朋友代付晚餐",
+            date: date,
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "晚餐",
+            payerAccount: nil,
+            category: category,
+            tags: [tag],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 150)],
+            isBorrowedByMe: true,
+            modelContext: modelContext
+        )
+
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let ownAccountTransactions = transactions.filter { $0.account?.id == ownAccount.id }
+        let debtTransactions = transactions.filter { $0.account?.id == debtAccount.id }
+
+        XCTAssertNil(advanceCase.payerAccount)
+        XCTAssertEqual(Decimal.zero, advanceCase.myShareAmount)
+        XCTAssertNil(advanceCase.selfExpenseTransactionID)
+        XCTAssertTrue(ownAccountTransactions.isEmpty)
+        XCTAssertEqual(1, debtTransactions.count)
+        XCTAssertEqual(.expense, debtTransactions.first?.type)
+        XCTAssertEqual(.outgoing, debtTransactions.first?.transferSide)
+        XCTAssertNil(debtTransactions.first?.linkedTransactionID)
+        XCTAssertEqual(Decimal(-150), debtTransactions.first?.amount)
+        XCTAssertEqual(category.id, debtTransactions.first?.category?.id)
+        XCTAssertEqual([tag.id], debtTransactions.first?.tags.map(\.id))
+
+        let report = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertEqual(0, report.errorCount)
+        XCTAssertEqual(0, report.warningCount)
+    }
+
+    func testLegacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndKeepsExpense() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+        let groupID = UUID()
+        let outID = UUID()
+        let inID = UUID()
+
+        let ownAccount = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        let category = Category(name: "Food", icon: "fork.knife", colorHex: "#FF8800", kind: .expense)
+        let advanceCase = AdvanceCase(
+            title: "朋友代付晚餐",
+            date: date,
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "晚餐",
+            payerAccount: ownAccount,
+            expenseCategory: category
+        )
+        let participant = AdvanceParticipant(
+            name: debtAccount.name,
+            owedAmount: 150,
+            initialTransferGroupID: groupID,
+            advanceCase: advanceCase,
+            debtAccount: debtAccount
+        )
+        let legacyOutgoing = FinancialTransaction(
+            id: outID,
+            amount: -150,
+            currencyCode: "HKD",
+            date: date,
+            note: "晚餐 (他人代墊我)",
+            type: .transfer,
+            linkedTransactionID: inID,
+            transferGroupID: groupID,
+            transferSide: .outgoing,
+            account: debtAccount
+        )
+        let inflatedIncoming = FinancialTransaction(
+            id: inID,
+            amount: 150,
+            currencyCode: "HKD",
+            date: date,
+            note: "晚餐 (入到自己帳戶)",
+            type: .transfer,
+            linkedTransactionID: outID,
+            transferGroupID: groupID,
+            transferSide: .incoming,
+            account: ownAccount
+        )
+
+        modelContext.insert(ownAccount)
+        modelContext.insert(debtAccount)
+        modelContext.insert(category)
+        modelContext.insert(advanceCase)
+        modelContext.insert(participant)
+        modelContext.insert(legacyOutgoing)
+        modelContext.insert(inflatedIncoming)
+        try modelContext.save()
+
+        let initialReport = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertTrue(initialReport.issues.contains { $0.title == "他人代墊我舊資料會虛增自己帳戶" })
+
+        let result = try AdvanceService.repairLegacyBorrowedAdvanceAccountInflation(modelContext: modelContext)
+
+        XCTAssertEqual(1, result.repairedParticipantCount)
+        XCTAssertEqual(1, result.removedInflatedAccountTransactionCount)
+
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let repaired = try XCTUnwrap(transactions.first(where: { $0.id == outID }))
+        XCTAssertNil(transactions.first(where: { $0.id == inID }))
+        XCTAssertEqual(.expense, repaired.type)
+        XCTAssertEqual(.outgoing, repaired.transferSide)
+        XCTAssertNil(repaired.linkedTransactionID)
+        XCTAssertEqual(category.id, repaired.category?.id)
+        XCTAssertNil(advanceCase.payerAccount)
+
+        let repairedReport = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertFalse(repairedReport.issues.contains { $0.title == "他人代墊我舊資料會虛增自己帳戶" })
+        XCTAssertEqual(0, repairedReport.errorCount)
     }
 
     private func makeInMemoryContainer() throws -> ModelContainer {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
@@ -83,6 +83,7 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
     var participants by remember { mutableStateOf(listOf(ParticipantDraft())) }
     var showCreateDebtDialog by remember { mutableStateOf(false) }
     var newDebtName by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
 
     val flowCategories = categories.filter { it.kind.supports(org.duckdns.lhfser.aiaccounting.core.model.TransactionType.Expense) }
     val requiresPayerAccount = direction == AdvanceDirection.IAdvanceOthers
@@ -182,6 +183,7 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                         index = index,
                         participant = participant,
                         debtAccounts = debtAccounts,
+                        amountLabel = if (direction == AdvanceDirection.IAdvanceOthers) "代墊金額" else "我欠此人的金額",
                         onUpdate = { updated ->
                             participants = participants.toMutableList().also { list ->
                                 val targetIndex = list.indexOfFirst { it.id == participant.id }
@@ -218,14 +220,29 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
             onClick = {
                 scope.launch {
                     val payer = payerAccount
-                    if (requiresPayerAccount && payer == null) return@launch
-                    val myShareValue = if (direction == AdvanceDirection.OthersAdvanceMe) BigDecimal.ZERO else (myShare.toBigDecimalOrNull() ?: BigDecimal.ZERO)
-                    val inputs = participants.mapNotNull { draft ->
-                        val account = draft.debtAccount ?: return@mapNotNull null
-                        val amount = draft.amount.toBigDecimalOrNull() ?: return@mapNotNull null
-                        AdvanceParticipantInput(account, amount)
+                    if (requiresPayerAccount && payer == null) {
+                        errorMessage = "請選擇付款帳戶。"
+                        return@launch
                     }
-                    if (inputs.isEmpty()) return@launch
+                    val myShareValue = if (direction == AdvanceDirection.OthersAdvanceMe) BigDecimal.ZERO else (myShare.toBigDecimalOrNull() ?: BigDecimal.ZERO)
+                    val inputs = mutableListOf<AdvanceParticipantInput>()
+                    for (draft in participants) {
+                        val account = draft.debtAccount
+                        if (account == null) {
+                            errorMessage = "請為每位對象選擇債務人物。"
+                            return@launch
+                        }
+                        val amount = draft.amount.toBigDecimalOrNull()
+                        if (amount == null || amount <= BigDecimal.ZERO) {
+                            errorMessage = "請填寫每位對象大於 0 的金額。"
+                            return@launch
+                        }
+                        inputs += AdvanceParticipantInput(account, amount)
+                    }
+                    if (inputs.isEmpty()) {
+                        errorMessage = "請至少新增一位對象。"
+                        return@launch
+                    }
                     repository.createAdvanceCase(
                         title = title,
                         date = Instant.now(),
@@ -299,6 +316,19 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
             }
         )
     }
+
+    errorMessage?.let { message ->
+        AlertDialog(
+            onDismissRequest = { errorMessage = null },
+            title = { Text("無法儲存") },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { errorMessage = null }) {
+                    Text("好")
+                }
+            }
+        )
+    }
 }
 
 
@@ -307,6 +337,7 @@ private fun ParticipantEditor(
     index: Int,
     participant: ParticipantDraft,
     debtAccounts: List<AccountEntity>,
+    amountLabel: String,
     onUpdate: (ParticipantDraft) -> Unit,
     onRemove: (() -> Unit)?
 ) {
@@ -319,7 +350,7 @@ private fun ParticipantEditor(
             onUpdate(participant.copy(debtAccount = acc))
         }
         AmountRow(
-            label = "代墊金額",
+            label = amountLabel,
             amount = participant.amount,
             onAmountChange = { onUpdate(participant.copy(amount = sanitizeAmount(it))) },
             currency = participant.debtAccount?.currency ?: "HKD"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -529,7 +529,7 @@ private fun AdvanceSummaryRow(
     val outstanding = item.participants.fold(BigDecimal.ZERO) { acc, participant ->
         acc + (participant.owedAmount - participant.repaidAmount).max(BigDecimal.ZERO)
     }
-    val payerText = item.payerAccount?.name ?: "未指定付款帳戶"
+    val payerText = item.payerAccount?.name ?: "他人代付（不影響自己帳戶）"
 
     PressableCard(
         modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -15,7 +15,9 @@ import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -148,6 +150,103 @@ class BackupRoundTripTest {
             val secondReport = secondRepository.buildDataHealthReport()
             assertFalse(secondReport.issues.any { it.title == "收入交易記到了借貸帳戶" })
             assertFalse(secondReport.issues.any { it.title == "收入捷徑綁到了借貸帳戶" })
+            assertEquals(0, secondReport.errorCount)
+        } finally {
+            secondDatabase.close()
+        }
+    }
+
+    @Test
+    fun borrowedAdvanceCreation_recordsDebtExpenseWithoutInflatingOwnAccount() = runBlocking {
+        val ownAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val debtAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Friend A",
+            currency = "HKD",
+            type = AccountType.Debt,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 1,
+            isArchived = false
+        )
+        val category = CategoryEntity(
+            id = UUID.randomUUID(),
+            name = "Food",
+            icon = "fork.knife",
+            colorHex = "#FF8800",
+            kind = CategoryKind.Expense
+        )
+        val tag = TagEntity(UUID.randomUUID(), "Dinner")
+        database.accountDao().upsertAll(listOf(ownAccount, debtAccount))
+        database.categoryDao().upsert(category)
+        database.tagDao().upsert(tag)
+
+        val caseId = repository.createAdvanceCase(
+            title = "朋友代付晚餐",
+            date = Instant.parse("2026-03-21T12:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "晚餐",
+            payerAccount = null,
+            expenseCategory = category,
+            tagIds = listOf(tag.id),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("150"))),
+            isBorrowedByMe = true
+        )
+
+        val advanceCase = checkNotNull(repository.getAdvanceCase(caseId))
+        val transactions = database.transactionDao().getAllWithDetails()
+        val ownAccountTransactions = transactions.filter { it.transaction.accountId == ownAccount.id }
+        val debtTransactions = transactions.filter { it.transaction.accountId == debtAccount.id }
+        val transactionTags = database.transactionDao().getTransactionTags()
+
+        assertNull(advanceCase.payerAccount)
+        assertEquals(BigDecimal.ZERO, advanceCase.advanceCase.myShareAmount)
+        assertNull(advanceCase.advanceCase.selfExpenseTransactionId)
+        assertTrue(ownAccountTransactions.isEmpty())
+        assertEquals(1, debtTransactions.size)
+        assertEquals(TransactionType.Expense, debtTransactions.single().transaction.type)
+        assertEquals(BigDecimal("-150"), debtTransactions.single().transaction.amount)
+        assertEquals(category.id, debtTransactions.single().transaction.categoryId)
+        assertTrue(transactionTags.any { it.transactionId == debtTransactions.single().transaction.id && it.tagId == tag.id })
+
+        val report = repository.buildDataHealthReport()
+        assertEquals(0, report.errorCount)
+        assertEquals(0, report.warningCount)
+    }
+
+    @Test
+    fun legacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndReimportsCleanly() = runBlocking {
+        val fixtureJson = loadFixture("fixtures/legacy_bidirectional_advances.json")
+
+        repository.importBackupJson(fixtureJson, replaceExisting = true)
+        val initialReport = repository.buildDataHealthReport()
+        assertTrue(initialReport.issues.any { it.title == "他人代墊我舊資料會虛增自己帳戶" })
+
+        val result = repository.repairLegacyBorrowedAdvanceAccountInflation()
+
+        assertEquals(1, result.repairedParticipantCount)
+        assertEquals(1, result.removedInflatedAccountTransactionCount)
+
+        val repairedReport = repository.buildDataHealthReport()
+        assertFalse(repairedReport.issues.any { it.title == "他人代墊我舊資料會虛增自己帳戶" })
+        assertEquals(0, repairedReport.errorCount)
+        assertEquals(0, repairedReport.warningCount)
+
+        val exportedJson = repository.exportBackupJson()
+        val secondDatabase = buildDatabase()
+        try {
+            val secondRepository = AccountingRepository(secondDatabase, currencyService)
+            secondRepository.importBackupJson(exportedJson, replaceExisting = true)
+            val secondReport = secondRepository.buildDataHealthReport()
+            assertFalse(secondReport.issues.any { it.title == "他人代墊我舊資料會虛增自己帳戶" })
             assertEquals(0, secondReport.errorCount)
         } finally {
             secondDatabase.close()


### PR DESCRIPTION
## Summary
- lock `他人代墊我` semantics so borrowed advances record debt-account expenses without inflating own accounts
- show borrowed advance summaries as `他人代付（不影響自己帳戶）` instead of an unspecified payer account
- tighten Android advance creation validation so incomplete participants are not silently ignored
- add iOS and Android regression coverage for new borrowed-advance records and legacy repair

## Validation
- `xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO`
- `./gradlew testDebugUnitTest assembleDebug`
