### PR TITLE
Polish report details and keyboard dismissal

### DIFF
--- a/AI 記帳/Views/Accounts/AddAccountView.swift
+++ b/AI 記帳/Views/Accounts/AddAccountView.swift
@@ -113,6 +113,7 @@ struct AddAccountView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("新增帳戶")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }

--- a/AI 記帳/Views/Accounts/EditAccountView.swift
+++ b/AI 記帳/Views/Accounts/EditAccountView.swift
@@ -96,6 +96,7 @@ struct EditAccountView: View {
                         .disabled(adjustmentAmountString.isEmpty)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("編輯帳戶")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -687,6 +687,7 @@ struct AddAdvanceCaseView: View {
                     TextField("可填入店名、說明等", text: $note)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("新增代墊")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -1290,6 +1291,7 @@ struct AddAdvanceRepaymentView: View {
                     TextField("備註", text: $note)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("記錄還款")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/AI 記帳/Views/Budgets/BudgetsView.swift
+++ b/AI 記帳/Views/Budgets/BudgetsView.swift
@@ -407,6 +407,7 @@ struct BudgetEditorView: View {
                     Toggle("啟用", isOn: $isEnabled)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle(existingBudget == nil ? "新增預算" : "編輯預算")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -416,6 +417,7 @@ struct BudgetEditorView: View {
                     Button("儲存") { save() }
                 }
             }
+            .keyboardDoneToolbar()
             .alert("無法儲存", isPresented: $showingError) {
                 Button("好", role: .cancel) {}
             } message: {

--- a/AI 記帳/Views/Categories/AddCategoryView.swift
+++ b/AI 記帳/Views/Categories/AddCategoryView.swift
@@ -141,6 +141,7 @@ struct AddCategoryView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("新增分類")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -157,6 +158,7 @@ struct AddCategoryView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
+            .keyboardDoneToolbar()
         }
     }
     

--- a/AI 記帳/Views/Categories/EditCategoryView.swift
+++ b/AI 記帳/Views/Categories/EditCategoryView.swift
@@ -133,6 +133,7 @@ struct EditCategoryView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("編輯分類")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -146,6 +147,7 @@ struct EditCategoryView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
+            .keyboardDoneToolbar()
             .onAppear {
                 // 初始化暫存數據
                 name = category.name

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -54,6 +54,10 @@ struct ChartsView: View {
     struct ReportDetail: Identifiable {
         let id = UUID()
         let title: String
+        let estimatedAmount: Decimal
+        let mainCurrency: String
+        let originalCurrencySummary: String
+        let estimateFootnote: String?
         let transactions: [FinancialTransaction]
     }
     
@@ -115,7 +119,7 @@ struct ChartsView: View {
                 )
             }
             .sheet(item: $selectedReportDetail) { detail in
-                ReportTransactionListView(title: detail.title, transactions: detail.transactions)
+                ReportTransactionListView(detail: detail)
             }
         }
     }
@@ -325,7 +329,14 @@ struct ChartsView: View {
         }
         
         let sortedTransactions = item.transactions.sorted { $0.date > $1.date }
-        selectedReportDetail = ReportDetail(title: title, transactions: sortedTransactions)
+        selectedReportDetail = ReportDetail(
+            title: title,
+            estimatedAmount: item.amount,
+            mainCurrency: currencyService.mainCurrency,
+            originalCurrencySummary: item.originalCurrencySummary,
+            estimateFootnote: item.estimateFootnote,
+            transactions: sortedTransactions
+        )
     }
     
     func totalAmount(data: [ChartData]) -> Decimal { data.reduce(0) { $0 + $1.amount } }
@@ -584,25 +595,30 @@ private struct ReportTransactionListView: View {
     @Query private var advanceParticipants: [AdvanceParticipant]
     @Query private var advanceRepayments: [AdvanceRepayment]
 
-    let title: String
-    let transactions: [FinancialTransaction]
+    let detail: ChartsView.ReportDetail
 
     @State private var transactionToEdit: FinancialTransaction?
     @State private var deletionErrorMessage: String?
 
     var body: some View {
         let renderState = ReportTransactionListRenderState(
-            transactions: transactions,
+            transactions: detail.transactions,
             advanceParticipants: advanceParticipants,
             advanceRepayments: advanceRepayments
         )
 
         NavigationStack {
             Group {
-                if transactions.isEmpty {
+                if detail.transactions.isEmpty {
                     ContentUnavailableView("找不到交易", systemImage: "tray")
                 } else {
                     List {
+                        Section {
+                            ReportDetailSummaryCard(detail: detail)
+                                .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
+                                .listRowBackground(Color.clear)
+                        }
+
                         ForEach(renderState.groupedTransactions, id: \.title) { group in
                             Section(group.title) {
                                 ForEach(group.items) { tx in
@@ -635,7 +651,7 @@ private struct ReportTransactionListView: View {
                     .listStyle(.insetGrouped)
                 }
             }
-            .navigationTitle(title)
+            .navigationTitle(detail.title)
             .navigationBarTitleDisplayMode(.inline)
         }
         .sheet(item: $transactionToEdit) { tx in
@@ -684,6 +700,52 @@ private struct ReportTransactionListView: View {
             || compacted.contains("(代墊給我")
             || compacted.contains("(還款至")
             || compacted.contains("(還款給")
+    }
+}
+
+private struct ReportDetailSummaryCard: View {
+    let detail: ChartsView.ReportDetail
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("明細總額")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("約 \(detail.estimatedAmount.formatted(.currency(code: detail.mainCurrency)))")
+                        .font(.title3.weight(.bold))
+                }
+
+                Spacer()
+
+                Text("\(detail.transactions.count) 筆")
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .foregroundStyle(.blue)
+                    .background(Color.blue.opacity(0.10), in: Capsule())
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("原幣種合計")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(detail.originalCurrencySummary.isEmpty ? "沒有金額資料" : detail.originalCurrencySummary)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let estimateFootnote = detail.estimateFootnote {
+                Label(estimateFootnote, systemImage: estimateFootnote == "估算不完整" ? "exclamationmark.triangle.fill" : "arrow.triangle.2.circlepath")
+                    .font(.caption)
+                    .foregroundStyle(estimateFootnote == "估算不完整" ? .orange : .secondary)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 16))
     }
 }
 

--- a/AI 記帳/Views/Common/ProminentInlineTitle.swift
+++ b/AI 記帳/Views/Common/ProminentInlineTitle.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct ProminentInlineTitleModifier: ViewModifier {
     let title: String
@@ -22,5 +23,25 @@ struct ProminentInlineTitleModifier: ViewModifier {
 extension View {
     func prominentInlineTitle(_ title: String) -> some View {
         modifier(ProminentInlineTitleModifier(title: title))
+    }
+
+    func keyboardDoneToolbar(title: String = "完成") -> some View {
+        toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button(title) {
+                    UIApplication.shared.sendAction(
+                        #selector(UIResponder.resignFirstResponder),
+                        to: nil,
+                        from: nil,
+                        for: nil
+                    )
+                }
+            }
+        }
+    }
+
+    func interactiveKeyboardDismiss() -> some View {
+        scrollDismissesKeyboard(.interactively)
     }
 }

--- a/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
+++ b/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
@@ -259,6 +259,7 @@ struct AddRecurringRuleView: View {
                     TextField("備註（可選）", text: $note, axis: .vertical)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle(rule == nil ? "新增定期記帳" : "編輯定期記帳")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -268,6 +269,7 @@ struct AddRecurringRuleView: View {
                     Button("儲存") { save() }
                 }
             }
+            .keyboardDoneToolbar()
             .alert("無法儲存", isPresented: Binding(
                 get: { validationMessage != nil },
                 set: { if !$0 { validationMessage = nil } }

--- a/AI 記帳/Views/Settings/RemoteBackupView.swift
+++ b/AI 記帳/Views/Settings/RemoteBackupView.swift
@@ -129,6 +129,8 @@ struct RemoteBackupView: View {
                 }
             }
         }
+        .interactiveKeyboardDismiss()
+        .keyboardDoneToolbar()
         .navigationTitle("WebDAV 遠端備份")
         .onAppear(perform: loadSecrets)
         .alert("還原遠端備份？", isPresented: $showingRestoreConfirm) {

--- a/AI 記帳/Views/Shortcuts/AddShortcutView.swift
+++ b/AI 記帳/Views/Shortcuts/AddShortcutView.swift
@@ -110,6 +110,7 @@ struct AddShortcutView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("新增捷徑")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }

--- a/AI 記帳/Views/Tags/EditTagView.swift
+++ b/AI 記帳/Views/Tags/EditTagView.swift
@@ -14,6 +14,7 @@ struct EditTagView: View {
                     TextField("例如: 旅行、報銷", text: $name)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("編輯標籤")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -28,6 +29,7 @@ struct EditTagView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
+            .keyboardDoneToolbar()
             .onAppear {
                 name = tag.name
             }

--- a/AI 記帳/Views/Transactions/AddDebtView.swift
+++ b/AI 記帳/Views/Transactions/AddDebtView.swift
@@ -170,6 +170,7 @@ struct AddDebtView: View {
                     previewBlock
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("借貸管理")
             .alert("輸入錯誤", isPresented: $showingValidationAlert) {
                 Button("確定", role: .cancel) { }

--- a/AI 記帳/Views/Transactions/AddTransactionView.swift
+++ b/AI 記帳/Views/Transactions/AddTransactionView.swift
@@ -186,6 +186,7 @@ struct AddTransactionView: View {
                     TextField("備註", text: $note)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("記一筆")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/AI 記帳/Views/Transactions/AddTransferView.swift
+++ b/AI 記帳/Views/Transactions/AddTransferView.swift
@@ -121,6 +121,7 @@ struct AddTransferView: View {
                     TextField("備註", text: $note)
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("轉帳")
             .alert("輸入錯誤", isPresented: $showingValidationAlert) {
                 Button("確定", role: .cancel) { }

--- a/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
@@ -198,6 +198,7 @@ struct EditAdvanceTransferView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle(titleText)
             .alert("輸入錯誤", isPresented: $showingValidationAlert) {
                 Button("確定", role: .cancel) {}

--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -129,6 +129,7 @@ struct EditTransactionView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("編輯交易")
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -212,6 +212,7 @@ struct EditTransferView: View {
                     }
                 }
             }
+            .interactiveKeyboardDismiss()
             .navigationTitle("編輯轉帳")
             .alert("輸入錯誤", isPresented: $showingValidationAlert) {
                 Button("確定", role: .cancel) {}

--- a/AI 記帳/Views/Transactions/ScannedResultView.swift
+++ b/AI 記帳/Views/Transactions/ScannedResultView.swift
@@ -67,6 +67,7 @@ struct ScannedResultView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
         }
+        .interactiveKeyboardDismiss()
         .navigationTitle("確認資料")
         .toolbar {
             Button("儲存") {
@@ -74,6 +75,7 @@ struct ScannedResultView: View {
             }
             .disabled(selectedAccount == nil || amountString.isEmpty)
         }
+        .keyboardDoneToolbar()
         .onAppear {
             // 填充 AI 資料
             amountString = "\(info.amount)"

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/ParityComponents.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -37,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -55,6 +57,12 @@ object ParityTokens {
     val BottomBarHeight = 72.dp
     val FloatingButtonSize = 60.dp
     val FloatingContentBottomPadding = 112.dp
+}
+
+@Composable
+fun keyboardDoneActions(): KeyboardActions {
+    val focusManager = LocalFocusManager.current
+    return KeyboardActions(onDone = { focusManager.clearFocus() })
 }
 
 @Composable

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountEditorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -73,7 +74,8 @@ fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text("帳戶資料", style = MaterialTheme.typography.titleMedium)
@@ -83,7 +85,9 @@ fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
                 onValueChange = { name = it },
                 label = { Text("帳戶名稱") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             CurrencyPicker(selected = currency, onSelect = { currency = it })
             AccountTypePicker(type = type, onChange = { type = it })
             OutlinedTextField(
@@ -91,7 +95,9 @@ fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
                 onValueChange = { baseBalance = sanitizeAmount(it) },
                 label = { Text("初始餘額") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         Text("其他設定", style = MaterialTheme.typography.titleMedium)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddAdvanceCaseScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -97,7 +98,8 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                 end = AppSpacing.screenHorizontal,
                 bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
             )
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         ParitySectionHeader(
@@ -129,7 +131,9 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                 onValueChange = { title = it },
                 label = { Text("標題") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             if (requiresPayerAccount) {
                 AccountPicker(label = "付款帳戶", accounts = payerAccounts, selected = payerAccount) { acc ->
                     payerAccount = acc
@@ -213,7 +217,9 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                 onValueChange = { note = it },
                 label = { Text("備註") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         Button(
@@ -277,7 +283,9 @@ fun AddAdvanceCaseScreen(onDone: () -> Unit) {
                     onValueChange = { newDebtName = it },
                     label = { Text("人物名稱") },
                     modifier = Modifier.fillMaxWidth()
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             },
             confirmButton = {
                 TextButton(onClick = {
@@ -407,7 +415,9 @@ private fun AmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AddTransferScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -107,7 +108,8 @@ fun AddTransferScreen(onDone: () -> Unit) {
                 end = AppSpacing.screenHorizontal,
                 bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
             )
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         ParitySectionHeader(
@@ -240,7 +242,9 @@ fun AddTransferScreen(onDone: () -> Unit) {
                 onValueChange = { note = it },
                 label = { Text("備註") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         ParitySectionHeader(
@@ -369,7 +373,9 @@ private fun AmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
         CurrencyRateHint(
             currencyService = currencyService,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
@@ -323,7 +323,9 @@ fun AdvanceDetailScreen(caseId: String?) {
                     onValueChange = { note = it },
                     label = { Text("備註") },
                     modifier = Modifier.fillMaxWidth()
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
 
                 Button(
                     onClick = {
@@ -512,7 +514,9 @@ private fun AmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
     }
 }
@@ -532,7 +536,9 @@ private fun SettlementAmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("沖銷金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             Text(
                 caseCurrency,
                 style = MaterialTheme.typography.bodyMedium,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/BudgetsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/BudgetsScreen.kt
@@ -309,7 +309,9 @@ fun BudgetsScreen() {
                             onValueChange = { amount = sanitizeAmount(it) },
                             label = { Text("預算金額") },
                             modifier = Modifier.weight(1f)
-                        )
+                        ,
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                            keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                     }
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                         Column(modifier = Modifier.weight(1f)) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/CategoryEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/CategoryEditorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -65,7 +66,8 @@ fun CategoryEditorScreen(categoryId: String?, onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text("分類資料", style = MaterialTheme.typography.titleMedium)
@@ -75,13 +77,17 @@ fun CategoryEditorScreen(categoryId: String?, onDone: () -> Unit) {
                 onValueChange = { name = it },
                 label = { Text("分類名稱") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             OutlinedTextField(
                 value = icon,
                 onValueChange = { icon = it },
                 label = { Text("圖示（SF Symbol 名稱）") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 ColorDot(colorHex = colorHex)
                 OutlinedTextField(
@@ -89,7 +95,9 @@ fun CategoryEditorScreen(categoryId: String?, onDone: () -> Unit) {
                     onValueChange = { colorHex = it },
                     label = { Text("顏色 Hex") },
                     modifier = Modifier.weight(1f)
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             }
             Button(
                 onClick = {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DataHealthScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DataHealthScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -48,7 +49,8 @@ fun DataHealthScreen() {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Card(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -182,6 +183,7 @@ fun DebtEntryScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,
@@ -355,7 +357,9 @@ fun DebtEntryScreen(
                 onValueChange = { note = it },
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("備註") }
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         ParitySummaryCard(
@@ -484,7 +488,9 @@ private fun AmountCurrencyRow(
                     onValueChange = onAmountChange,
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text("金額") }
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             }
             CurrencyPicker(selected = currency, onSelect = onCurrencyChange, buttonStyle = CurrencyButtonStyle.Text)
         }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/OverviewScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -262,6 +263,7 @@ fun OverviewScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(scrollState)
+            .imePadding()
                 .padding(
                     start = AppSpacing.screenHorizontal,
                     end = AppSpacing.screenHorizontal,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReceiptScanScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -122,6 +123,7 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,
@@ -195,7 +197,9 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("備註（可選）") },
                 placeholder = { Text("例如：我和朋友 AA 制，只計我自己的餐費") }
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
 
             Button(
                 onClick = {
@@ -257,7 +261,9 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text("金額") },
                     shape = RoundedCornerShape(18.dp)
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 CurrencyPicker(selected = currencyCode, onSelect = { currencyCode = it }, buttonStyle = CurrencyButtonStyle.Text)
                 CurrencyRateHint(
                     currencyService = currencyService,
@@ -270,21 +276,27 @@ fun ReceiptScanScreen(onDone: () -> Unit) {
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text("日期（YYYY-MM-DD）") },
                     shape = RoundedCornerShape(18.dp)
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 OutlinedTextField(
                     value = timeInput,
                     onValueChange = { timeInput = it },
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text("時間（HH:mm，可選）") },
                     shape = RoundedCornerShape(18.dp)
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 OutlinedTextField(
                     value = noteInput,
                     onValueChange = { noteInput = it },
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text("商戶 / 備註") },
                     shape = RoundedCornerShape(18.dp)
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 EntityPicker(
                     label = "帳戶",
                     options = activeAccounts,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -96,6 +97,7 @@ fun RecurringTransactionsScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,
@@ -323,6 +325,7 @@ fun RecurringRuleEditorScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,
@@ -350,7 +353,9 @@ fun RecurringRuleEditorScreen(
                     label = { Text("名稱") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
                     CurrencyPicker(
                         selected = currencyCode,
@@ -363,7 +368,9 @@ fun RecurringRuleEditorScreen(
                         label = { Text("金額") },
                         modifier = Modifier.weight(1f),
                         singleLine = true
-                    )
+                    ,
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                        keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 }
                 AccountDropdown(
                     accounts = ownAccounts,
@@ -384,7 +391,9 @@ fun RecurringRuleEditorScreen(
                     onValueChange = { note = it },
                     label = { Text("備註") },
                     modifier = Modifier.fillMaxWidth()
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             }
         }
 
@@ -404,14 +413,18 @@ fun RecurringRuleEditorScreen(
                         label = { Text("間隔") },
                         modifier = Modifier.weight(0.35f),
                         singleLine = true
-                    )
+                    ,
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                        keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                     OutlinedTextField(
                         value = nextDueDate,
                         onValueChange = { nextDueDate = it },
                         label = { Text("下次日期 yyyy-MM-dd") },
                         modifier = Modifier.weight(0.65f),
                         singleLine = true
-                    )
+                    ,
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                        keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 }
                 TextButton(onClick = { isPaused = !isPaused }) {
                     Text(if (isPaused) "目前已暫停，點擊恢復" else "目前啟用中，點擊暫停")

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RemoteBackupScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -151,6 +152,7 @@ fun RemoteBackupScreen() {
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,
@@ -173,14 +175,18 @@ fun RemoteBackupScreen() {
                     label = { Text("WebDAV URL") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 OutlinedTextField(
                     value = username,
                     onValueChange = { username = it },
                     label = { Text("帳戶") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 OutlinedTextField(
                     value = password,
                     onValueChange = { password = it },
@@ -188,7 +194,9 @@ fun RemoteBackupScreen() {
                     modifier = Modifier.fillMaxWidth(),
                     visualTransformation = PasswordVisualTransformation(),
                     singleLine = true
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 OutlinedTextField(
                     value = passphrase,
                     onValueChange = { passphrase = it },
@@ -196,7 +204,9 @@ fun RemoteBackupScreen() {
                     modifier = Modifier.fillMaxWidth(),
                     visualTransformation = PasswordVisualTransformation(),
                     singleLine = true
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(AppSpacing.inline)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -111,6 +111,10 @@ private data class CurrencyReportAggregate(
 
 private data class ReportDetail(
     val title: String,
+    val estimatedAmount: BigDecimal,
+    val baseCurrency: String,
+    val originalCurrencySummary: String,
+    val estimateFootnote: String?,
     val transactions: List<TransactionWithDetails>
 )
 
@@ -282,7 +286,8 @@ fun ReportsScreen(
                             reportDetail = presentTransactions(
                                 flowMode = flowMode,
                                 item = item,
-                                tagName = selectedTag
+                                tagName = selectedTag,
+                                baseCurrency = baseCurrency
                             )
                         }
                     }
@@ -304,7 +309,7 @@ fun ReportsScreen(
                             if (chartMode == ReportChartMode.Tag) {
                                 selectedTag = item.name
                             } else {
-                                reportDetail = presentTransactions(flowMode, item, null)
+                                reportDetail = presentTransactions(flowMode, item, null, baseCurrency)
                             }
                         }
                     }
@@ -628,6 +633,7 @@ private fun ReportDetailSheet(
             title = detail.title,
             detail = "${detail.transactions.size} 筆"
         )
+        ReportDetailSummaryCard(detail = detail)
         LazyColumn(
             contentPadding = PaddingValues(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
@@ -693,6 +699,83 @@ private fun ReportDetailSheet(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReportDetailSummaryCard(detail: ReportDetail) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = androidx.compose.foundation.BorderStroke(
+            0.6.dp,
+            MaterialTheme.colorScheme.outline.copy(alpha = 0.24f)
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(AppSpacing.card),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.inline)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Text(
+                        "明細總額",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        "約 ${detail.estimatedAmount.asCurrencyText(detail.baseCurrency)}",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+                ) {
+                    Text(
+                        "${detail.transactions.size} 筆",
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    "原幣種合計",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    detail.originalCurrencySummary.ifBlank { "沒有金額資料" },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            detail.estimateFootnote?.let { footnote ->
+                Text(
+                    footnote,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (footnote == "估算不完整") {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    fontWeight = FontWeight.Medium
+                )
             }
         }
     }
@@ -839,7 +922,8 @@ private fun totalAmount(data: List<ReportSlice>): BigDecimal {
 private fun presentTransactions(
     flowMode: ReportFlowMode,
     item: ReportSlice,
-    tagName: String?
+    tagName: String?,
+    baseCurrency: String
 ): ReportDetail {
     val title = if (tagName != null) {
         "${flowMode.label}・$tagName・${item.name}"
@@ -847,7 +931,14 @@ private fun presentTransactions(
         "${flowMode.label}・${item.name}"
     }
     val sorted = item.transactions.sortedByDescending { it.transaction.date }
-    return ReportDetail(title = title, transactions = sorted)
+    return ReportDetail(
+        title = title,
+        estimatedAmount = item.amount,
+        baseCurrency = baseCurrency,
+        originalCurrencySummary = item.originalCurrencySummary,
+        estimateFootnote = item.estimateFootnote,
+        transactions = sorted
+    )
 }
 
 private fun parseColor(hex: String): Color {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -118,6 +119,7 @@ fun SettingsScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,
@@ -187,7 +189,9 @@ fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(18.dp),
                     visualTransformation = PasswordVisualTransformation()
-                )
+                ,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                 ParitySettingRow(
                     title = "固定總覽頁頂部區塊",
                     subtitle = "固定標題與日期篩選；關閉後會跟內容一起捲動",

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ShortcutEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ShortcutEditorScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -97,7 +98,8 @@ fun ShortcutEditorScreen(shortcutId: String?, onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text("捷徑外觀", style = MaterialTheme.typography.titleMedium)
@@ -107,13 +109,17 @@ fun ShortcutEditorScreen(shortcutId: String?, onDone: () -> Unit) {
                 onValueChange = { name = it },
                 label = { Text("捷徑名稱") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             OutlinedTextField(
                 value = icon,
                 onValueChange = { icon = it },
                 label = { Text("圖示（Emoji 或簡短文字）") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         Text("預設交易內容", style = MaterialTheme.typography.titleMedium)
@@ -130,7 +136,9 @@ fun ShortcutEditorScreen(shortcutId: String?, onDone: () -> Unit) {
                 onValueChange = { note = it },
                 label = { Text("備註（選填）") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
             AccountPicker(
                 accounts = availableAccounts,
                 selected = selectedAccount,
@@ -218,7 +226,9 @@ private fun AmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TagEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TagEditorScreen.kt
@@ -3,6 +3,7 @@ package org.duckdns.lhfser.aiaccounting.ui.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -48,7 +49,8 @@ fun TagEditorScreen(tagId: String?, onDone: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical)
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text("標籤資料", style = MaterialTheme.typography.titleMedium)
@@ -58,7 +60,9 @@ fun TagEditorScreen(tagId: String?, onDone: () -> Unit) {
                 onValueChange = { name = it },
                 label = { Text("標籤名稱") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
         Button(
             onClick = {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -179,7 +180,8 @@ fun TransactionEditorScreen(
                 end = AppSpacing.screenHorizontal,
                 bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
             )
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         ParitySectionHeader(
@@ -324,7 +326,9 @@ fun TransactionEditorScreen(
                 onValueChange = { note = it },
                 label = { Text("備註") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         Button(
@@ -413,20 +417,26 @@ fun TransactionEditorScreen(
                         onValueChange = { newCategoryName = it },
                         label = { Text("分類名稱") },
                         modifier = Modifier.fillMaxWidth()
-                    )
+                    ,
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                        keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                     OutlinedTextField(
                         value = newCategoryIcon,
                         onValueChange = { newCategoryIcon = it },
                         label = { Text("圖示（SF Symbol 名稱）") },
                         modifier = Modifier.fillMaxWidth()
-                    )
+                    ,
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                        keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                     Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
                         OutlinedTextField(
                             value = newCategoryColorHex,
                             onValueChange = { newCategoryColorHex = it },
                             label = { Text("顏色 Hex") },
                             modifier = Modifier.weight(1f)
-                        )
+                        ,
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                            keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
                         TextButton(onClick = {
                             newCategoryColorHex = autoPickDistinctColor(categories.map { it.colorHex })
                         }) {
@@ -516,7 +526,9 @@ private fun AmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
         CurrencyRateHint(
             currencyService = currencyService,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -171,7 +172,8 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                 end = AppSpacing.screenHorizontal,
                 bottom = AppSpacing.screenVertical + ParityTokens.FloatingContentBottomPadding
             )
-            .verticalScroll(scrollState),
+            .verticalScroll(scrollState)
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         SectionCard {
@@ -318,7 +320,9 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                 onValueChange = { note = it },
                 label = { Text("備註") },
                 modifier = Modifier.fillMaxWidth()
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
 
         Button(
@@ -462,7 +466,9 @@ private fun AmountRow(
                 onValueChange = onAmountChange,
                 label = { Text("金額") },
                 modifier = Modifier.weight(1f)
-            )
+            ,
+                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
+                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
         }
         CurrencyRateHint(
             currencyService = currencyService,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/UserGuideScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/UserGuideScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -41,6 +42,7 @@ fun UserGuideScreen(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .imePadding()
             .padding(
                 start = AppSpacing.screenHorizontal,
                 end = AppSpacing.screenHorizontal,


### PR DESCRIPTION
## Summary
- Add report drill-down summary cards on iOS and Android with estimated main-currency amount, original-currency totals, transaction count, and estimate status.
- Add reusable iOS keyboard Done toolbar support and interactive keyboard dismissal to major form flows.
- Add Android Compose Done IME handling for `OutlinedTextField` form inputs and `imePadding()` for scrollable form screens.

## Product Context
- Created with `to-prd` / `to-issues` from the report detail + keyboard dismissal polish request.
- References #110
- Closes #111
- Closes #112

## Guidelines Used
- Apple HIG form/input guidance: keep text entry clear and provide suitable keyboard/input behaviours.
- Android Compose IME actions: use Done actions to finish text input and clear focus.

## Notes
- No SwiftData / Room schema changes.
- No JSON backup schema changes.
- Existing local private diffs in `AI 記帳.xcscheme` and `Localizable.xcstrings` were not staged or committed.

## Tests
- `xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO`
- `./gradlew testDebugUnitTest assembleDebug`
