### PR TITLE
Warn about uncategorised borrowed advances

### DIFF
--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -356,12 +356,66 @@ enum DataHealthCheckService {
             )
         }
 
+        checkBorrowedAdvanceExpenseCategories(
+            participants: participants,
+            transactions: transactions,
+            into: &issues
+        )
+
         checkAdvanceTransferMappings(
             participants: participants,
             repayments: repayments,
             transactions: transactions,
             into: &issues
         )
+    }
+
+    private static func checkBorrowedAdvanceExpenseCategories(
+        participants: [AdvanceParticipant],
+        transactions: [FinancialTransaction],
+        into issues: inout [HealthIssue]
+    ) {
+        let groupedTransfers = Dictionary(grouping: transactions.filter { $0.transferGroupID != nil }) {
+            $0.transferGroupID!
+        }
+
+        var missingCategoryExpenseCount = 0
+
+        for participant in participants {
+            guard
+                let advanceCase = participant.advanceCase,
+                advanceCase.payerAccount == nil,
+                let debtAccountID = participant.debtAccount?.id,
+                let groupID = participant.initialTransferGroupID,
+                let group = groupedTransfers[groupID]
+            else {
+                continue
+            }
+
+            let borrowedExpenseTransactions = group.filter {
+                $0.type == .expense &&
+                ($0.transferSide == .outgoing || $0.amount < 0) &&
+                $0.account?.id == debtAccountID
+            }
+
+            guard !borrowedExpenseTransactions.isEmpty else { continue }
+
+            let caseCategoryMissing = advanceCase.expenseCategory == nil
+            missingCategoryExpenseCount += borrowedExpenseTransactions.filter {
+                caseCategoryMissing || $0.category == nil
+            }.count
+        }
+
+        if missingCategoryExpenseCount > 0 {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "他人代墊我缺少支出分類",
+                    detail: "共有 \(missingCategoryExpenseCount) 筆他人代墊我支出未設定分類，會出現在未分類支出。",
+                    recommendation: "請從報表明細、帳目頁或代墊詳情打開對應帳目，補上支出分類。"
+                )
+            )
+        }
     }
 
     private static func checkAdvanceTransferMappings(

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -271,6 +271,38 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(0, report.warningCount)
     }
 
+    func testBorrowedAdvanceWithoutCategory_reportsUncategorisedExpenseWarning() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        modelContext.insert(debtAccount)
+        try modelContext.save()
+
+        _ = try AdvanceService.createAdvanceCase(
+            title: "朋友代付晚餐",
+            date: date,
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "晚餐",
+            payerAccount: nil,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 150)],
+            isBorrowedByMe: true,
+            modelContext: modelContext
+        )
+
+        let report = DataHealthCheckService.run(modelContext: modelContext)
+
+        XCTAssertEqual(0, report.errorCount)
+        XCTAssertTrue(report.issues.contains { issue in
+            issue.title == "他人代墊我缺少支出分類" &&
+            issue.detail.contains("1 筆")
+        })
+    }
+
     func testLegacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndKeepsExpense() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/health/DataHealthChecker.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/health/DataHealthChecker.kt
@@ -370,7 +370,52 @@ object DataHealthChecker {
             )
         }
 
+        checkBorrowedAdvanceExpenseCategories(cases, participants, transactions, issues)
         checkAdvanceTransferMappings(cases, participants, repayments, transactions, issues)
+    }
+
+    private fun checkBorrowedAdvanceExpenseCategories(
+        cases: List<AdvanceCaseWithDetails>,
+        participants: List<AdvanceParticipantEntity>,
+        transactions: List<TransactionWithDetails>,
+        issues: MutableList<HealthIssue>
+    ) {
+        val casesById = cases.associateBy { it.advanceCase.id }
+        val groupedTransfers = transactions
+            .filter { it.transaction.transferGroupId != null }
+            .groupBy { it.transaction.transferGroupId!! }
+
+        var missingCategoryExpenseCount = 0
+
+        participants.forEach { participant ->
+            val caseDetails = participant.advanceCaseId?.let { casesById[it] } ?: return@forEach
+            if (caseDetails.advanceCase.payerAccountId != null) return@forEach
+
+            val debtAccountId = participant.debtAccountId ?: return@forEach
+            val groupId = participant.initialTransferGroupId ?: return@forEach
+            val group = groupedTransfers[groupId] ?: return@forEach
+
+            val borrowedExpenseTransactions = group.filter {
+                it.transaction.type == TransactionType.Expense &&
+                    (it.transaction.transferSide == TransferSide.Outgoing || it.transaction.amount < BigDecimal.ZERO) &&
+                    it.transaction.accountId == debtAccountId
+            }
+            if (borrowedExpenseTransactions.isEmpty()) return@forEach
+
+            val caseCategoryMissing = caseDetails.advanceCase.expenseCategoryId == null || caseDetails.expenseCategory == null
+            missingCategoryExpenseCount += borrowedExpenseTransactions.count {
+                caseCategoryMissing || it.transaction.categoryId == null || it.category == null
+            }
+        }
+
+        if (missingCategoryExpenseCount > 0) {
+            issues += HealthIssue(
+                severity = HealthSeverity.Warning,
+                title = "他人代墊我缺少支出分類",
+                detail = "共有 $missingCategoryExpenseCount 筆他人代墊我支出未設定分類，會出現在未分類支出。",
+                recommendation = "請從報表明細、帳目頁或代墊詳情打開對應帳目，補上支出分類。"
+            )
+        }
     }
 
     private fun checkAdvanceTransferMappings(

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/DataHealthCheckerTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/DataHealthCheckerTest.kt
@@ -161,6 +161,69 @@ class DataHealthCheckerTest {
     }
 
     @Test
+    fun borrowedByMeExpenseWithoutCategory_reportsUncategorisedExpenseWarning() {
+        val initialGroup = UUID.randomUUID()
+        val caseId = UUID.randomUUID()
+
+        val snapshot = DataHealthSnapshot(
+            transactions = listOf(
+                expense(
+                    groupId = initialGroup,
+                    accountId = debtAccount.id,
+                    amount = BigDecimal("-50"),
+                    side = TransferSide.Outgoing,
+                    category = null
+                )
+            ),
+            categories = listOf(foodCategory),
+            budgets = emptyList(),
+            advanceCases = listOf(
+                AdvanceCaseWithDetails(
+                    advanceCase = AdvanceCaseEntity(
+                        id = caseId,
+                        title = "Taxi",
+                        date = now,
+                        currencyCode = "HKD",
+                        myShareAmount = BigDecimal.ZERO,
+                        note = "",
+                        selfExpenseTransactionId = null,
+                        createdAt = now,
+                        updatedAt = now,
+                        payerAccountId = null,
+                        expenseCategoryId = null
+                    ),
+                    payerAccount = null,
+                    expenseCategory = null,
+                    participants = emptyList(),
+                    repayments = emptyList()
+                )
+            ),
+            advanceParticipants = listOf(
+                AdvanceParticipantEntity(
+                    id = UUID.randomUUID(),
+                    name = debtAccount.name,
+                    owedAmount = BigDecimal("50"),
+                    repaidAmount = BigDecimal.ZERO,
+                    initialTransferGroupId = initialGroup,
+                    createdAt = now,
+                    updatedAt = now,
+                    advanceCaseId = caseId,
+                    debtAccountId = debtAccount.id
+                )
+            ),
+            advanceRepayments = emptyList(),
+            shortcuts = emptyList()
+        )
+
+        val report = DataHealthChecker.run(snapshot, now)
+
+        assertEquals(0, report.errorCount)
+        assertTrue(report.issues.any {
+            it.title == "他人代墊我缺少支出分類" && it.detail.contains("1 筆")
+        })
+    }
+
+    @Test
     fun mismatchedInitialTransferDirection_reportsWarning() {
         val initialGroup = UUID.randomUUID()
         val caseId = UUID.randomUUID()
@@ -220,7 +283,8 @@ class DataHealthCheckerTest {
         groupId: UUID,
         accountId: UUID,
         amount: BigDecimal,
-        side: TransferSide
+        side: TransferSide,
+        category: CategoryEntity? = foodCategory
     ): TransactionWithDetails {
         return TransactionWithDetails(
             transaction = TransactionEntity(
@@ -237,10 +301,10 @@ class DataHealthCheckerTest {
                 createdAt = now,
                 updatedAt = now,
                 accountId = accountId,
-                categoryId = foodCategory.id
+                categoryId = category?.id
             ),
             account = null,
-            category = foodCategory,
+            category = category,
             tags = emptyList()
         )
     }


### PR DESCRIPTION
## Summary
- add iOS and Android data-health warnings when borrowed-by-me advance expenses are missing categories
- keep the warning scoped to the current debt-account expense representation so normal advances are not affected
- add iOS and Android regression tests for uncategorised borrowed advance expenses

Closes #100

## Tests
- xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest assembleDebug