### PR TITLE
Add mutual debt offset for advances

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -83,8 +83,27 @@ enum AdvanceService {
         let repairedParticipantCount: Int
         let removedInflatedAccountTransactionCount: Int
     }
+
+    struct MutualDebtOffsetCandidate: Identifiable {
+        let id = UUID()
+        let debtAccount: Account
+        let currencyCode: String
+        let amount: Decimal
+        let receivableAmount: Decimal
+        let payableAmount: Decimal
+        let receivableParticipantCount: Int
+        let payableParticipantCount: Int
+    }
+
+    struct MutualDebtOffsetResult {
+        let offsetGroupID: UUID
+        let amount: Decimal
+        let currencyCode: String
+        let repaymentCount: Int
+    }
     
     private static let roundingTolerance = Decimal(string: "0.0001") ?? 0.0001
+    static let mutualDebtOffsetMarkerPrefix = "[債務抵銷:"
     
     static func totalAdvanced(for advanceCase: AdvanceCase) -> Decimal {
         advanceCase.myShareAmount + advanceCase.participants.reduce(Decimal.zero) { $0 + $1.owedAmount }
@@ -94,6 +113,122 @@ enum AdvanceService {
         advanceCase.participants.reduce(Decimal.zero) { partial, participant in
             partial + participant.remainingAmount
         }
+    }
+
+    static func isMutualDebtOffset(note: String) -> Bool {
+        note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix(mutualDebtOffsetMarkerPrefix)
+    }
+
+    static func mutualDebtOffsetID(from note: String) -> UUID? {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix(mutualDebtOffsetMarkerPrefix),
+              let closeIndex = trimmed.firstIndex(of: "]") else {
+            return nil
+        }
+        let startIndex = trimmed.index(trimmed.startIndex, offsetBy: mutualDebtOffsetMarkerPrefix.count)
+        return UUID(uuidString: String(trimmed[startIndex..<closeIndex]))
+    }
+
+    @MainActor
+    static func mutualDebtOffsetCandidate(
+        debtAccount: Account,
+        currencyCode: String,
+        advanceCases: [AdvanceCase],
+        modelContext: ModelContext
+    ) -> MutualDebtOffsetCandidate? {
+        let offsetable = offsetableParticipants(
+            debtAccount: debtAccount,
+            currencyCode: currencyCode,
+            advanceCases: advanceCases,
+            modelContext: modelContext
+        )
+        let receivableAmount = offsetable.receivable.reduce(Decimal.zero) { $0 + $1.participant.remainingAmount }
+        let payableAmount = offsetable.payable.reduce(Decimal.zero) { $0 + $1.participant.remainingAmount }
+        let amount = min(receivableAmount, payableAmount)
+        guard amount > roundingTolerance else { return nil }
+        return MutualDebtOffsetCandidate(
+            debtAccount: debtAccount,
+            currencyCode: currencyCode,
+            amount: amount,
+            receivableAmount: receivableAmount,
+            payableAmount: payableAmount,
+            receivableParticipantCount: offsetable.receivable.count,
+            payableParticipantCount: offsetable.payable.count
+        )
+    }
+
+    @MainActor
+    static func recordMutualDebtOffset(
+        debtAccount: Account,
+        currencyCode: String,
+        date: Date = Date(),
+        note: String = "",
+        modelContext: ModelContext
+    ) throws -> MutualDebtOffsetResult {
+        let advanceCases = try modelContext.fetch(FetchDescriptor<AdvanceCase>())
+        let offsetable = offsetableParticipants(
+            debtAccount: debtAccount,
+            currencyCode: currencyCode,
+            advanceCases: advanceCases,
+            modelContext: modelContext
+        )
+        let receivableAmount = offsetable.receivable.reduce(Decimal.zero) { $0 + $1.participant.remainingAmount }
+        let payableAmount = offsetable.payable.reduce(Decimal.zero) { $0 + $1.participant.remainingAmount }
+        let offsetAmount = min(receivableAmount, payableAmount)
+        guard offsetAmount > roundingTolerance else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+
+        let offsetGroupID = UUID()
+        let baseNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let marker = "\(mutualDebtOffsetMarkerPrefix)\(offsetGroupID.uuidString)]"
+        let finalNote = baseNote.isEmpty ? "\(marker) 與 \(debtAccount.name) 互相代墊抵銷" : "\(marker) \(baseNote)"
+        var repaymentCount = 0
+
+        repaymentCount += applyMutualDebtOffset(
+            amount: offsetAmount,
+            entries: offsetable.receivable,
+            date: date,
+            note: finalNote,
+            modelContext: modelContext
+        )
+        repaymentCount += applyMutualDebtOffset(
+            amount: offsetAmount,
+            entries: offsetable.payable,
+            date: date,
+            note: finalNote,
+            modelContext: modelContext
+        )
+
+        try modelContext.save()
+        return MutualDebtOffsetResult(
+            offsetGroupID: offsetGroupID,
+            amount: offsetAmount,
+            currencyCode: currencyCode,
+            repaymentCount: repaymentCount
+        )
+    }
+
+    @MainActor
+    static func rollbackMutualDebtOffset(
+        offsetGroupID: UUID,
+        modelContext: ModelContext
+    ) throws -> Int {
+        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+            .filter { mutualDebtOffsetID(from: $0.note) == offsetGroupID }
+        guard !repayments.isEmpty else { return 0 }
+
+        for repayment in repayments {
+            if let participant = repayment.participant {
+                let updated = participant.repaidAmount - repayment.normalizedAmount
+                participant.repaidAmount = updated > 0 ? updated : 0
+                participant.updatedAt = Date()
+            }
+            repayment.advanceCase?.updatedAt = Date()
+            modelContext.delete(repayment)
+        }
+        try modelContext.save()
+        return repayments.count
     }
     
     @MainActor
@@ -514,6 +649,88 @@ enum AdvanceService {
         advanceCase.updatedAt = Date()
         
         try modelContext.save()
+    }
+
+    private struct OffsetParticipantEntry {
+        let participant: AdvanceParticipant
+        let advanceCase: AdvanceCase
+    }
+
+    @MainActor
+    private static func offsetableParticipants(
+        debtAccount: Account,
+        currencyCode: String,
+        advanceCases: [AdvanceCase],
+        modelContext: ModelContext
+    ) -> (receivable: [OffsetParticipantEntry], payable: [OffsetParticipantEntry]) {
+        var receivable: [OffsetParticipantEntry] = []
+        var payable: [OffsetParticipantEntry] = []
+
+        for advanceCase in advanceCases where advanceCase.currencyCode == currencyCode {
+            for participant in advanceCase.participants {
+                guard participant.debtAccount?.id == debtAccount.id,
+                      participant.remainingAmount > roundingTolerance else {
+                    continue
+                }
+                let entry = OffsetParticipantEntry(participant: participant, advanceCase: advanceCase)
+                switch inferSettlementDirection(for: participant, modelContext: modelContext) {
+                case .iAdvancedOthers:
+                    receivable.append(entry)
+                case .othersAdvancedMe:
+                    payable.append(entry)
+                }
+            }
+        }
+
+        let byDate: (OffsetParticipantEntry, OffsetParticipantEntry) -> Bool = {
+            if $0.advanceCase.date == $1.advanceCase.date {
+                return $0.participant.createdAt < $1.participant.createdAt
+            }
+            return $0.advanceCase.date < $1.advanceCase.date
+        }
+        return (receivable.sorted(by: byDate), payable.sorted(by: byDate))
+    }
+
+    @MainActor
+    private static func applyMutualDebtOffset(
+        amount: Decimal,
+        entries: [OffsetParticipantEntry],
+        date: Date,
+        note: String,
+        modelContext: ModelContext
+    ) -> Int {
+        var remaining = amount
+        var repaymentCount = 0
+
+        for entry in entries where remaining > roundingTolerance {
+            let allocation = min(entry.participant.remainingAmount, remaining)
+            guard allocation > roundingTolerance else { continue }
+
+            let repayment = AdvanceRepayment(
+                amount: allocation,
+                currencyCode: entry.advanceCase.currencyCode,
+                normalizedAmount: allocation,
+                date: date,
+                note: note,
+                linkedTransferGroupID: nil,
+                createdAt: Date(),
+                advanceCase: entry.advanceCase,
+                participant: entry.participant,
+                receivedAccount: nil
+            )
+            modelContext.insert(repayment)
+
+            let updatedRepaid = entry.participant.repaidAmount + allocation
+            entry.participant.repaidAmount = entry.participant.owedAmount - updatedRepaid < roundingTolerance
+                ? entry.participant.owedAmount
+                : updatedRepaid
+            entry.participant.updatedAt = Date()
+            entry.advanceCase.updatedAt = Date()
+            remaining -= allocation
+            repaymentCount += 1
+        }
+
+        return repaymentCount
     }
     
     @MainActor

--- a/AI 記帳/Views/Settlements/SettlementCenterView.swift
+++ b/AI 記帳/Views/Settlements/SettlementCenterView.swift
@@ -14,6 +14,7 @@ private struct SettlementPersonSummary: Identifiable {
     let account: Account
     let name: String
     let balances: [SettlementCurrencyBalance]
+    let offsetCandidates: [AdvanceService.MutualDebtOffsetCandidate]
     let netBalanceInMainCurrency: Decimal
     let advanceCaseCount: Int
     let repaymentCount: Int
@@ -58,6 +59,7 @@ private struct SettlementDebtRoute: Identifiable, Hashable {
 }
 
 struct SettlementCenterView: View {
+    @Environment(\.modelContext) private var modelContext
     @Query(sort: \Account.sortOrder) private var accounts: [Account]
     @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var transactions: [FinancialTransaction]
@@ -67,6 +69,7 @@ struct SettlementCenterView: View {
     @State private var selectedPerson: SettlementPersonSummary?
     @State private var timelineFilter: SettlementTimelineFilter?
     @State private var debtRoute: SettlementDebtRoute?
+    @State private var statusMessage: String?
 
     private var activeDebtAccounts: [Account] {
         accounts.filter { $0.type == .debt && !$0.isArchived }
@@ -79,6 +82,16 @@ struct SettlementCenterView: View {
             let forgiveness = transactions.filter {
                 $0.account?.id == account.id && TransactionSemantics.isDebtForgiveness(note: $0.note)
             }
+            let offsetCandidates = Set(participants.compactMap { $0.advanceCase?.currencyCode })
+                .compactMap {
+                    AdvanceService.mutualDebtOffsetCandidate(
+                        debtAccount: account,
+                        currencyCode: $0,
+                        advanceCases: advanceCases,
+                        modelContext: modelContext
+                    )
+                }
+                .sorted { $0.currencyCode < $1.currencyCode }
             let caseCount = Set(participants.compactMap { $0.advanceCase?.id }).count
             let balances = balances(for: account)
             let netInMainCurrency = balances.reduce(Decimal.zero) { partial, balance in
@@ -94,6 +107,7 @@ struct SettlementCenterView: View {
                 account: account,
                 name: account.name,
                 balances: balances,
+                offsetCandidates: offsetCandidates,
                 netBalanceInMainCurrency: netInMainCurrency,
                 advanceCaseCount: caseCount,
                 repaymentCount: repayments.count,
@@ -134,7 +148,8 @@ struct SettlementCenterView: View {
             )
         }
 
-        items += advanceCases.flatMap(\.repayments).map { repayment in
+        let allRepayments = advanceCases.flatMap(\.repayments)
+        items += allRepayments.filter { !AdvanceService.isMutualDebtOffset(note: $0.note) }.map { repayment in
             SettlementTimelineItem(
                 id: "repayment-\(repayment.id.uuidString)",
                 relatedAccountID: repayment.participant?.debtAccount?.id,
@@ -144,6 +159,26 @@ struct SettlementCenterView: View {
                 amount: repayment.amount,
                 currencyCode: repayment.currencyCode,
                 tint: .green
+            )
+        }
+
+        let offsetRepaymentsByID = Dictionary(grouping: allRepayments.compactMap { repayment -> (UUID, AdvanceRepayment)? in
+            guard let offsetID = AdvanceService.mutualDebtOffsetID(from: repayment.note) else { return nil }
+            return (offsetID, repayment)
+        }) { $0.0 }
+        items += offsetRepaymentsByID.compactMap { offsetID, entries in
+            let repayments = entries.map(\.1)
+            guard let first = repayments.first else { return nil }
+            let total = repayments.reduce(Decimal.zero) { $0 + $1.amount } / 2
+            return SettlementTimelineItem(
+                id: "offset-\(offsetID.uuidString)",
+                relatedAccountID: first.participant?.debtAccount?.id,
+                date: first.date,
+                title: "債務抵銷",
+                subtitle: first.participant?.debtAccount?.name ?? "互相代墊抵銷",
+                amount: total,
+                currencyCode: first.currencyCode,
+                tint: .teal
             )
         }
 
@@ -262,10 +297,25 @@ struct SettlementCenterView: View {
         .task {
             await currencyService.fetchRates()
         }
+        .alert("結算中心", isPresented: Binding(
+            get: { statusMessage != nil },
+            set: { if !$0 { statusMessage = nil } }
+        )) {
+            Button("知道了", role: .cancel) {}
+        } message: {
+            Text(statusMessage ?? "")
+        }
         .confirmationDialog("結算動作", isPresented: Binding(
             get: { selectedPerson != nil },
             set: { if !$0 { selectedPerson = nil } }
         ), titleVisibility: .visible) {
+            if let summary = selectedPerson {
+                ForEach(summary.offsetCandidates) { candidate in
+                    Button("抵銷 \(candidate.amount.formatted(.currency(code: candidate.currencyCode)))") {
+                        recordOffset(candidate)
+                    }
+                }
+            }
             if let summary = selectedPerson, summary.netBalanceInMainCurrency > 0 {
                 Button("記錄對方還款") {
                     selectedPerson = nil
@@ -315,7 +365,10 @@ struct SettlementCenterView: View {
             Button("取消", role: .cancel) {}
         } message: {
             if let summary = selectedPerson {
-                Text("\(summary.name)：\(directionText(for: summary.netBalanceInMainCurrency))")
+                let offsetText = summary.offsetCandidates.first.map {
+                    "\n可抵銷：\($0.amount.formatted(.currency(code: $0.currencyCode)))"
+                } ?? ""
+                Text("\(summary.name)：\(directionText(for: summary.netBalanceInMainCurrency))\(offsetText)")
             }
         }
         .navigationDestination(isPresented: Binding(
@@ -378,6 +431,9 @@ struct SettlementCenterView: View {
                             settlementPill("代墊 \(summary.advanceCaseCount)")
                             settlementPill("還款 \(summary.repaymentCount)")
                             settlementPill("免除 \(summary.forgivenessCount)")
+                            if let offset = summary.offsetCandidates.first {
+                                settlementPill("可抵銷 \(offset.amount.formatted(.currency(code: offset.currencyCode)))")
+                            }
                         }
 
                         if let latest = summary.latestActivityDate {
@@ -558,5 +614,20 @@ struct SettlementCenterView: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(Color(uiColor: .secondarySystemBackground), in: Capsule())
+    }
+
+    private func recordOffset(_ candidate: AdvanceService.MutualDebtOffsetCandidate) {
+        do {
+            let result = try AdvanceService.recordMutualDebtOffset(
+                debtAccount: candidate.debtAccount,
+                currencyCode: candidate.currencyCode,
+                modelContext: modelContext
+            )
+            selectedPerson = nil
+            statusMessage = "已抵銷 \(result.amount.formatted(.currency(code: result.currencyCode)))。"
+        } catch {
+            selectedPerson = nil
+            statusMessage = error.localizedDescription
+        }
     }
 }

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -303,6 +303,81 @@ final class BackupCompatibilityTests: XCTestCase {
         })
     }
 
+    func testMutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let ownAccount = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        modelContext.insert(ownAccount)
+        modelContext.insert(debtAccount)
+        try modelContext.save()
+
+        let receivableCase = try AdvanceService.createAdvanceCase(
+            title: "我先付晚餐",
+            date: date,
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: ownAccount,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 100)],
+            isBorrowedByMe: false,
+            modelContext: modelContext
+        )
+        let payableCase = try AdvanceService.createAdvanceCase(
+            title: "朋友先付車費",
+            date: date.addingTimeInterval(60),
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: nil,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 40)],
+            isBorrowedByMe: true,
+            modelContext: modelContext
+        )
+
+        let beforeTransactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>()).count
+        let candidate = try XCTUnwrap(
+            AdvanceService.mutualDebtOffsetCandidate(
+                debtAccount: debtAccount,
+                currencyCode: "HKD",
+                advanceCases: [receivableCase, payableCase],
+                modelContext: modelContext
+            )
+        )
+        XCTAssertEqual(Decimal(40), candidate.amount)
+
+        let result = try AdvanceService.recordMutualDebtOffset(
+            debtAccount: debtAccount,
+            currencyCode: "HKD",
+            date: date,
+            modelContext: modelContext
+        )
+
+        XCTAssertEqual(Decimal(40), result.amount)
+        XCTAssertEqual(2, result.repaymentCount)
+        XCTAssertEqual(beforeTransactions, try modelContext.fetch(FetchDescriptor<FinancialTransaction>()).count)
+        XCTAssertEqual(Decimal(60), receivableCase.participants.first?.remainingAmount)
+        XCTAssertEqual(Decimal.zero, payableCase.participants.first?.remainingAmount)
+
+        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+        XCTAssertEqual(2, repayments.count)
+        XCTAssertTrue(repayments.allSatisfy { AdvanceService.mutualDebtOffsetID(from: $0.note) == result.offsetGroupID })
+
+        let rollbackCount = try AdvanceService.rollbackMutualDebtOffset(
+            offsetGroupID: result.offsetGroupID,
+            modelContext: modelContext
+        )
+        XCTAssertEqual(2, rollbackCount)
+        XCTAssertEqual(Decimal(100), receivableCase.participants.first?.remainingAmount)
+        XCTAssertEqual(Decimal(40), payableCase.participants.first?.remainingAmount)
+    }
+
     func testLegacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndKeepsExpense() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -75,9 +75,27 @@ data class LegacyBorrowedAdvanceRepairResult(
     val removedInflatedAccountTransactionCount: Int
 )
 
+data class MutualDebtOffsetCandidate(
+    val debtAccount: AccountEntity,
+    val currencyCode: String,
+    val amount: BigDecimal,
+    val receivableAmount: BigDecimal,
+    val payableAmount: BigDecimal,
+    val receivableParticipantCount: Int,
+    val payableParticipantCount: Int
+)
+
+data class MutualDebtOffsetResult(
+    val offsetGroupId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val repaymentCount: Int
+)
+
 private const val RECURRING_STATUS_PENDING = "Pending"
 private const val RECURRING_STATUS_CONFIRMED = "Confirmed"
 private const val RECURRING_STATUS_SKIPPED = "Skipped"
+const val MUTUAL_DEBT_OFFSET_MARKER_PREFIX = "[債務抵銷:"
 
 class AccountingRepository(
     private val database: AIAccountingDatabase,
@@ -113,6 +131,12 @@ class AccountingRepository(
         val shortcutsToDetach: List<ShortcutEntity>
     )
 
+    private data class OffsetParticipantEntry(
+        val advanceCase: AdvanceCaseEntity,
+        val participant: AdvanceParticipantEntity,
+        val remaining: BigDecimal
+    )
+
     suspend fun getTransaction(transactionId: UUID): TransactionWithDetails? {
         return transactionDao.getTransaction(transactionId)
     }
@@ -129,6 +153,78 @@ class AccountingRepository(
         return advanceDao.getAdvanceCase(caseId)
     }
 
+    suspend fun mutualDebtOffsetCandidate(debtAccountId: UUID, currencyCode: String): MutualDebtOffsetCandidate? {
+        val debtAccount = accountDao.getAccount(debtAccountId) ?: return null
+        val offsetable = offsetableParticipants(debtAccountId, currencyCode, advanceDao.getAllCasesWithDetails())
+        val receivableAmount = offsetable.receivable.fold(BigDecimal.ZERO) { acc, entry -> acc + entry.remaining }
+        val payableAmount = offsetable.payable.fold(BigDecimal.ZERO) { acc, entry -> acc + entry.remaining }
+        val amount = receivableAmount.min(payableAmount)
+        if (amount <= BigDecimal.ZERO) return null
+        return MutualDebtOffsetCandidate(
+            debtAccount = debtAccount,
+            currencyCode = currencyCode,
+            amount = amount,
+            receivableAmount = receivableAmount,
+            payableAmount = payableAmount,
+            receivableParticipantCount = offsetable.receivable.size,
+            payableParticipantCount = offsetable.payable.size
+        )
+    }
+
+    suspend fun recordMutualDebtOffset(
+        debtAccountId: UUID,
+        currencyCode: String,
+        date: Instant = Instant.now(),
+        note: String = ""
+    ): MutualDebtOffsetResult {
+        return database.withTransaction {
+            val debtAccount = accountDao.getAccount(debtAccountId) ?: error("找不到債務對象")
+            val offsetable = offsetableParticipants(debtAccountId, currencyCode, advanceDao.getAllCasesWithDetails())
+            val receivableAmount = offsetable.receivable.fold(BigDecimal.ZERO) { acc, entry -> acc + entry.remaining }
+            val payableAmount = offsetable.payable.fold(BigDecimal.ZERO) { acc, entry -> acc + entry.remaining }
+            val offsetAmount = receivableAmount.min(payableAmount)
+            require(offsetAmount > BigDecimal.ZERO) { "沒有可抵銷的同幣種互相代墊" }
+
+            val now = Instant.now()
+            val offsetGroupId = UUID.randomUUID()
+            val trimmedNote = note.trim()
+            val marker = "$MUTUAL_DEBT_OFFSET_MARKER_PREFIX$offsetGroupId]"
+            val finalNote = if (trimmedNote.isBlank()) {
+                "$marker 與 ${debtAccount.name} 互相代墊抵銷"
+            } else {
+                "$marker $trimmedNote"
+            }
+
+            val receivableCount = applyMutualDebtOffset(offsetAmount, offsetable.receivable, date, finalNote, now)
+            val payableCount = applyMutualDebtOffset(offsetAmount, offsetable.payable, date, finalNote, now)
+
+            MutualDebtOffsetResult(
+                offsetGroupId = offsetGroupId,
+                amount = offsetAmount,
+                currencyCode = currencyCode,
+                repaymentCount = receivableCount + payableCount
+            )
+        }
+    }
+
+    suspend fun rollbackMutualDebtOffset(offsetGroupId: UUID): Int {
+        return database.withTransaction {
+            val repayments = advanceDao.getAllRepayments()
+                .filter { mutualDebtOffsetId(it.note) == offsetGroupId }
+            repayments.forEach { repayment ->
+                val participant = repayment.participantId?.let { participantId ->
+                    advanceDao.getAllParticipants().firstOrNull { it.id == participantId }
+                }
+                if (participant != null) {
+                    val updatedRepaid = (participant.repaidAmount - repayment.normalizedAmount).max(BigDecimal.ZERO)
+                    advanceDao.upsertParticipants(listOf(participant.copy(repaidAmount = updatedRepaid, updatedAt = Instant.now())))
+                }
+                advanceDao.deleteRepayment(repayment)
+            }
+            repayments.size
+        }
+    }
+
     suspend fun buildDataHealthReport(): DataHealthReport {
         return DataHealthChecker.run(
             DataHealthSnapshot(
@@ -141,6 +237,93 @@ class AccountingRepository(
                 shortcuts = shortcutDao.getAllWithDetails()
             )
         )
+    }
+
+    private fun offsetableParticipants(
+        debtAccountId: UUID,
+        currencyCode: String,
+        advanceCases: List<AdvanceCaseWithDetails>
+    ): OffsetableParticipants {
+        val receivable = mutableListOf<OffsetParticipantEntry>()
+        val payable = mutableListOf<OffsetParticipantEntry>()
+        advanceCases
+            .filter { it.advanceCase.currencyCode == currencyCode }
+            .sortedBy { it.advanceCase.date }
+            .forEach { caseDetails ->
+                caseDetails.participants
+                    .filter { it.debtAccountId == debtAccountId }
+                    .forEach { participant ->
+                        val remaining = (participant.owedAmount - participant.repaidAmount).max(BigDecimal.ZERO)
+                        if (remaining > BigDecimal.ZERO) {
+                            val entry = OffsetParticipantEntry(caseDetails.advanceCase, participant, remaining)
+                            if (caseDetails.advanceCase.payerAccountId == null) {
+                                payable += entry
+                            } else {
+                                receivable += entry
+                            }
+                        }
+                    }
+            }
+        return OffsetableParticipants(receivable, payable)
+    }
+
+    private data class OffsetableParticipants(
+        val receivable: List<OffsetParticipantEntry>,
+        val payable: List<OffsetParticipantEntry>
+    )
+
+    private suspend fun applyMutualDebtOffset(
+        amount: BigDecimal,
+        entries: List<OffsetParticipantEntry>,
+        date: Instant,
+        note: String,
+        now: Instant
+    ): Int {
+        var remaining = amount
+        var count = 0
+        entries.forEach { entry ->
+            if (remaining <= BigDecimal.ZERO) return@forEach
+            val allocation = entry.remaining.min(remaining)
+            if (allocation <= BigDecimal.ZERO) return@forEach
+            advanceDao.upsertRepayment(
+                AdvanceRepaymentEntity(
+                    id = UUID.randomUUID(),
+                    amount = allocation,
+                    currencyCode = entry.advanceCase.currencyCode,
+                    normalizedAmount = allocation,
+                    date = date,
+                    note = note,
+                    linkedTransferGroupId = null,
+                    createdAt = now,
+                    advanceCaseId = entry.advanceCase.id,
+                    participantId = entry.participant.id,
+                    receivedAccountId = null
+                )
+            )
+            val updatedRepaid = (entry.participant.repaidAmount + allocation)
+                .min(entry.participant.owedAmount)
+            advanceDao.upsertParticipants(listOf(entry.participant.copy(repaidAmount = updatedRepaid, updatedAt = now)))
+            advanceDao.upsertCase(entry.advanceCase.copy(updatedAt = now))
+            remaining -= allocation
+            count += 1
+        }
+        return count
+    }
+
+    companion object {
+        fun isMutualDebtOffset(note: String): Boolean {
+            return note.trim().startsWith(MUTUAL_DEBT_OFFSET_MARKER_PREFIX)
+        }
+
+        fun mutualDebtOffsetId(note: String): UUID? {
+            val trimmed = note.trim()
+            if (!trimmed.startsWith(MUTUAL_DEBT_OFFSET_MARKER_PREFIX)) return null
+            val end = trimmed.indexOf(']')
+            if (end <= MUTUAL_DEBT_OFFSET_MARKER_PREFIX.length) return null
+            return runCatching {
+                UUID.fromString(trimmed.substring(MUTUAL_DEBT_OFFSET_MARKER_PREFIX.length, end))
+            }.getOrNull()
+        }
     }
 
     suspend fun legacyDebtIncomeTransactions(): List<TransactionWithDetails> {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,6 +36,8 @@ import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.MutualDebtOffsetCandidate
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
@@ -50,6 +53,7 @@ import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
+import kotlinx.coroutines.launch
 
 private enum class SettlementMode(val label: String) {
     People("按對象"),
@@ -60,6 +64,7 @@ private enum class SettlementMode(val label: String) {
 private data class SettlementPersonSummary(
     val account: AccountEntity,
     val balances: List<SettlementCurrencyBalance>,
+    val offsetCandidates: List<MutualDebtOffsetCandidate>,
     val netInMainCurrency: BigDecimal,
     val advanceCaseCount: Int,
     val repaymentCount: Int,
@@ -92,6 +97,7 @@ fun SettlementCenterScreen(
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val transactions by repository.transactions.collectAsState(initial = emptyList())
@@ -101,6 +107,7 @@ fun SettlementCenterScreen(
     var mode by rememberSaveable { mutableStateOf(SettlementMode.People) }
     var selectedPerson by remember { mutableStateOf<SettlementPersonSummary?>(null) }
     var timelineFilter by remember { mutableStateOf<SettlementPersonSummary?>(null) }
+    var message by remember { mutableStateOf<String?>(null) }
 
     val personSummaries = remember(accounts, transactions, advanceCases, mainCurrency, rateSnapshot) {
         buildPersonSummaries(accounts, transactions, advanceCases, currencyService, mainCurrency)
@@ -251,9 +258,28 @@ fun SettlementCenterScreen(
         AlertDialog(
             onDismissRequest = { selectedPerson = null },
             title = { Text(summary.account.name) },
-            text = { Text("${directionText(summary.netInMainCurrency)} · ${summary.netInMainCurrency.asCurrencyText(mainCurrency)}") },
+            text = {
+                val offsetText = summary.offsetCandidates.firstOrNull()?.let {
+                    "\n可抵銷：${it.amount.asCurrencyText(it.currencyCode)}"
+                }.orEmpty()
+                Text("${directionText(summary.netInMainCurrency)} · ${summary.netInMainCurrency.asCurrencyText(mainCurrency)}$offsetText")
+            },
             confirmButton = {
                 Column {
+                    summary.offsetCandidates.forEach { candidate ->
+                        TextButton(onClick = {
+                            selectedPerson = null
+                            scope.launch {
+                                runCatching {
+                                    repository.recordMutualDebtOffset(candidate.debtAccount.id, candidate.currencyCode)
+                                }.onSuccess {
+                                    message = "已抵銷 ${it.amount.asCurrencyText(it.currencyCode)}。"
+                                }.onFailure {
+                                    message = it.message ?: "債務抵銷失敗。"
+                                }
+                            }
+                        }) { Text("抵銷 ${candidate.amount.asCurrencyText(candidate.currencyCode)}") }
+                    }
                     if (summary.netInMainCurrency.signum() > 0) {
                         TextButton(onClick = {
                             selectedPerson = null
@@ -282,6 +308,17 @@ fun SettlementCenterScreen(
             },
             dismissButton = {
                 TextButton(onClick = { selectedPerson = null }) { Text("取消") }
+            }
+        )
+    }
+
+    message?.let { text ->
+        AlertDialog(
+            onDismissRequest = { message = null },
+            title = { Text("結算中心") },
+            text = { Text(text) },
+            confirmButton = {
+                TextButton(onClick = { message = null }) { Text("知道了") }
             }
         )
     }
@@ -320,6 +357,9 @@ private fun PersonSummaryCard(summary: SettlementPersonSummary, mainCurrency: St
                 ParityStatusPill("代墊 ${summary.advanceCaseCount}", tint = MaterialTheme.colorScheme.tertiary)
                 ParityStatusPill("還款 ${summary.repaymentCount}", tint = MaterialTheme.colorScheme.primary)
                 ParityStatusPill("免除 ${summary.forgivenessCount}", tint = MaterialTheme.colorScheme.secondary)
+                summary.offsetCandidates.firstOrNull()?.let {
+                    ParityStatusPill("可抵銷 ${it.amount.asCurrencyText(it.currencyCode)}", tint = MaterialTheme.colorScheme.primary)
+                }
             }
             summary.balances.drop(1).forEach { balance ->
                 Text(
@@ -422,12 +462,14 @@ private fun buildPersonSummaries(
         val netInMain = balances.fold(BigDecimal.ZERO) { acc, balance ->
             acc + currencyService.convert(balance.amount, balance.currency, mainCurrency)
         }
+        val offsetCandidates = buildOffsetCandidates(account, advanceCases)
         val caseCount = participantsByAccount[account.id].orEmpty().map { it.first.advanceCase.id }.toSet().size
         val repaymentCount = repaymentsByAccount[account.id].orEmpty().size
         val latestActivityDate = latestActivityDate(account, transactions, advanceCases)
         SettlementPersonSummary(
             account = account,
             balances = balances,
+            offsetCandidates = offsetCandidates,
             netInMainCurrency = netInMain,
             advanceCaseCount = caseCount,
             repaymentCount = repaymentCount,
@@ -437,6 +479,47 @@ private fun buildPersonSummaries(
     }
         .filter { it.netInMainCurrency != BigDecimal.ZERO || it.advanceCaseCount > 0 || it.repaymentCount > 0 || it.forgivenessCount > 0 }
         .sortedByDescending { it.netInMainCurrency.abs() }
+}
+
+private fun buildOffsetCandidates(
+    account: AccountEntity,
+    advanceCases: List<AdvanceCaseWithDetails>
+): List<MutualDebtOffsetCandidate> {
+    return advanceCases
+        .filter { advanceCase -> advanceCase.participants.any { it.debtAccountId == account.id } }
+        .map { it.advanceCase.currencyCode }
+        .toSet()
+        .mapNotNull { currency ->
+            val participants = advanceCases
+                .filter { it.advanceCase.currencyCode == currency }
+                .flatMap { advanceCase -> advanceCase.participants.map { advanceCase to it } }
+                .filter { it.second.debtAccountId == account.id }
+            val receivable = participants
+                .filter { it.first.advanceCase.payerAccountId != null }
+                .sumOfBigDecimal { (it.second.owedAmount - it.second.repaidAmount).max(BigDecimal.ZERO) }
+            val payable = participants
+                .filter { it.first.advanceCase.payerAccountId == null }
+                .sumOfBigDecimal { (it.second.owedAmount - it.second.repaidAmount).max(BigDecimal.ZERO) }
+            val amount = receivable.min(payable)
+            if (amount > BigDecimal.ZERO) {
+                MutualDebtOffsetCandidate(
+                    debtAccount = account,
+                    currencyCode = currency,
+                    amount = amount,
+                    receivableAmount = receivable,
+                    payableAmount = payable,
+                    receivableParticipantCount = participants.count { it.first.advanceCase.payerAccountId != null },
+                    payableParticipantCount = participants.count { it.first.advanceCase.payerAccountId == null }
+                )
+            } else {
+                null
+            }
+        }
+        .sortedBy { it.currencyCode }
+}
+
+private inline fun <T> Iterable<T>.sumOfBigDecimal(selector: (T) -> BigDecimal): BigDecimal {
+    return fold(BigDecimal.ZERO) { acc, item -> acc + selector(item) }
 }
 
 private fun calculateDebtBalances(
@@ -483,7 +566,9 @@ private fun buildTimelineItems(
             currencyCode = advanceCase.advanceCase.currencyCode,
             tint = Color(0xFFFF9800)
         )
-        advanceCase.repayments.forEach { repayment ->
+        advanceCase.repayments
+            .filter { !AccountingRepository.isMutualDebtOffset(it.note) }
+            .forEach { repayment ->
             val participant = advanceCase.participants.firstOrNull { it.id == repayment.participantId }
             items += TimelineItem(
                 id = "repayment-${repayment.id}",
@@ -497,6 +582,33 @@ private fun buildTimelineItems(
             )
         }
     }
+
+    advanceCases
+        .flatMap { advanceCase -> advanceCase.repayments.map { repayment -> advanceCase to repayment } }
+        .mapNotNull { (advanceCase, repayment) ->
+            AccountingRepository.mutualDebtOffsetId(repayment.note)?.let { offsetId ->
+                offsetId to (advanceCase to repayment)
+            }
+        }
+        .groupBy { it.first }
+        .forEach { (offsetId, grouped) ->
+            val repayments = grouped.map { it.second.second }
+            val firstCase = grouped.firstOrNull()?.second?.first
+            val first = repayments.firstOrNull()
+            if (first != null) {
+                val participant = firstCase?.participants?.firstOrNull { it.id == first.participantId }
+                items += TimelineItem(
+                    id = "offset-$offsetId",
+                    relatedAccountId = participant?.debtAccountId,
+                    date = first.date,
+                    title = "債務抵銷",
+                    subtitle = participant?.name ?: "互相代墊抵銷",
+                    amount = repayments.sumOfBigDecimal { it.amount }.divide(BigDecimal("2")),
+                    currencyCode = first.currencyCode,
+                    tint = Color(0xFF00897B)
+                )
+            }
+        }
 
     transactions.forEach { tx ->
         val transaction = tx.transaction

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -223,6 +223,80 @@ class BackupRoundTripTest {
     }
 
     @Test
+    fun mutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions() = runBlocking {
+        val ownAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val debtAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Friend A",
+            currency = "HKD",
+            type = AccountType.Debt,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 1,
+            isArchived = false
+        )
+        database.accountDao().upsertAll(listOf(ownAccount, debtAccount))
+
+        val date = Instant.parse("2026-03-21T12:00:00Z")
+        val receivableCaseId = repository.createAdvanceCase(
+            title = "我先付晚餐",
+            date = date,
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = ownAccount,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("100"))),
+            isBorrowedByMe = false
+        )
+        val payableCaseId = repository.createAdvanceCase(
+            title = "朋友先付車費",
+            date = date.plusSeconds(60),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = null,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("40"))),
+            isBorrowedByMe = true
+        )
+
+        val beforeTransactionCount = database.transactionDao().getAll().size
+        val candidate = checkNotNull(repository.mutualDebtOffsetCandidate(debtAccount.id, "HKD"))
+        assertEquals(BigDecimal("40"), candidate.amount)
+
+        val result = repository.recordMutualDebtOffset(debtAccount.id, "HKD", date)
+
+        assertEquals(BigDecimal("40"), result.amount)
+        assertEquals(2, result.repaymentCount)
+        assertEquals(beforeTransactionCount, database.transactionDao().getAll().size)
+
+        val receivableCase = checkNotNull(repository.getAdvanceCase(receivableCaseId))
+        val payableCase = checkNotNull(repository.getAdvanceCase(payableCaseId))
+        assertEquals(BigDecimal("60"), receivableCase.participants.single().owedAmount - receivableCase.participants.single().repaidAmount)
+        assertEquals(BigDecimal.ZERO, payableCase.participants.single().owedAmount - payableCase.participants.single().repaidAmount)
+
+        val exported = BackupJsonAdapter.gson.fromJson(repository.exportBackupJson(), FullBackupData::class.java)
+        assertEquals(2, exported.advanceRepayments?.count { it.note?.contains("[債務抵銷:") == true })
+
+        val rollbackCount = repository.rollbackMutualDebtOffset(result.offsetGroupId)
+        assertEquals(2, rollbackCount)
+        val rolledBackReceivable = checkNotNull(repository.getAdvanceCase(receivableCaseId))
+        val rolledBackPayable = checkNotNull(repository.getAdvanceCase(payableCaseId))
+        assertEquals(BigDecimal("100"), rolledBackReceivable.participants.single().owedAmount - rolledBackReceivable.participants.single().repaidAmount)
+        assertEquals(BigDecimal("40"), rolledBackPayable.participants.single().owedAmount - rolledBackPayable.participants.single().repaidAmount)
+    }
+
+    @Test
     fun legacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndReimportsCleanly() = runBlocking {
         val fixtureJson = loadFixture("fixtures/legacy_bidirectional_advances.json")
 


### PR DESCRIPTION
## Summary
- add same-person same-currency mutual debt offset for advance cases on iOS and Android
- record offsets as paired AdvanceRepayment audit records without creating FinancialTransaction rows
- surface offset candidates and offset timeline entries in the settlement center

## Tests
- xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest assembleDebug