### PR TITLE
Document ledger semantics decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,78 @@
+# AI Accounting Domain Context
+
+Status: Active
+Last updated: 2026-06-05
+
+This file is the shared domain glossary for the iOS and Android apps. It explains the accounting language that agents should use when changing code, docs, tests, or GitHub issues.
+
+The canonical data contract lives in `docs/specs/data-model.md`. Android/iOS UI parity lives in `docs/specs/android-ios-parity.md`. Deterministic cross-platform behaviour checks live in `docs/specs/parity-test-vectors.md`.
+
+## Product Boundary
+
+AI Accounting is a personal ledger app. It tracks the user's own accounts, debt accounts, transfers, advances, reports, budgets, backups, and data health checks.
+
+The app is not a double-entry accounting system. It still needs strict semantic rules because the same real-world event can be represented as an income/expense transaction, a transfer-only ledger event, or an advance/debt settlement event.
+
+## Core Entities
+
+- **Own account**: A cash, bank, or credit-card account that represents the user's assets or liabilities. Income and expense entry points must only target own accounts unless a flow explicitly says otherwise.
+- **Debt account**: An account of type `Debt`. It represents money owed between the user and another person. Debt accounts are not own accounts and should not appear in normal income account pickers.
+- **Financial transaction**: A persisted ledger record. It is one of `Income`, `Expense`, or `Transfer`.
+- **Transfer group**: One or more transfer legs sharing `transferGroupID`. Transfer groups support ordinary transfers, split transfers, merged transfers, repayments, debt forgiveness markers, and some legacy repair flows.
+- **Category**: A classification for income and/or expense reporting. `CategoryKind` controls whether it is valid for expense, income, or both.
+- **Tag**: A user-defined label that can cross-cut categories.
+- **Shortcut**: A quick-entry template. It may create a transaction faster, but must obey the same account/category validity rules as the full editor.
+
+## Ledger Inclusion Rules
+
+- **Income** counts toward income reports and budgets only when the flow is true income into an own account.
+- **Expense** counts toward expense reports and budgets when the flow represents consumption or a cost incurred by the user.
+- **Transfer** does not count toward income or expense reports. It moves value between accounts or records settlement semantics.
+- **Asset adjustment** is represented as transfer-like bookkeeping and must not affect income/expense charts.
+- **Debt forgiveness** and **mutual debt offset** are not regular income/expense. They settle debt semantics without changing own-account cash flow.
+
+## Advances
+
+- **Advance case**: A case-based record of someone paying for someone else. The ledger page shows initial advance creation as one summary row per case, not one row per underlying leg.
+- **Advance participant**: A person involved in an advance case. The participant stores owed amount, repaid amount, and optional debt-account linkage.
+- **I advanced others (`我代墊他人`)**: The user paid from an own account. The user's own share is an expense. Other people owe the user for their shares.
+- **Others advanced me (`他人代墊我`)**: Another person paid for the user. The user's own account does not move at creation time. The cost is still the user's expense on the advance date, recorded against the other person's debt account.
+- **Advance repayment**: A settlement record for a participant. If real money moves, it may link to a transfer group. If it is a ledger-only offset, it can exist without a received account or transfer group.
+- **Cross-currency advance repayment**: The amount actually received or paid can use a different currency from the advance case. The repayment stores the actual currency amount and a normalized amount in the case currency for remaining-balance calculations.
+- **Mutual debt offset (`債務抵銷`)**: Ledger-only settlement between opposing advance balances for the same person and currency. It is not repayment by cash and not debt forgiveness.
+
+## Debt Management
+
+- **Borrow (`借入`)**: The user receives value and owes another person.
+- **Repay (`還款`)**: The user pays down an amount owed, or records collection from someone who owes the user, depending on direction.
+- **Debt forgiveness (`免除債務`)**: A debt amount is reduced without cash movement. It is transfer/settlement semantics, not ordinary income.
+- **Debt direction**: Positive settlement summaries mean the user is waiting to receive money. Negative summaries mean the user is waiting to pay money.
+
+## Reports And Estimates
+
+- **Main currency**: The user's primary display currency.
+- **Original currency total**: Totals grouped by the transaction's original currency before conversion.
+- **Estimated main-currency total**: A report display amount converted into the main currency using the current rate system. It is a display estimate, not a stored historical FX snapshot.
+- **Estimate status**: Report UI should make clear whether conversion used live, cached, partial, or unavailable rates.
+- **Report drill-down**: Category/tag detail sheets should show both estimated main-currency totals and original-currency breakdowns so users can audit the estimate.
+
+## Backup Roundtrip
+
+- **Backup roundtrip** means export -> import -> export should preserve the meaning of accounts, transactions, categories, tags, budgets, advance cases, participants, repayments, and semantic markers.
+- Backward-compatible import defaults are documented in `docs/specs/data-model.md`.
+- Changes that alter persisted meaning must update data-model docs and parity vectors in the same PR.
+
+## Architecture Expectations
+
+- iOS remains the product source of truth for screen structure and flow semantics.
+- Android should match iOS semantics and user-facing flow unless `docs/specs/android-ios-parity.md` explicitly allows a difference.
+- Domain logic should move toward small testable services/modules rather than screen-level recalculation.
+- New agent work should prefer documented vocabulary from this file over ad-hoc synonyms.
+
+## Architecture Decision Records
+
+Current ADRs:
+
+- `docs/adr/0001-ledger-classification.md`
+- `docs/adr/0002-advance-and-debt-settlement.md`
+- `docs/adr/0003-report-currency-estimates.md`

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -48,6 +48,8 @@ This document describes the current file layout for `AI 記帳`.
 ## Repository Docs
 
 - Root: `README*.md`, `CONTRIBUTING*.md`, `SECURITY*.md`, `LICENSE`.
+- `CONTEXT.md`: shared domain glossary and accounting semantics entry point.
+- `docs/adr/`: accepted architecture decision records for ledger and report semantics.
 - `docs/CI_CHECKLIST.md`: CI/release quality gate checklist.
 - `docs/specs/data-model.md`: cross-platform data contract.
 - `docs/specs/parity-test-vectors.md`: deterministic parity vectors.

--- a/docs/adr/0001-ledger-classification.md
+++ b/docs/adr/0001-ledger-classification.md
@@ -1,0 +1,36 @@
+# ADR 0001: Ledger Classification And Report Inclusion
+
+Status: Accepted
+Date: 2026-06-05
+
+## Context
+
+The app stores financial records as `Income`, `Expense`, or `Transfer`. Several flows look like income or expense at the UI level but must not be counted in reports, including transfers, asset adjustments, debt forgiveness, and mutual debt offsets.
+
+Without a written rule, future changes can accidentally inflate income, expense, or asset totals.
+
+## Decision
+
+Use the transaction type and flow marker semantics to decide report inclusion:
+
+- `Income` counts in income reports only when it represents real income into an own account.
+- `Expense` counts in expense reports when it represents a cost incurred by the user.
+- `Transfer` never counts in income/expense reports.
+- Asset-adjustment legacy records are transfer-like and excluded from income/expense reports.
+- Debt forgiveness is a settlement event and excluded from income/expense reports.
+- Mutual debt offset is a ledger-only settlement event and excluded from income/expense reports.
+
+Normal income entry points must only allow own accounts. Debt accounts are handled through debt or advance flows.
+
+## Consequences
+
+- Report code must not infer income/expense from note text alone.
+- Transfer groups can carry settlement semantics but must remain excluded from income/expense totals.
+- Data health checks should flag old data where normal income was recorded into a debt account.
+- Shortcut creation and editing must obey the same own-account/debt-account boundary as full entry forms.
+
+## Related Specs
+
+- `CONTEXT.md`
+- `docs/specs/data-model.md`
+- `docs/specs/parity-test-vectors.md`

--- a/docs/adr/0002-advance-and-debt-settlement.md
+++ b/docs/adr/0002-advance-and-debt-settlement.md
@@ -1,0 +1,67 @@
+# ADR 0002: Advance And Debt Settlement Semantics
+
+Status: Accepted
+Date: 2026-06-05
+
+## Context
+
+Advance and debt flows are high-risk because they can describe real spending, cash movement, or ledger-only settlement. The most ambiguous cases are `他人代墊我`, `免除債務`, and `債務抵銷`.
+
+## Decision
+
+### 我代墊他人
+
+When the user pays for others:
+
+- The paying account is an own account.
+- The user's own share is an expense on the advance date.
+- Other participants' shares become amounts they owe the user.
+- Initial advance creation appears as one case summary row in the ledger, not one row per participant leg.
+
+### 他人代墊我
+
+When someone else pays for the user:
+
+- The user's own cash/bank/credit-card account does not move at creation time.
+- The app must not create an incoming transfer into an own account.
+- The cost is still the user's expense on the advance date.
+- The expense is recorded through the other person's debt account so reports and budgets reflect the consumption date.
+- Repayment later is a transfer/settlement event and must not double-count expense.
+
+### Advance Repayment
+
+A repayment can have an actual payment currency different from the advance case currency. Remaining balance calculations use `normalizedAmount` in the case currency. The actual amount/currency remain available for audit and display.
+
+### 免除債務
+
+Debt forgiveness reduces what one side owes without cash movement:
+
+- It is not ordinary income.
+- It is not ordinary expense.
+- It is represented as settlement/transfer semantics using existing persistence.
+- Ledger and account-detail UI should label it as `免除債務` instead of generic transfer when detected.
+
+### 債務抵銷
+
+Mutual debt offset is used when the same person and same currency has opposing outstanding advance balances:
+
+- It does not touch own accounts.
+- It does not create a regular `FinancialTransaction` for cash movement.
+- It records auditable settlement through linked offset repayment markers.
+- It is not repayment, not income, not expense, and not debt forgiveness.
+- v1 does not offset across currencies.
+
+## Consequences
+
+- `他人代墊我` creation forms should not require an own account.
+- Repayment forms should clearly distinguish actual payment currency from normalized settlement amount.
+- Settlement center summaries should use directional language:待收 when others owe the user, 待還 when the user owes others.
+- Data health checks should detect legacy `他人代墊我` data that increased an own account.
+- Cross-platform tests should cover both ledger effects and report inclusion/exclusion.
+
+## Related Specs
+
+- `CONTEXT.md`
+- `docs/specs/data-model.md`
+- `docs/specs/parity-test-vectors.md`
+- `docs/specs/android-ios-parity.md`

--- a/docs/adr/0003-report-currency-estimates.md
+++ b/docs/adr/0003-report-currency-estimates.md
@@ -1,0 +1,39 @@
+# ADR 0003: Report Currency Estimates And Drill-Down Totals
+
+Status: Accepted
+Date: 2026-06-05
+
+## Context
+
+The app supports accounts and transactions in multiple currencies. Users need reports in their main currency, but they also need to see the original currencies that produced the estimate. Exchange rates can be live, cached, partially available, or unavailable.
+
+The app currently does not store historical FX snapshots for each transaction.
+
+## Decision
+
+Report totals should expose two layers:
+
+- Original-currency totals grouped by transaction currency.
+- Estimated main-currency totals converted using the current currency service and its fallback rules.
+
+Report drill-down sheets should show the same information as the top-level report:
+
+- estimated total in main currency;
+- original currency breakdown;
+- transaction count;
+- estimate status when conversion is cached, partial, or unavailable.
+
+Cross-currency advance repayments should preserve both actual payment currency and normalized case-currency amount. Reports should use transaction semantics for income/expense inclusion and should not treat repayment transfer movement as new spending.
+
+## Consequences
+
+- Main-currency report totals are estimates unless the transaction currency already equals the main currency.
+- UI should avoid presenting converted totals as exact historical accounting facts.
+- Tests should use fixed exchange rates and exact decimal arithmetic.
+- Future work that stores historical FX snapshots must update this ADR, the data model contract, backup compatibility, and parity vectors.
+
+## Related Specs
+
+- `CONTEXT.md`
+- `docs/specs/data-model.md`
+- `docs/specs/parity-test-vectors.md`


### PR DESCRIPTION
## Summary

- Add `CONTEXT.md` as the shared domain glossary for iOS and Android ledger semantics.
- Add ADRs for ledger classification, advance/debt settlement, and report currency estimates.
- Update project structure docs so future agents can find the glossary and ADRs.

Closes #115

## Validation

- `git diff --cached --check`
- Doc reference smoke check for `CONTEXT.md`, ADRs, data model spec, parity spec, and parity vectors

## Notes

- Documentation-only change.
- No app code, data model, database schema, or JSON backup schema changes.
