### PR TITLE
Support cross-currency advance repayments and report estimates

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -465,6 +465,7 @@ enum AdvanceService {
         category: Category?,
         tags: [Tag],
         currencyService: CurrencyService,
+        normalizedAmountOverride: Decimal? = nil,
         direction: SettlementDirection? = nil,
         autosave: Bool = true,
         modelContext: ModelContext
@@ -479,7 +480,7 @@ enum AdvanceService {
             throw AdvanceServiceError.invalidRepaymentAmount
         }
         
-        let normalizedAmount = currencyService.convert(
+        let normalizedAmount = normalizedAmountOverride ?? currencyService.convert(
             amount: abs(amount),
             from: currencyCode,
             to: advanceCase.currencyCode

--- a/AI 記帳/Services/CurrencyService.swift
+++ b/AI 記帳/Services/CurrencyService.swift
@@ -7,6 +7,11 @@ struct ExchangeRateResponse: Codable {
     let rates: [String: Double]
 }
 
+struct CurrencyConversionEstimate {
+    let amount: Decimal
+    let source: RateSourceState
+}
+
 class CurrencyService: ObservableObject {
     private struct ExchangeRateCache: Codable {
         let base: String
@@ -133,6 +138,33 @@ class CurrencyService: ObservableObject {
         let inMain = convert(amount: amount, from: source)
         return inMain * Decimal(targetRate)
     }
+
+    func estimate(amount: Decimal, from source: String, to target: String) -> CurrencyConversionEstimate? {
+        let sourceCode = source.uppercased()
+        let targetCode = target.uppercased()
+        if sourceCode == targetCode {
+            return CurrencyConversionEstimate(amount: amount, source: resolvedRateSourceState)
+        }
+
+        guard !resolvedRates.isEmpty else { return nil }
+
+        if sourceCode == mainCurrency.uppercased() {
+            guard let targetRate = resolvedRates[targetCode], targetRate.isFinite, targetRate > 0 else { return nil }
+            return CurrencyConversionEstimate(amount: amount * Decimal(targetRate), source: resolvedRateSourceState)
+        }
+
+        if targetCode == mainCurrency.uppercased() {
+            guard let sourceRate = resolvedRates[sourceCode], sourceRate.isFinite, sourceRate > 0 else { return nil }
+            return CurrencyConversionEstimate(amount: amount / Decimal(sourceRate), source: resolvedRateSourceState)
+        }
+
+        guard let sourceRate = resolvedRates[sourceCode], sourceRate.isFinite, sourceRate > 0,
+              let targetRate = resolvedRates[targetCode], targetRate.isFinite, targetRate > 0 else {
+            return nil
+        }
+        let inMain = amount / Decimal(sourceRate)
+        return CurrencyConversionEstimate(amount: inMain * Decimal(targetRate), source: resolvedRateSourceState)
+    }
     
     func getMarketRate(from source: String, to target: String) -> Double? {
         if source == target { return 1.0 }
@@ -142,8 +174,8 @@ class CurrencyService: ObservableObject {
 
     func previewInMainCurrency(amount: Decimal, from currency: String) -> (amount: Decimal, source: RateSourceState)? {
         guard currency.uppercased() != mainCurrency.uppercased() else { return nil }
-        guard !resolvedRates.isEmpty else { return nil }
-        return (convert(amount: amount, from: currency.uppercased()), resolvedRateSourceState)
+        guard let estimate = estimate(amount: amount, from: currency.uppercased(), to: mainCurrency) else { return nil }
+        return (estimate.amount, estimate.source)
     }
 
     var resolvedRateSourceState: RateSourceState {

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -994,6 +994,8 @@ struct AddAdvanceRepaymentView: View {
     @State private var selectedReceiveAccount: Account?
     @State private var amountString = ""
     @State private var selectedCurrency = "HKD"
+    @State private var settlementAmountString = ""
+    @State private var settlementAmountManuallyEdited = false
     @State private var selectedCategory: Category?
     @State private var selectedTags: Set<Tag> = []
     @State private var settlementDirection: AdvanceService.SettlementDirection = .iAdvancedOthers
@@ -1014,6 +1016,14 @@ struct AddAdvanceRepaymentView: View {
     
     private var remaining: Decimal {
         participant.remainingAmount
+    }
+
+    private var repaymentAmount: Decimal? {
+        positiveDecimal(from: amountString)
+    }
+
+    private var isCrossCurrencyRepayment: Bool {
+        selectedCurrency.uppercased() != advanceCase.currencyCode.uppercased()
     }
     
     private var directionalCategories: [Category] {
@@ -1043,15 +1053,25 @@ struct AddAdvanceRepaymentView: View {
         }
     }
     
-    private var convertedPreview: Decimal? {
-        guard let amount = Decimal(string: amountString), amount > 0 else { return nil }
-        return currencyService.convert(amount: amount, from: selectedCurrency, to: advanceCase.currencyCode)
+    private var settlementEstimate: CurrencyConversionEstimate? {
+        guard let repaymentAmount else { return nil }
+        return currencyService.estimate(
+            amount: repaymentAmount,
+            from: selectedCurrency,
+            to: advanceCase.currencyCode
+        )
+    }
+
+    private var normalSettlementAmount: Decimal? {
+        guard let repaymentAmount else { return nil }
+        if !isCrossCurrencyRepayment { return repaymentAmount }
+        return positiveDecimal(from: settlementAmountString)
     }
     
     private var canSubmit: Bool {
         switch entryMode {
         case .normal:
-            return selectedReceiveAccount != nil && positiveDecimal(from: amountString) != nil
+            return selectedReceiveAccount != nil && repaymentAmount != nil && normalSettlementAmount != nil
         case .split:
             return splitLegs.contains { $0.receiveAccount != nil && positiveDecimal(from: $0.amountString) != nil }
                 && splitLegs.allSatisfy { $0.receiveAccount != nil && positiveDecimal(from: $0.amountString) != nil }
@@ -1106,13 +1126,42 @@ struct AddAdvanceRepaymentView: View {
                             
                             TextField("還款金額", text: Binding(
                                 get: { amountString },
-                                set: { amountString = sanitizePositiveDecimalInput($0) }
+                                set: {
+                                    amountString = sanitizePositiveDecimalInput($0)
+                                    syncSettlementEstimateIfNeeded()
+                                }
                             ))
                             .keyboardType(.decimalPad)
                         }
                         
-                        if let convertedPreview {
-                            Text("折算為 \(convertedPreview.formatted(.currency(code: advanceCase.currencyCode)))")
+                        if isCrossCurrencyRepayment {
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    TextField("沖銷代墊金額", text: Binding(
+                                        get: { settlementAmountString },
+                                        set: {
+                                            settlementAmountString = sanitizePositiveDecimalInput($0)
+                                            settlementAmountManuallyEdited = true
+                                        }
+                                    ))
+                                    .keyboardType(.decimalPad)
+
+                                    Text(advanceCase.currencyCode)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                if let settlementEstimate {
+                                    Text("建議 \(settlementEstimate.amount.formatted(.currency(code: advanceCase.currencyCode)))（\(settlementEstimate.source.label)）")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                } else {
+                                    Text("暫時無法取得匯率，請手動填入要沖銷的 \(advanceCase.currencyCode) 金額。")
+                                        .font(.caption)
+                                        .foregroundStyle(.orange)
+                                }
+                            }
+                        } else if let settlementEstimate {
+                            Text("沖銷 \(settlementEstimate.amount.formatted(.currency(code: advanceCase.currencyCode)))")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -1281,6 +1330,13 @@ struct AddAdvanceRepaymentView: View {
                     splitLegs[0].receiveAccount = first
                     splitLegs[0].currency = first.currency
                 }
+                syncSettlementEstimateIfNeeded(force: true)
+            }
+            .onChange(of: selectedCurrency) { _, _ in
+                syncSettlementEstimateIfNeeded()
+            }
+            .onChange(of: amountString) { _, _ in
+                syncSettlementEstimateIfNeeded()
             }
         }
     }
@@ -1297,11 +1353,21 @@ struct AddAdvanceRepaymentView: View {
                     showError("請輸入大於 0 的還款金額。")
                     return
                 }
+                guard let normalizedAmount = normalSettlementAmount else {
+                    showError("請輸入大於 0 的沖銷金額。")
+                    return
+                }
+                let tolerance = Decimal(string: "0.0001") ?? 0.0001
+                guard normalizedAmount - remaining <= tolerance else {
+                    showError("沖銷金額超過未還餘額。")
+                    return
+                }
                 
                 _ = try recordSingleRepayment(
                     receiveAccount: receiveAccount,
                     amount: amount,
                     currencyCode: selectedCurrency,
+                    normalizedAmount: normalizedAmount,
                     note: note,
                     autosave: true
                 )
@@ -1317,7 +1383,11 @@ struct AddAdvanceRepaymentView: View {
                     legs.append((account, amount, leg.currency))
                 }
                 
-                guard validateTotalNotExceedingRemaining(items: legs.map { ($0.amount, $0.currency) }) else {
+                guard let totalIsValid = validateTotalNotExceedingRemaining(items: legs.map { ($0.amount, $0.currency) }) else {
+                    showError("暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。")
+                    return
+                }
+                guard totalIsValid else {
                     showError("分拆總金額超過未還餘額。")
                     return
                 }
@@ -1327,6 +1397,7 @@ struct AddAdvanceRepaymentView: View {
                         receiveAccount: leg.account,
                         amount: leg.amount,
                         currencyCode: leg.currency,
+                        normalizedAmount: normalizedAmount(for: leg.amount, currency: leg.currency),
                         note: indexedNote(base: note, mode: .split, index: index, count: legs.count),
                         autosave: false
                     )
@@ -1348,7 +1419,11 @@ struct AddAdvanceRepaymentView: View {
                     items.append((amount, leg.currency))
                 }
                 
-                guard validateTotalNotExceedingRemaining(items: items) else {
+                guard let totalIsValid = validateTotalNotExceedingRemaining(items: items) else {
+                    showError("暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。")
+                    return
+                }
+                guard totalIsValid else {
                     showError("合併總金額超過未還餘額。")
                     return
                 }
@@ -1358,6 +1433,7 @@ struct AddAdvanceRepaymentView: View {
                         receiveAccount: receiveAccount,
                         amount: item.amount,
                         currencyCode: item.currency,
+                        normalizedAmount: normalizedAmount(for: item.amount, currency: item.currency),
                         note: indexedNote(base: note, mode: .merge, index: index, count: items.count),
                         autosave: false
                     )
@@ -1410,22 +1486,41 @@ struct AddAdvanceRepaymentView: View {
         newTagName = ""
     }
     
-    private func validateTotalNotExceedingRemaining(items: [(amount: Decimal, currency: String)]) -> Bool {
-        let totalNormalized = items.reduce(Decimal.zero) { partial, item in
-            partial + currencyService.convert(amount: abs(item.amount), from: item.currency, to: advanceCase.currencyCode)
+    private func validateTotalNotExceedingRemaining(items: [(amount: Decimal, currency: String)]) -> Bool? {
+        var totalNormalized = Decimal.zero
+        for item in items {
+            guard let normalized = normalizedAmount(for: item.amount, currency: item.currency) else {
+                return nil
+            }
+            totalNormalized += normalized
         }
         let tolerance = Decimal(string: "0.0001") ?? 0.0001
         return totalNormalized - remaining <= tolerance
+    }
+
+    private func normalizedAmount(for amount: Decimal, currency: String) -> Decimal? {
+        if currency.uppercased() == advanceCase.currencyCode.uppercased() {
+            return abs(amount)
+        }
+        return currencyService.estimate(
+            amount: abs(amount),
+            from: currency,
+            to: advanceCase.currencyCode
+        )?.amount
     }
     
     private func recordSingleRepayment(
         receiveAccount: Account,
         amount: Decimal,
         currencyCode: String,
+        normalizedAmount: Decimal?,
         note: String,
         autosave: Bool
     ) throws -> AdvanceRepayment {
-        try AdvanceService.recordRepayment(
+        guard let normalizedAmount else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        return try AdvanceService.recordRepayment(
             advanceCase: advanceCase,
             participant: participant,
             amount: amount,
@@ -1436,10 +1531,24 @@ struct AddAdvanceRepaymentView: View {
             category: selectedCategory,
             tags: Array(selectedTags),
             currencyService: currencyService,
+            normalizedAmountOverride: normalizedAmount,
             direction: settlementDirection,
             autosave: autosave,
             modelContext: modelContext
         )
+    }
+
+    private func syncSettlementEstimateIfNeeded(force: Bool = false) {
+        guard force || !settlementAmountManuallyEdited else { return }
+        if !isCrossCurrencyRepayment {
+            settlementAmountString = amountString
+            return
+        }
+        guard let settlementEstimate else {
+            settlementAmountString = ""
+            return
+        }
+        settlementAmountString = NSDecimalNumber(decimal: settlementEstimate.amount).stringValue
     }
     
     private func indexedNote(base: String, mode: EntryMode, index: Int, count: Int) -> String {

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -257,10 +257,16 @@ struct ChartsView: View {
             let normalized = percentDouble / 100.0
             return CGFloat(min(max(normalized, 0), 1))
         }()
+        let percentText = "\(percent.formatted(.number.precision(.fractionLength(1))))%"
+        let footnoteText = item.estimateFootnote.map { "\(percentText)・\($0)" } ?? percentText
         return HStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 4).fill(item.color).frame(width: 4, height: 40)
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.name).font(.body).fontWeight(.medium)
+                Text(item.originalCurrencySummary)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
                 GeometryReader { geo in
                     ZStack(alignment: .leading) {
                         Capsule().fill(Color.gray.opacity(0.1))
@@ -272,9 +278,9 @@ struct ChartsView: View {
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 2) {
-                Text(item.amount.formatted(.currency(code: currencyService.mainCurrency))).font(.body).bold()
+                Text("約 \(item.amount.formatted(.currency(code: currencyService.mainCurrency)))").font(.body).bold()
                 HStack(spacing: 4) {
-                    Text("\(percent.formatted(.number.precision(.fractionLength(1))))%")
+                    Text(footnoteText)
                     Image(systemName: trailingIcon)
                 }.font(.caption).foregroundStyle(.secondary)
             }
@@ -305,6 +311,8 @@ struct ChartsView: View {
         let amount: Decimal
         let color: Color
         let transactions: [FinancialTransaction]
+        let originalCurrencySummary: String
+        let estimateFootnote: String?
     }
     
     func presentTransactions(for item: ChartData, tagName: String? = nil) {
@@ -469,54 +477,106 @@ private struct ChartsRenderState {
         currencyService: CurrencyService
     ) -> [ChartsView.ChartData] {
         let grouped = Dictionary(grouping: transactions) { $0.category?.id.uuidString ?? "uncategorized" }
-        let sorted = grouped.sorted {
-            let sum0 = $0.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-            let sum1 = $1.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
-            return sum0 > sum1
-        }
-        return sorted.map { item in
-            let total = item.value.reduce(0) { $0 + currencyService.convert(amount: abs($1.amount), from: $1.currencyCode) }
+        let mapped = grouped.map { item -> ChartsView.ChartData in
+            let aggregate = currencyAggregate(from: item.value, currencyService: currencyService)
             let category = item.value.compactMap { $0.category }.first
             let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
             return ChartsView.ChartData(
                 key: item.key,
                 name: category?.name ?? "未分類",
-                amount: total,
+                amount: aggregate.estimatedAmount,
                 color: displayColor,
-                transactions: item.value
+                transactions: item.value,
+                originalCurrencySummary: aggregate.originalCurrencySummary,
+                estimateFootnote: aggregate.estimateFootnote
             )
         }
+        return mapped.sorted { $0.amount > $1.amount }
     }
 
     private static func tagBreakdown(
         from transactions: [FinancialTransaction],
         currencyService: CurrencyService
     ) -> [ChartsView.ChartData] {
-        var tagDict: [String: Decimal] = [:]
         var tagTransactions: [String: [FinancialTransaction]] = [:]
         for tx in transactions {
-            let amount = currencyService.convert(amount: abs(tx.amount), from: tx.currencyCode)
             if tx.tags.isEmpty {
-                tagDict["無標籤", default: 0] += amount
                 tagTransactions["無標籤", default: []].append(tx)
             } else {
                 for tag in tx.tags {
-                    tagDict[tag.name, default: 0] += amount
                     tagTransactions[tag.name, default: []].append(tx)
                 }
             }
         }
-        let sorted = tagDict.sorted { $0.value > $1.value }
+        let sorted = tagTransactions
+            .map { item -> (key: String, aggregate: CurrencyReportAggregate, transactions: [FinancialTransaction]) in
+                (item.key, currencyAggregate(from: item.value, currencyService: currencyService), item.value)
+            }
+            .sorted { $0.aggregate.estimatedAmount > $1.aggregate.estimatedAmount }
         return sorted.enumerated().map { index, item in
             ChartsView.ChartData(
                 key: item.key,
                 name: item.key,
-                amount: item.value,
+                amount: item.aggregate.estimatedAmount,
                 color: Color.generateDistinctColor(index: index, total: sorted.count),
-                transactions: tagTransactions[item.key] ?? []
+                transactions: item.transactions,
+                originalCurrencySummary: item.aggregate.originalCurrencySummary,
+                estimateFootnote: item.aggregate.estimateFootnote
             )
         }
     }
+}
+
+private struct CurrencyReportAggregate {
+    let estimatedAmount: Decimal
+    let originalCurrencySummary: String
+    let estimateFootnote: String?
+}
+
+private func currencyAggregate(
+    from transactions: [FinancialTransaction],
+    currencyService: CurrencyService
+) -> CurrencyReportAggregate {
+    var estimatedAmount = Decimal.zero
+    var originalTotals: [String: Decimal] = [:]
+    var usesEstimate = false
+    var hasUnavailableRate = false
+    let mainCurrency = currencyService.mainCurrency.uppercased()
+
+    for transaction in transactions {
+        let amount = abs(transaction.amount)
+        let currency = transaction.currencyCode.uppercased()
+        originalTotals[currency, default: 0] += amount
+
+        if currency == mainCurrency {
+            estimatedAmount += amount
+        } else if let estimate = currencyService.estimate(amount: amount, from: currency, to: mainCurrency) {
+            estimatedAmount += estimate.amount
+            usesEstimate = true
+        } else {
+            hasUnavailableRate = true
+        }
+    }
+
+    let originalSummary = originalTotals
+        .sorted { $0.key < $1.key }
+        .map { amount in amount.value.formatted(.currency(code: amount.key)) }
+        .joined(separator: " · ")
+
+    let footnote: String?
+    if hasUnavailableRate {
+        footnote = "估算不完整"
+    } else if usesEstimate {
+        footnote = currencyService.resolvedRateSourceState.label
+    } else {
+        footnote = nil
+    }
+
+    return CurrencyReportAggregate(
+        estimatedAmount: estimatedAmount,
+        originalCurrencySummary: originalSummary,
+        estimateFootnote: footnote
+    )
 }
 
 private struct ReportTransactionListView: View {

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -378,6 +378,68 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(Decimal(40), payableCase.participants.first?.remainingAmount)
     }
 
+    func testCrossCurrencyAdvanceRepayment_preservesActualCurrencyAndManualSettlementAmount() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let payerAccount = Account(name: "HKD Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let receiveAccount = Account(name: "CNY Wallet", currency: "CNY", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        modelContext.insert(payerAccount)
+        modelContext.insert(receiveAccount)
+        modelContext.insert(debtAccount)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "晚餐代墊",
+            date: date,
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: payerAccount,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 100)],
+            isBorrowedByMe: false,
+            modelContext: modelContext
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 90,
+            currencyCode: "CNY",
+            date: date.addingTimeInterval(3600),
+            note: "朋友用人民幣還款",
+            receiveAccount: receiveAccount,
+            category: nil,
+            tags: [],
+            currencyService: CurrencyService.shared,
+            normalizedAmountOverride: 100,
+            modelContext: modelContext
+        )
+
+        XCTAssertEqual(Decimal(90), repayment.amount)
+        XCTAssertEqual("CNY", repayment.currencyCode)
+        XCTAssertEqual(Decimal(100), repayment.normalizedAmount)
+        XCTAssertEqual(Decimal.zero, participant.remainingAmount)
+
+        let linkedTransfers = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+            .filter { $0.transferGroupID == repayment.linkedTransferGroupID }
+        XCTAssertEqual(2, linkedTransfers.count)
+        let incoming = try XCTUnwrap(linkedTransfers.first { $0.transferSide == .incoming })
+        XCTAssertEqual(receiveAccount.id, incoming.account?.id)
+        XCTAssertEqual(Decimal(90), incoming.amount)
+        XCTAssertEqual("CNY", incoming.currencyCode)
+
+        let exported = BackupManager.shared.createBackupData(modelContext: modelContext)
+        let exportedRepayment = try XCTUnwrap(exported.advanceRepayments?.first { $0.id == repayment.id })
+        XCTAssertEqual(Decimal(90), exportedRepayment.amount)
+        XCTAssertEqual("CNY", exportedRepayment.currencyCode)
+        XCTAssertEqual(Decimal(100), exportedRepayment.normalizedAmount)
+    }
+
     func testLegacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndKeepsExpense() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/currency/CurrencyService.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/currency/CurrencyService.kt
@@ -145,6 +145,40 @@ class CurrencyService(context: Context) {
         return inMain.multiply(targetRate.toBigDecimal()).setScale(6, RoundingMode.HALF_UP)
     }
 
+    fun estimate(amount: BigDecimal, from: String, to: String): CurrencyPreview? {
+        val sourceCode = from.uppercase()
+        val targetCode = to.uppercase()
+        if (sourceCode == targetCode) return CurrencyPreview(amount, resolvedRateSourceState)
+        if (resolvedRates.isEmpty()) return null
+
+        if (sourceCode == mainCurrency.uppercase()) {
+            val targetRate = resolvedRates[targetCode] ?: return null
+            if (targetRate <= 0.0) return null
+            return CurrencyPreview(
+                amount.multiply(targetRate.toBigDecimal()).setScale(6, RoundingMode.HALF_UP),
+                resolvedRateSourceState
+            )
+        }
+
+        if (targetCode == mainCurrency.uppercase()) {
+            val sourceRate = resolvedRates[sourceCode] ?: return null
+            if (sourceRate <= 0.0) return null
+            return CurrencyPreview(
+                amount.divide(sourceRate.toBigDecimal(), 6, RoundingMode.HALF_UP),
+                resolvedRateSourceState
+            )
+        }
+
+        val sourceRate = resolvedRates[sourceCode] ?: return null
+        val targetRate = resolvedRates[targetCode] ?: return null
+        if (sourceRate <= 0.0 || targetRate <= 0.0) return null
+        val inMain = amount.divide(sourceRate.toBigDecimal(), 6, RoundingMode.HALF_UP)
+        return CurrencyPreview(
+            inMain.multiply(targetRate.toBigDecimal()).setScale(6, RoundingMode.HALF_UP),
+            resolvedRateSourceState
+        )
+    }
+
     fun getMarketRate(from: String, to: String): Double? {
         if (from.equals(to, ignoreCase = true)) return 1.0
         val rateFrom = resolvedRates[from.uppercase()] ?: return null
@@ -155,9 +189,7 @@ class CurrencyService(context: Context) {
 
     fun previewInMainCurrency(amount: BigDecimal, from: String): CurrencyPreview? {
         if (from.equals(mainCurrency, ignoreCase = true)) return null
-        val converted = convert(amount, from)
-        if (converted == amount && resolvedRates[from.uppercase()] == null) return null
-        return CurrencyPreview(converted, resolvedRateSourceState)
+        return estimate(amount, from, mainCurrency)
     }
 
     val resolvedRateSourceState: RateSourceState

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
@@ -86,6 +86,8 @@ fun AdvanceDetailScreen(caseId: String?) {
     var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
     var selectedTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
     var amountInput by remember { mutableStateOf("") }
+    var settlementAmountInput by remember { mutableStateOf("") }
+    var settlementManuallyEdited by remember { mutableStateOf(false) }
     var note by remember { mutableStateOf("") }
     var selectedCurrency by remember { mutableStateOf("HKD") }
     var mode by remember { mutableStateOf(RepaymentMode.Normal) }
@@ -157,11 +159,20 @@ fun AdvanceDetailScreen(caseId: String?) {
     val remaining = selectedParticipant?.let {
         (it.owedAmount - it.repaidAmount).max(BigDecimal.ZERO)
     } ?: BigDecimal.ZERO
+    val parsedAmount = parsePositive(amountInput)
+    val isCrossCurrencyRepayment = !selectedCurrency.equals(caseCurrency, ignoreCase = true)
+    val settlementEstimate = parsedAmount?.let { currencyService.estimate(it, selectedCurrency, caseCurrency) }
+    val parsedSettlementAmount = if (isCrossCurrencyRepayment) {
+        parsePositive(settlementAmountInput)
+    } else {
+        parsedAmount
+    }
 
     val canSubmit = when (mode) {
         RepaymentMode.Normal -> selectedParticipant != null &&
             selectedReceiveAccount != null &&
-            parsePositive(amountInput) != null
+            parsedAmount != null &&
+            parsedSettlementAmount != null
         RepaymentMode.Split -> selectedParticipant != null &&
             splitLegs.isNotEmpty() &&
             splitLegs.all { it.account != null && parsePositive(it.amount) != null }
@@ -169,6 +180,16 @@ fun AdvanceDetailScreen(caseId: String?) {
             selectedReceiveAccount != null &&
             mergeLegs.isNotEmpty() &&
             mergeLegs.all { parsePositive(it.amount) != null }
+    }
+
+    LaunchedEffect(amountInput, selectedCurrency, caseCurrency, mode) {
+        if (mode == RepaymentMode.Normal && !settlementManuallyEdited) {
+            settlementAmountInput = if (isCrossCurrencyRepayment) {
+                settlementEstimate?.amount?.stripTrailingZeros()?.toPlainString().orEmpty()
+            } else {
+                amountInput
+            }
+        }
     }
 
     LazyColumn(
@@ -237,6 +258,25 @@ fun AdvanceDetailScreen(caseId: String?) {
                             currency = selectedCurrency,
                             onCurrencyChange = { selectedCurrency = it }
                         )
+                        if (isCrossCurrencyRepayment) {
+                            SettlementAmountRow(
+                                amount = settlementAmountInput,
+                                onAmountChange = {
+                                    settlementAmountInput = sanitizeAmount(it)
+                                    settlementManuallyEdited = true
+                                },
+                                caseCurrency = caseCurrency,
+                                estimateText = settlementEstimate?.let {
+                                    "建議 ${it.amount.asCurrencyText(caseCurrency)}（${it.source.label}）"
+                                } ?: "暫時無法取得匯率，請手動填入要沖銷的 $caseCurrency 金額。"
+                            )
+                        } else if (settlementEstimate != null) {
+                            Text(
+                                "沖銷 ${settlementEstimate.amount.asCurrencyText(caseCurrency)}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                     RepaymentMode.Split -> {
                         splitLegs.forEach { leg ->
@@ -290,49 +330,57 @@ fun AdvanceDetailScreen(caseId: String?) {
                         scope.launch {
                             val participant = selectedParticipant ?: return@launch
                             when (mode) {
-                                RepaymentMode.Normal -> {
-                                    val receiveAccount = selectedReceiveAccount ?: return@launch
-                                    val amount = parsePositive(amountInput) ?: return@launch
-                                    if (!validateTotal(currencyService, caseCurrency, remaining, listOf(amount to selectedCurrency))) {
-                                        errorMessage = "還款金額超過未還餘額。"
-                                        return@launch
-                                    }
-                                    recordSingleRepayment(
-                                        repository = repository,
-                                        currencyService = currencyService,
-                                        advanceCase = caseData,
-                                        participant = participant,
-                                        receiveAccount = receiveAccount,
-                                        amount = amount,
-                                        currency = selectedCurrency,
-                                        note = note,
-                                        category = selectedCategory,
-                                        tagIds = selectedTags.map { it.id },
+	                                RepaymentMode.Normal -> {
+	                                    val receiveAccount = selectedReceiveAccount ?: return@launch
+	                                    val amount = parsePositive(amountInput) ?: return@launch
+	                                    val normalizedAmount = parsedSettlementAmount ?: return@launch
+	                                    if (normalizedAmount - remaining > BigDecimal("0.0001")) {
+	                                        errorMessage = "沖銷金額超過未還餘額。"
+	                                        return@launch
+	                                    }
+	                                    recordSingleRepayment(
+	                                        repository = repository,
+	                                        advanceCase = caseData,
+	                                        participant = participant,
+	                                        receiveAccount = receiveAccount,
+	                                        amount = amount,
+	                                        currency = selectedCurrency,
+	                                        normalizedAmount = normalizedAmount,
+	                                        note = note,
+	                                        category = selectedCategory,
+	                                        tagIds = selectedTags.map { it.id },
                                         isBorrowedByMe = isBorrowedByMe
                                     )
                                 }
                                 RepaymentMode.Split -> {
                                     val legs = splitLegs.mapNotNull { leg ->
                                         val account = leg.account ?: return@mapNotNull null
-                                        val amount = parsePositive(leg.amount) ?: return@mapNotNull null
-                                        Triple(account, amount, leg.currency)
-                                    }
-                                    if (!validateTotal(currencyService, caseCurrency, remaining, legs.map { it.second to it.third })) {
-                                        errorMessage = "分拆總金額超過未還餘額。"
-                                        return@launch
-                                    }
-                                    legs.forEachIndexed { index, leg ->
-                                        recordSingleRepayment(
-                                            repository = repository,
-                                            currencyService = currencyService,
-                                            advanceCase = caseData,
-                                            participant = participant,
-                                            receiveAccount = leg.first,
-                                            amount = leg.second,
-                                            currency = leg.third,
-                                            note = indexedNote(note, "分拆", index, legs.size),
-                                            category = selectedCategory,
-                                            tagIds = selectedTags.map { it.id },
+	                                        val amount = parsePositive(leg.amount) ?: return@mapNotNull null
+	                                        Triple(account, amount, leg.currency)
+	                                    }
+	                                    val normalizedLegs = legs.map { leg ->
+	                                        normalizedAmount(currencyService, leg.second, leg.third, caseCurrency)
+	                                    }
+	                                    if (normalizedLegs.any { it == null }) {
+	                                        errorMessage = "暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。"
+	                                        return@launch
+	                                    }
+	                                    if (!validateTotal(remaining, normalizedLegs.filterNotNull())) {
+	                                        errorMessage = "分拆總金額超過未還餘額。"
+	                                        return@launch
+	                                    }
+	                                    legs.forEachIndexed { index, leg ->
+	                                        recordSingleRepayment(
+	                                            repository = repository,
+	                                            advanceCase = caseData,
+	                                            participant = participant,
+	                                            receiveAccount = leg.first,
+	                                            amount = leg.second,
+	                                            currency = leg.third,
+	                                            normalizedAmount = normalizedLegs[index] ?: return@launch,
+	                                            note = indexedNote(note, "分拆", index, legs.size),
+	                                            category = selectedCategory,
+	                                            tagIds = selectedTags.map { it.id },
                                             isBorrowedByMe = isBorrowedByMe
                                         )
                                     }
@@ -340,24 +388,31 @@ fun AdvanceDetailScreen(caseId: String?) {
                                 RepaymentMode.Merge -> {
                                     val receiveAccount = selectedReceiveAccount ?: return@launch
                                     val legs = mergeLegs.mapNotNull { leg ->
-                                        val amount = parsePositive(leg.amount) ?: return@mapNotNull null
-                                        amount to leg.currency
-                                    }
-                                    if (!validateTotal(currencyService, caseCurrency, remaining, legs)) {
-                                        errorMessage = "合併總金額超過未還餘額。"
-                                        return@launch
-                                    }
-                                    legs.forEachIndexed { index, item ->
-                                        recordSingleRepayment(
-                                            repository = repository,
-                                            currencyService = currencyService,
-                                            advanceCase = caseData,
-                                            participant = participant,
-                                            receiveAccount = receiveAccount,
-                                            amount = item.first,
-                                            currency = item.second,
-                                            note = indexedNote(note, "合併", index, legs.size),
-                                            category = selectedCategory,
+	                                        val amount = parsePositive(leg.amount) ?: return@mapNotNull null
+	                                        amount to leg.currency
+	                                    }
+	                                    val normalizedLegs = legs.map { leg ->
+	                                        normalizedAmount(currencyService, leg.first, leg.second, caseCurrency)
+	                                    }
+	                                    if (normalizedLegs.any { it == null }) {
+	                                        errorMessage = "暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。"
+	                                        return@launch
+	                                    }
+	                                    if (!validateTotal(remaining, normalizedLegs.filterNotNull())) {
+	                                        errorMessage = "合併總金額超過未還餘額。"
+	                                        return@launch
+	                                    }
+	                                    legs.forEachIndexed { index, item ->
+	                                        recordSingleRepayment(
+	                                            repository = repository,
+	                                            advanceCase = caseData,
+	                                            participant = participant,
+	                                            receiveAccount = receiveAccount,
+	                                            amount = item.first,
+	                                            currency = item.second,
+	                                            normalizedAmount = normalizedLegs[index] ?: return@launch,
+	                                            note = indexedNote(note, "合併", index, legs.size),
+	                                            category = selectedCategory,
                                             tagIds = selectedTags.map { it.id },
                                             isBorrowedByMe = isBorrowedByMe
                                         )
@@ -459,6 +514,37 @@ private fun AmountRow(
                 modifier = Modifier.weight(1f)
             )
         }
+    }
+}
+
+@Composable
+private fun SettlementAmountRow(
+    amount: String,
+    onAmountChange: (String) -> Unit,
+    caseCurrency: String,
+    estimateText: String
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text("沖銷代墊金額", style = MaterialTheme.typography.titleSmall)
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedTextField(
+                value = amount,
+                onValueChange = onAmountChange,
+                label = { Text("沖銷金額") },
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                caseCurrency,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+        }
+        Text(
+            estimateText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 
@@ -583,33 +669,35 @@ private fun parsePositive(input: String): BigDecimal? {
     return input.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO }
 }
 
-private fun validateTotal(
-    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
-    caseCurrency: String,
-    remaining: BigDecimal,
-    items: List<Pair<BigDecimal, String>>
-): Boolean {
-    val totalNormalized = items.fold(BigDecimal.ZERO) { acc, item ->
-        acc + currencyService.convert(item.first.abs(), item.second, caseCurrency)
-    }
+private fun validateTotal(remaining: BigDecimal, normalizedAmounts: List<BigDecimal>): Boolean {
+    val totalNormalized = normalizedAmounts.fold(BigDecimal.ZERO) { acc, item -> acc + item.abs() }
     val tolerance = BigDecimal("0.0001")
     return totalNormalized - remaining <= tolerance
 }
 
+private fun normalizedAmount(
+    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
+    amount: BigDecimal,
+    currency: String,
+    caseCurrency: String
+): BigDecimal? {
+    if (currency.equals(caseCurrency, ignoreCase = true)) return amount.abs()
+    return currencyService.estimate(amount.abs(), currency, caseCurrency)?.amount
+}
+
 private suspend fun recordSingleRepayment(
     repository: org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository,
-    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     advanceCase: AdvanceCaseWithDetails,
     participant: AdvanceParticipantEntity,
     receiveAccount: AccountEntity,
     amount: BigDecimal,
     currency: String,
+    normalizedAmount: BigDecimal,
     note: String,
     category: CategoryEntity?,
     tagIds: List<UUID>,
     isBorrowedByMe: Boolean
 ) {
-    val normalizedAmount = currencyService.convert(amount.abs(), currency, advanceCase.advanceCase.currencyCode)
     repository.recordAdvanceRepayment(
         advanceCase = advanceCase.advanceCase,
         participant = participant,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -98,7 +98,15 @@ private data class ReportSlice(
     val name: String,
     val amount: BigDecimal,
     val color: Color,
-    val transactions: List<TransactionWithDetails>
+    val transactions: List<TransactionWithDetails>,
+    val originalCurrencySummary: String,
+    val estimateFootnote: String?
+)
+
+private data class CurrencyReportAggregate(
+    val estimatedAmount: BigDecimal,
+    val originalCurrencySummary: String,
+    val estimateFootnote: String?
 )
 
 private data class ReportDetail(
@@ -420,24 +428,30 @@ private fun ReportRow(
         ) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 ColorDot(color = item.color)
-                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(item.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                    Text(
-                        "${percent.stripTrailingZeros().toPlainString()}% · ${item.transactions.size} 筆",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        item.amount.asCurrencyText(baseCurrency),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    Text(
-                        trailingLabel,
-                        style = MaterialTheme.typography.labelMedium,
+	                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+	                    Text(item.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+	                    Text(
+	                        "${percent.stripTrailingZeros().toPlainString()}% · ${item.transactions.size} 筆",
+	                        style = MaterialTheme.typography.labelSmall,
+	                        color = MaterialTheme.colorScheme.onSurfaceVariant
+	                    )
+	                    Text(
+	                        item.originalCurrencySummary,
+	                        style = MaterialTheme.typography.labelSmall,
+	                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+	                        maxLines = 1
+	                    )
+	                }
+	                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+	                    Text(
+	                        "約 ${item.amount.asCurrencyText(baseCurrency)}",
+	                        style = MaterialTheme.typography.bodyLarge,
+	                        fontWeight = FontWeight.SemiBold,
+	                        color = MaterialTheme.colorScheme.onSurface
+	                    )
+	                    Text(
+	                        item.estimateFootnote?.let { "$trailingLabel · $it" } ?: trailingLabel,
+	                        style = MaterialTheme.typography.labelMedium,
                         fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colorScheme.primary
                     )
@@ -726,51 +740,96 @@ private fun categoryBreakdown(
     currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     baseCurrency: String
 ): List<ReportSlice> {
-    val grouped = transactions.groupBy { it.category?.id }
-    return grouped.mapNotNull { (categoryId, items) ->
-        val category = categories.firstOrNull { it.id == categoryId }
-        val total = items.fold(BigDecimal.ZERO) { acc, tx ->
-            acc + currencyService.convert(tx.transaction.amount.abs(), tx.transaction.currencyCode, baseCurrency)
-        }
-        ReportSlice(
-            key = categoryId?.toString() ?: "uncategorized",
-            name = category?.name ?: "未分類",
-            amount = total,
-            color = parseColor(category?.colorHex ?: "#90A4AE"),
-            transactions = items
-        )
-    }.sortedByDescending { it.amount }
+	val grouped = transactions.groupBy { it.category?.id }
+	return grouped.mapNotNull { (categoryId, items) ->
+	    val category = categories.firstOrNull { it.id == categoryId }
+	    val aggregate = currencyAggregate(items, currencyService, baseCurrency)
+	    ReportSlice(
+	        key = categoryId?.toString() ?: "uncategorized",
+	        name = category?.name ?: "未分類",
+	        amount = aggregate.estimatedAmount,
+	        color = parseColor(category?.colorHex ?: "#90A4AE"),
+	        transactions = items,
+	        originalCurrencySummary = aggregate.originalCurrencySummary,
+	        estimateFootnote = aggregate.estimateFootnote
+	    )
+	}.sortedByDescending { it.amount }
 }
 
 private fun tagBreakdown(
     transactions: List<TransactionWithDetails>,
+	currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
+	baseCurrency: String
+): List<ReportSlice> {
+	val tagTransactions = mutableMapOf<String, MutableList<TransactionWithDetails>>()
+	transactions.forEach { tx ->
+	    if (tx.tags.isEmpty()) {
+	        tagTransactions.getOrPut("無標籤") { mutableListOf() }.add(tx)
+	    } else {
+	        tx.tags.forEach { tag ->
+	            tagTransactions.getOrPut(tag.name) { mutableListOf() }.add(tx)
+	        }
+	    }
+	}
+	val sorted = tagTransactions.entries
+	    .map { entry -> entry.key to currencyAggregate(entry.value, currencyService, baseCurrency) }
+	    .sortedByDescending { it.second.estimatedAmount }
+	return sorted.mapIndexed { index, entry ->
+	    ReportSlice(
+	        key = entry.first,
+	        name = entry.first,
+	        amount = entry.second.estimatedAmount,
+	        color = generateDistinctColor(index),
+	        transactions = tagTransactions[entry.first]?.toList().orEmpty(),
+	        originalCurrencySummary = entry.second.originalCurrencySummary,
+	        estimateFootnote = entry.second.estimateFootnote
+	    )
+	}
+}
+
+private fun currencyAggregate(
+    transactions: List<TransactionWithDetails>,
     currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
     baseCurrency: String
-): List<ReportSlice> {
-    val tagTotals = mutableMapOf<String, BigDecimal>()
-    val tagTransactions = mutableMapOf<String, MutableList<TransactionWithDetails>>()
+): CurrencyReportAggregate {
+    var estimatedAmount = BigDecimal.ZERO
+    val originalTotals = mutableMapOf<String, BigDecimal>()
+    var usesEstimate = false
+    var hasUnavailableRate = false
+    val mainCurrency = baseCurrency.uppercase()
+
     transactions.forEach { tx ->
-        val amount = currencyService.convert(tx.transaction.amount.abs(), tx.transaction.currencyCode, baseCurrency)
-        if (tx.tags.isEmpty()) {
-            tagTotals["無標籤"] = (tagTotals["無標籤"] ?: BigDecimal.ZERO) + amount
-            tagTransactions.getOrPut("無標籤") { mutableListOf() }.add(tx)
+        val amount = tx.transaction.amount.abs()
+        val currency = tx.transaction.currencyCode.uppercase()
+        originalTotals[currency] = (originalTotals[currency] ?: BigDecimal.ZERO) + amount
+
+        if (currency == mainCurrency) {
+            estimatedAmount += amount
         } else {
-            tx.tags.forEach { tag ->
-                tagTotals[tag.name] = (tagTotals[tag.name] ?: BigDecimal.ZERO) + amount
-                tagTransactions.getOrPut(tag.name) { mutableListOf() }.add(tx)
+            val estimate = currencyService.estimate(amount, currency, mainCurrency)
+            if (estimate != null) {
+                estimatedAmount += estimate.amount
+                usesEstimate = true
+            } else {
+                hasUnavailableRate = true
             }
         }
     }
-    val sorted = tagTotals.entries.sortedByDescending { it.value }
-    return sorted.mapIndexed { index, entry ->
-        ReportSlice(
-            key = entry.key,
-            name = entry.key,
-            amount = entry.value,
-            color = generateDistinctColor(index),
-            transactions = tagTransactions[entry.key]?.toList().orEmpty()
-        )
+
+    val originalSummary = originalTotals.entries
+        .sortedBy { it.key }
+        .joinToString(" · ") { it.value.asCurrencyText(it.key) }
+    val footnote = when {
+        hasUnavailableRate -> "估算不完整"
+        usesEstimate -> currencyService.resolvedRateSourceState.label
+        else -> null
     }
+
+    return CurrencyReportAggregate(
+        estimatedAmount = estimatedAmount,
+        originalCurrencySummary = originalSummary,
+        estimateFootnote = footnote
+    )
 }
 
 private fun totalAmount(data: List<ReportSlice>): BigDecimal {

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -297,6 +297,83 @@ class BackupRoundTripTest {
     }
 
     @Test
+    fun crossCurrencyAdvanceRepayment_preservesActualCurrencyAndManualSettlementAmount() = runBlocking {
+        val payerAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "HKD Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val receiveAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "CNY Wallet",
+            currency = "CNY",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 1,
+            isArchived = false
+        )
+        val debtAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Friend A",
+            currency = "HKD",
+            type = AccountType.Debt,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 2,
+            isArchived = false
+        )
+        database.accountDao().upsertAll(listOf(payerAccount, receiveAccount, debtAccount))
+
+        val date = Instant.parse("2026-03-21T12:00:00Z")
+        val caseId = repository.createAdvanceCase(
+            title = "晚餐代墊",
+            date = date,
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = payerAccount,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("100"))),
+            isBorrowedByMe = false
+        )
+        val advanceCase = checkNotNull(repository.getAdvanceCase(caseId))
+        val participant = advanceCase.participants.single()
+
+        repository.recordAdvanceRepayment(
+            advanceCase = advanceCase.advanceCase,
+            participant = participant,
+            amount = BigDecimal("90"),
+            normalizedAmount = BigDecimal("100"),
+            currencyCode = "CNY",
+            date = date.plusSeconds(3600),
+            note = "朋友用人民幣還款",
+            receiveAccount = receiveAccount,
+            category = null,
+            tagIds = emptyList(),
+            isBorrowedByMe = false
+        )
+
+        val updatedCase = checkNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(BigDecimal.ZERO, updatedCase.participants.single().owedAmount - updatedCase.participants.single().repaidAmount)
+
+        val exported = BackupJsonAdapter.gson.fromJson(repository.exportBackupJson(), FullBackupData::class.java)
+        val exportedRepayment = checkNotNull(exported.advanceRepayments?.single())
+        assertEquals(BigDecimal("90"), exportedRepayment.amount)
+        assertEquals("CNY", exportedRepayment.currencyCode)
+        assertEquals(BigDecimal("100"), exportedRepayment.normalizedAmount)
+
+        val linkedTransactions = database.transactionDao().getAll().filter { it.transferGroupId == exportedRepayment.linkedTransferGroupID }
+        assertEquals(2, linkedTransactions.size)
+        val incoming = checkNotNull(linkedTransactions.firstOrNull { it.accountId == receiveAccount.id })
+        assertEquals(BigDecimal("90"), incoming.amount)
+        assertEquals("CNY", incoming.currencyCode)
+    }
+
+    @Test
     fun legacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndReimportsCleanly() = runBlocking {
         val fixtureJson = loadFixture("fixtures/legacy_bidirectional_advances.json")
 


### PR DESCRIPTION
## Summary
- Support recording advance repayments in a different actual currency while manually setting the settlement amount in the advance case currency.
- Show report category/tag totals as estimated main-currency amounts with original-currency breakdowns.
- Avoid silent 1:1 currency fallback in report/preview estimate paths; missing rates are surfaced as incomplete estimates.

## Product Context
- Implements child issues for the PRD created with `to-prd` / `to-issues`.
- References #106
- Closes #107
- Closes #108

## Notes
- No SwiftData / Room schema changes.
- No JSON backup schema changes.
- Existing repayment fields are reused: actual repayment amount/currency stay as paid, while `normalizedAmount` stores the settled advance-case amount.
- Existing local private diffs in `AI 記帳.xcscheme` and `Localizable.xcstrings` were not staged or committed.

## Tests
- `xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO`
- `./gradlew testDebugUnitTest assembleDebug`
