### PR TITLE
Add ledger actions to report details

### DIFF
--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -4,7 +4,10 @@ import SwiftData
 struct AccountDetailView: View {
     let account: Account
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
+    @Query private var advanceParticipants: [AdvanceParticipant]
+    @Query private var advanceRepayments: [AdvanceRepayment]
     @Environment(\.modelContext) private var modelContext
+    @State private var transactionToEdit: FinancialTransaction?
     @State private var deletionErrorMessage: String?
     
     // 🔥 修正 1：定義一個結構體來代替 Tuple，讓 ForEach 能識別
@@ -15,7 +18,12 @@ struct AccountDetailView: View {
     }
     
     var body: some View {
-        let renderState = AccountDetailRenderState(account: account, allTransactions: allTransactions)
+        let renderState = AccountDetailRenderState(
+            account: account,
+            allTransactions: allTransactions,
+            advanceParticipants: advanceParticipants,
+            advanceRepayments: advanceRepayments
+        )
 
         List {
             // 1. 頂部資訊卡 (總覽)
@@ -76,18 +84,32 @@ struct AccountDetailView: View {
                         transaction: transaction,
                         transferCounterpart: renderState.transferCounterpartByID[transaction.id]
                     )
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                deleteTransaction(transaction)
-                            } label: {
-                                Label("刪除", systemImage: "trash")
-                            }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        transactionToEdit = transaction
+                    }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            deleteTransaction(transaction)
+                        } label: {
+                            Label("刪除", systemImage: "trash")
                         }
+
+                        Button {
+                            transactionToEdit = transaction
+                        } label: {
+                            Label("編輯", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                    }
                 }
             }
         }
         .navigationTitle(account.name)
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $transactionToEdit) { tx in
+            transactionEditor(for: tx, renderState: renderState)
+        }
         .alert("無法刪除", isPresented: Binding(
             get: { deletionErrorMessage != nil },
             set: { if !$0 { deletionErrorMessage = nil } }
@@ -98,6 +120,33 @@ struct AccountDetailView: View {
         }
     }
     
+    @ViewBuilder
+    private func transactionEditor(for tx: FinancialTransaction, renderState: AccountDetailRenderState) -> some View {
+        if tx.type == .transfer {
+            if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
+                EditAdvanceTransferView(originalTransaction: tx)
+            } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+                AddDebtView(existingForgivenessTransaction: tx)
+            } else {
+                EditTransferView(originalTransaction: tx)
+            }
+        } else {
+            EditTransactionView(transaction: tx)
+        }
+    }
+
+    private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {
+        guard tx.type == .transfer else { return false }
+        if let groupID = tx.transferGroupID, advanceGroupIDs.contains(groupID) {
+            return true
+        }
+        let compacted = tx.note.replacingOccurrences(of: " ", with: "")
+        return compacted.contains("(代墊給")
+            || compacted.contains("(代墊給我")
+            || compacted.contains("(還款至")
+            || compacted.contains("(還款給")
+    }
+
     private func deleteTransaction(_ transaction: FinancialTransaction) {
         do {
             try LedgerDeletionService.delete(transaction: transaction, modelContext: modelContext)
@@ -111,11 +160,20 @@ private struct AccountDetailRenderState {
     let accountTransactions: [FinancialTransaction]
     let transferCounterpartByID: [UUID: TransferCounterpartInfo]
     let currencyBalances: [AccountDetailView.CurrencyBalance]
+    let advanceGroupIDs: Set<UUID>
 
-    init(account: Account, allTransactions: [FinancialTransaction]) {
+    init(
+        account: Account,
+        allTransactions: [FinancialTransaction],
+        advanceParticipants: [AdvanceParticipant],
+        advanceRepayments: [AdvanceRepayment]
+    ) {
         let accountTransactions = allTransactions.filter { $0.account?.id == account.id }
+        var advanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
+        advanceGroupIDs.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
 
         self.accountTransactions = accountTransactions
+        self.advanceGroupIDs = advanceGroupIDs
         self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: allTransactions)
         self.currencyBalances = Self.currencyBalances(
             account: account,

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -520,11 +520,22 @@ private struct ChartsRenderState {
 }
 
 private struct ReportTransactionListView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var advanceParticipants: [AdvanceParticipant]
+    @Query private var advanceRepayments: [AdvanceRepayment]
+
     let title: String
     let transactions: [FinancialTransaction]
 
+    @State private var transactionToEdit: FinancialTransaction?
+    @State private var deletionErrorMessage: String?
+
     var body: some View {
-        let renderState = ReportTransactionListRenderState(transactions: transactions)
+        let renderState = ReportTransactionListRenderState(
+            transactions: transactions,
+            advanceParticipants: advanceParticipants,
+            advanceRepayments: advanceRepayments
+        )
 
         NavigationStack {
             Group {
@@ -539,6 +550,24 @@ private struct ReportTransactionListView: View {
                                         transaction: tx,
                                         transferCounterpart: renderState.transferCounterpartByID[tx.id]
                                     )
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        transactionToEdit = tx
+                                    }
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                        Button(role: .destructive) {
+                                            deleteTransaction(tx)
+                                        } label: {
+                                            Label("刪除", systemImage: "trash")
+                                        }
+
+                                        Button {
+                                            transactionToEdit = tx
+                                        } label: {
+                                            Label("編輯", systemImage: "pencil")
+                                        }
+                                        .tint(.blue)
+                                    }
                                 }
                             }
                         }
@@ -549,14 +578,68 @@ private struct ReportTransactionListView: View {
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
         }
+        .sheet(item: $transactionToEdit) { tx in
+            transactionEditor(for: tx, renderState: renderState)
+        }
+        .alert("無法刪除", isPresented: Binding(
+            get: { deletionErrorMessage != nil },
+            set: { if !$0 { deletionErrorMessage = nil } }
+        )) {
+            Button("好", role: .cancel) { deletionErrorMessage = nil }
+        } message: {
+            Text(deletionErrorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private func transactionEditor(for tx: FinancialTransaction, renderState: ReportTransactionListRenderState) -> some View {
+        if tx.type == .transfer {
+            if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
+                EditAdvanceTransferView(originalTransaction: tx)
+            } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+                AddDebtView(existingForgivenessTransaction: tx)
+            } else {
+                EditTransferView(originalTransaction: tx)
+            }
+        } else {
+            EditTransactionView(transaction: tx)
+        }
+    }
+
+    private func deleteTransaction(_ tx: FinancialTransaction) {
+        do {
+            try LedgerDeletionService.delete(transaction: tx, modelContext: modelContext)
+        } catch {
+            deletionErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {
+        guard tx.type == .transfer else { return false }
+        if let groupID = tx.transferGroupID, advanceGroupIDs.contains(groupID) {
+            return true
+        }
+        let compacted = tx.note.replacingOccurrences(of: " ", with: "")
+        return compacted.contains("(代墊給")
+            || compacted.contains("(代墊給我")
+            || compacted.contains("(還款至")
+            || compacted.contains("(還款給")
     }
 }
 
 private struct ReportTransactionListRenderState {
     let transferCounterpartByID: [UUID: TransferCounterpartInfo]
     let groupedTransactions: [(title: String, items: [FinancialTransaction])]
+    let advanceGroupIDs: Set<UUID>
 
-    init(transactions: [FinancialTransaction]) {
+    init(
+        transactions: [FinancialTransaction],
+        advanceParticipants: [AdvanceParticipant],
+        advanceRepayments: [AdvanceRepayment]
+    ) {
+        var advanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
+        advanceGroupIDs.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
+        self.advanceGroupIDs = advanceGroupIDs
         self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: transactions)
         self.groupedTransactions = Self.groupedTransactions(from: transactions)
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -256,7 +256,13 @@ fun AIAccountingRoot(
                     onAddShortcut = { navController.navigate("shortcuts/edit/${UUID.randomUUID()}") }
                 )
             }
-            composable(AppDestination.Reports.route) { ReportsScreen() }
+            composable(AppDestination.Reports.route) {
+                ReportsScreen(
+                    onEdit = { id -> navController.navigate("transaction/edit/$id") },
+                    onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") },
+                    onEditDebt = { id -> navController.navigate("debt/edit/$id") }
+                )
+            }
             composable(AppDestination.Accounts.route) {
                 AccountsScreen(
                     onOpenDetail = { id -> navController.navigate("accounts/$id") },

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -12,19 +12,25 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
@@ -48,11 +54,14 @@ fun AccountDetailScreen(
     onEditDebt: (String) -> Unit
 ) {
     val repository = LocalRepository.current
+    val scope = rememberCoroutineScope()
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val transactions by repository.transactions.collectAsState(initial = emptyList())
 
     val resolvedId = remember(accountId) { accountId?.let(UUID::fromString) }
     val account = remember(accounts, resolvedId) { accounts.firstOrNull { it.id == resolvedId } }
+    var transactionToDelete by remember { mutableStateOf<TransactionWithDetails?>(null) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
 
     if (account == null) {
         Column(
@@ -156,17 +165,53 @@ fun AccountDetailScreen(
                             item.transaction.type == TransactionType.Transfer && groupId != null -> onEditTransfer(groupId)
                             else -> onEditTransaction(item.transaction.id.toString())
                         }
-                    }
+                    },
+                    onLongClick = { transactionToDelete = item }
                 )
             }
         }
     }
+    if (transactionToDelete != null) {
+        val target = transactionToDelete ?: return
+        val groupId = target.transaction.transferGroupId?.toString()
+        val isTransfer = target.transaction.type == TransactionType.Transfer && groupId != null
+        AlertDialog(
+            onDismissRequest = { transactionToDelete = null },
+            title = { Text(if (isTransfer) "刪除轉帳？" else "刪除交易？") },
+            text = { Text(if (isTransfer) "將刪除此筆轉帳的所有分錄。" else "刪除後無法復原。") },
+            confirmButton = {
+                TextButton(onClick = {
+                    transactionToDelete = null
+                    scope.launch {
+                        val result = repository.deleteLedgerTransactionById(target.transaction.id)
+                        if (result == LedgerDeletionResult.AdvanceInitialRequiresCase) {
+                            errorMessage = "這是代墊建立分錄，請進入代墊詳情刪除整個代墊案件。"
+                        }
+                    }
+                }) { Text("刪除", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { transactionToDelete = null }) { Text("取消") }
+            }
+        )
+    }
+
+    if (errorMessage != null) {
+        AlertDialog(
+            onDismissRequest = { errorMessage = null },
+            title = { Text("無法執行操作") },
+            text = { Text(errorMessage ?: "") },
+            confirmButton = { TextButton(onClick = { errorMessage = null }) { Text("了解") } }
+        )
+    }
+
 }
 
 @Composable
 private fun AccountTransactionRow(
     item: TransactionWithDetails,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
 ) {
     val transaction = item.transaction
     val amountColor = when {
@@ -189,6 +234,7 @@ private fun AccountTransactionRow(
     PressableCard(
         modifier = Modifier.fillMaxWidth(),
         onClick = onClick,
+        onLongClick = onLongClick,
         containerColor = MaterialTheme.colorScheme.surface,
         pressedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
         borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
@@ -245,7 +291,7 @@ private fun AccountTransactionRow(
                         text = when {
                             isDebtForgiveness -> "編輯免除債務"
                             transaction.type == TransactionType.Transfer -> "編輯轉帳"
-                            else -> "查看 / 編輯"
+                            else -> "點擊編輯 · 長按刪除"
                         },
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.primary

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,13 +56,16 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
 import org.duckdns.lhfser.aiaccounting.core.preferences.resolveSharedDateRange
 import org.duckdns.lhfser.aiaccounting.core.preferences.sharedDateFilterLabel
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
@@ -110,11 +114,16 @@ private data class BudgetAlert(
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun ReportsScreen() {
+fun ReportsScreen(
+    onEdit: (String) -> Unit,
+    onEditTransfer: (String) -> Unit,
+    onEditDebt: (String) -> Unit
+) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
     val uiPreferencesStore = LocalUiPreferences.current
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     val transactions by repository.transactions.collectAsState(initial = emptyList())
     val categories by repository.categories.collectAsState(initial = emptyList())
@@ -126,6 +135,8 @@ fun ReportsScreen() {
     var flowMode by remember { mutableStateOf(ReportFlowMode.Expense) }
     var selectedTag by remember { mutableStateOf<String?>(null) }
     var reportDetail by remember { mutableStateOf<ReportDetail?>(null) }
+    var transactionToDelete by remember { mutableStateOf<TransactionWithDetails?>(null) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
     val dateFilter = uiPreferences.dateFilter
     val filterType = dateFilter.type
     val selectedDate = dateFilter.selectedDate
@@ -300,6 +311,43 @@ fun ReportsScreen() {
         }
     }
 
+
+    if (transactionToDelete != null) {
+        val target = transactionToDelete ?: return
+        val groupId = target.transaction.transferGroupId?.toString()
+        val isTransfer = target.transaction.type == TransactionType.Transfer && groupId != null
+        AlertDialog(
+            onDismissRequest = { transactionToDelete = null },
+            title = { Text(if (isTransfer) "刪除轉帳？" else "刪除交易？") },
+            text = { Text(if (isTransfer) "將刪除此筆轉帳的所有分錄。" else "刪除後無法復原。") },
+            confirmButton = {
+                TextButton(onClick = {
+                    transactionToDelete = null
+                    scope.launch {
+                        val result = repository.deleteLedgerTransactionById(target.transaction.id)
+                        if (result == LedgerDeletionResult.AdvanceInitialRequiresCase) {
+                            errorMessage = "這是代墊建立分錄，請進入代墊詳情刪除整個代墊案件。"
+                        }
+                    }
+                }) { Text("刪除", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { transactionToDelete = null }) { Text("取消") }
+            }
+        )
+    }
+
+    if (errorMessage != null) {
+        AlertDialog(
+            onDismissRequest = { errorMessage = null },
+            title = { Text("無法執行操作") },
+            text = { Text(errorMessage ?: "") },
+            confirmButton = {
+                TextButton(onClick = { errorMessage = null }) { Text("了解") }
+            }
+        )
+    }
+
     if (showFilterDialog) {
         SharedDateFilterSheet(
             title = "選擇區間",
@@ -334,7 +382,16 @@ fun ReportsScreen() {
             containerColor = MaterialTheme.colorScheme.background,
             dragHandle = { ParitySheetHandle() }
         ) {
-            ReportDetailSheet(detail = reportDetail ?: return@ModalBottomSheet)
+            ReportDetailSheet(
+                detail = reportDetail ?: return@ModalBottomSheet,
+                onEdit = { tx ->
+                    reportDetail = null
+                    routeTransactionEdit(tx, onEdit, onEditTransfer, onEditDebt)
+                },
+                onDelete = { tx ->
+                    transactionToDelete = tx
+                }
+            )
         }
     }
 }
@@ -535,7 +592,11 @@ private fun BudgetAlertCard(alerts: List<BudgetAlert>) {
 }
 
 @Composable
-private fun ReportDetailSheet(detail: ReportDetail) {
+private fun ReportDetailSheet(
+    detail: ReportDetail,
+    onEdit: (TransactionWithDetails) -> Unit,
+    onDelete: (TransactionWithDetails) -> Unit
+) {
     val grouped = remember(detail.transactions) {
         val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd (E)")
         detail.transactions.groupBy { tx ->
@@ -568,14 +629,14 @@ private fun ReportDetailSheet(detail: ReportDetail) {
                     )
                 }
                 items(items, key = { it.transaction.id }) { tx ->
-                    Surface(
+                    PressableCard(
                         modifier = Modifier.fillMaxWidth(),
-                        shape = MaterialTheme.shapes.large,
-                        color = MaterialTheme.colorScheme.surfaceVariant,
-                        border = androidx.compose.foundation.BorderStroke(
-                            0.6.dp,
-                            MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
-                        )
+                        onClick = { onEdit(tx) },
+                        onLongClick = { onDelete(tx) },
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        pressedContainerColor = MaterialTheme.colorScheme.surface,
+                        borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.20f),
+                        pressedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.42f)
                     ) {
                         Row(
                             modifier = Modifier.padding(horizontal = AppSpacing.card, vertical = 12.dp),
@@ -603,6 +664,11 @@ private fun ReportDetailSheet(detail: ReportDetail) {
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
+                                Text(
+                                    "點擊編輯 · 長按刪除",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
                             }
                             Text(
                                 tx.transaction.amount.asCurrencyText(tx.transaction.currencyCode),
@@ -614,6 +680,26 @@ private fun ReportDetailSheet(detail: ReportDetail) {
                     }
                 }
             }
+        }
+    }
+}
+
+private fun routeTransactionEdit(
+    item: TransactionWithDetails,
+    onEdit: (String) -> Unit,
+    onEditTransfer: (String) -> Unit,
+    onEditDebt: (String) -> Unit
+) {
+    val groupId = item.transaction.transferGroupId?.toString()
+    when {
+        item.transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(item.transaction.note) -> {
+            onEditDebt(item.transaction.id.toString())
+        }
+        item.transaction.type == TransactionType.Transfer && groupId != null -> {
+            onEditTransfer(groupId)
+        }
+        else -> {
+            onEdit(item.transaction.id.toString())
         }
     }
 }


### PR DESCRIPTION
## Summary
- make iOS report detail rows behave like ledger rows with tap-to-edit and swipe-to-delete
- add the same edit/delete semantics to iOS account detail rows
- wire Android report detail rows to existing edit routes and semantic delete
- add long-press delete to Android account detail rows for parity

## Validation
- `xcodebuild -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `./gradlew testDebugUnitTest assembleDebug`
