### PR TITLE
Document WebDAV optional encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AI Accounting is a personal finance app for multi-currency bookkeeping, account 
 - Debt management with borrow, repay, and debt-forgiveness semantics
 - Income/expense charts with category/tag drill-down
 - Budgets, overspending alerts, and AI-assisted budget suggestions
-- Data health checks, JSON backup/restore, WebDAV remote backup, and CSV export
+- Data health checks, JSON backup/restore, WebDAV remote backup with optional encryption, and CSV export
 - Optional AI receipt scanning with a user-provided Gemini API key
 
 ## Platform Status
@@ -106,6 +106,7 @@ GitHub Actions on `push` / `pull_request` to `main`:
 - CI checklist: [`docs/CI_CHECKLIST.md`](./docs/CI_CHECKLIST.md)
 - Deployment guide: [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md)
 - Android APK build guide: [`docs/ANDROID_APK_BUILD.md`](./docs/ANDROID_APK_BUILD.md)
+- WebDAV remote backup guide: [`docs/REMOTE_BACKUP.md`](./docs/REMOTE_BACKUP.md)
 
 ## Disclaimer
 

--- a/android/README.md
+++ b/android/README.md
@@ -7,7 +7,7 @@ This folder contains the Android implementation of AI Accounting. Android follow
 - Five main tabs aligned with iOS: Overview / Ledger / Reports / Accounts / Settings
 - First-launch behaviour: open Overview on first launch, then default to Ledger for returning users
 - Core bookkeeping flows for income, expense, transfer, debt, advances, budgets, reports, accounts, and backups
-- Settlement centre, data health checks, recurring transactions, WebDAV backup, and local preferences
+- Settlement centre, data health checks, recurring transactions, WebDAV backup with optional encryption, and local preferences
 - Optional receipt scan review flow and Gemini API key settings
 - Android-only summary widget with app-driven preview content and refresh hook (`SummaryWidgetProvider`)
 - Unit tests for parity vectors from `../docs/specs/parity-test-vectors.md`
@@ -34,6 +34,8 @@ cd android
 ```
 
 Detailed APK build guide: [`../docs/ANDROID_APK_BUILD.md`](../docs/ANDROID_APK_BUILD.md)
+
+WebDAV remote backup guide: [`../docs/REMOTE_BACKUP.md`](../docs/REMOTE_BACKUP.md)
 
 ## APK Location
 

--- a/docs/REMOTE_BACKUP.md
+++ b/docs/REMOTE_BACKUP.md
@@ -1,0 +1,75 @@
+# WebDAV Remote Backup
+
+AI Accounting supports manual WebDAV remote backup on iOS and Android. Remote backup is not live sync: upload and restore are deliberate user actions.
+
+## Encryption Modes
+
+Remote backup has two modes.
+
+| Mode | Default | File type | Passphrase required for upload | Passphrase required for restore | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Encrypted remote backup | Yes | `.aibackup` | Yes | Yes | Recommended. The backup JSON is wrapped in an AES-GCM envelope before upload. |
+| Plain JSON remote backup | No | `.json` | No | No | Opt-in only. The cloud provider can read the financial backup content. |
+
+The app defaults to `Encrypt remote backups (recommended)` on both platforms. Users can turn it off manually from the WebDAV remote backup settings screen.
+
+## What The Passphrase Does
+
+The WebDAV username and password are only used to connect to the WebDAV server.
+
+The backup passphrase is separate. It is only used to encrypt or decrypt `.aibackup` files. It is not needed for:
+
+- Testing the WebDAV connection
+- Listing remote backups
+- Uploading a plain `.json` backup
+- Restoring a plain `.json` backup
+
+It is needed for:
+
+- Uploading an encrypted `.aibackup` backup
+- Restoring an encrypted `.aibackup` backup
+
+If the passphrase is lost, encrypted `.aibackup` files cannot be recovered by the app.
+
+## Plain JSON Risk
+
+Plain `.json` remote backups contain personal finance data such as accounts, transactions, notes, categories, tags, budgets, debts, and advances. They should only be used when the WebDAV storage is already trusted and protected by the user.
+
+The app warns before unencrypted uploads. HTTP WebDAV remains supported for local or LAN testing, but HTTPS is strongly preferred. Using HTTP with plain JSON is the highest-risk combination because the data is exposed both in transit and at rest.
+
+## Restore Behaviour
+
+The restore flow detects the selected remote file format.
+
+- `.aibackup`: asks for a passphrase and decrypts before preview/restore.
+- `.json`: previews and restores directly without a passphrase.
+- Unknown file format: rejected.
+
+Restore still overwrites local app data after confirmation. Export a local backup first when testing real data.
+
+## Platform Parity
+
+The expected behaviour is the same on iOS and Android:
+
+- Encryption is enabled by default.
+- Encrypted upload requires a non-empty passphrase.
+- Plain JSON upload does not require a passphrase.
+- Encrypted restore requires a passphrase.
+- Plain JSON restore does not require a passphrase.
+- Remote backup lists show whether a file is encrypted or unencrypted.
+- HTTP risk warnings are stronger when encryption is disabled.
+
+## Manual Validation Checklist
+
+Use this checklist when changing WebDAV backup code or UI.
+
+1. Connection test works with WebDAV URL, username, and password only.
+2. Encrypted upload without passphrase is blocked.
+3. Encrypted upload with passphrase creates `.aibackup`.
+4. Encrypted restore without passphrase is blocked.
+5. Encrypted restore with the correct passphrase previews and restores.
+6. Plain upload without passphrase creates `.json`.
+7. Plain restore previews and restores without passphrase.
+8. Wrong passphrase for `.aibackup` shows a clear failure and does not restore.
+9. HTTP WebDAV shows a risk warning; HTTP plus plain JSON shows the stronger warning.
+10. Remote backup list labels `.aibackup` as encrypted and `.json` as unencrypted.

--- a/docs/VALIDATION_MATRIX.md
+++ b/docs/VALIDATION_MATRIX.md
@@ -57,3 +57,4 @@ Every core flow should cover at least one full cycle:
 - Add -> edit -> delete for transfer group
 - Add -> edit -> repayment or rollback for advance
 - Import -> operate -> export -> re-import for backup safety
+- WebDAV encrypted upload/restore and plain JSON upload/restore per [`docs/REMOTE_BACKUP.md`](./REMOTE_BACKUP.md)


### PR DESCRIPTION
## Summary
- document WebDAV backup encryption modes, passphrase requirements, plain JSON risk, restore behaviour, and platform parity
- link the WebDAV remote backup guide from root and Android READMEs
- add WebDAV encrypted/plain backup checks to the validation matrix

Closes #101

## Tests
- git diff --check