### PR TITLE
Fix cross-currency advance settlement balances

### DIFF
--- a/AI 記帳/Services/DebtSettlementBalanceService.swift
+++ b/AI 記帳/Services/DebtSettlementBalanceService.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftData
+
+struct DebtSettlementCurrencyBalance: Identifiable, Equatable {
+    let currencyCode: String
+    let amount: Decimal
+
+    var id: String { currencyCode }
+}
+
+@MainActor
+enum DebtSettlementBalanceService {
+    private static let tolerance = Decimal(string: "0.0001") ?? Decimal(0.0001)
+
+    static func balances(
+        for account: Account,
+        transactions: [FinancialTransaction],
+        advanceCases: [AdvanceCase],
+        modelContext: ModelContext
+    ) -> [DebtSettlementCurrencyBalance] {
+        if account.type == .debt {
+            return semanticDebtBalances(
+                for: account,
+                transactions: transactions,
+                advanceCases: advanceCases,
+                modelContext: modelContext
+            )
+        }
+
+        return rawBalances(for: account, transactions: transactions)
+    }
+
+    static func rawBalances(
+        for account: Account,
+        transactions: [FinancialTransaction]
+    ) -> [DebtSettlementCurrencyBalance] {
+        var totals: [String: Decimal] = [:]
+        if account.baseBalance != 0 {
+            totals[account.currency, default: 0] += account.baseBalance
+        }
+        for transaction in transactions where transaction.account?.id == account.id {
+            totals[transaction.currencyCode, default: 0] += transaction.amount
+        }
+        return sortedBalances(totals)
+    }
+
+    static func semanticDebtBalances(
+        for account: Account,
+        transactions: [FinancialTransaction],
+        advanceCases: [AdvanceCase],
+        modelContext: ModelContext
+    ) -> [DebtSettlementCurrencyBalance] {
+        var totals: [String: Decimal] = [:]
+        if account.baseBalance != 0 {
+            totals[account.currency, default: 0] += account.baseBalance
+        }
+
+        let advanceGroupIDs = Set(
+            advanceCases.flatMap { advanceCase in
+                advanceCase.participants.compactMap(\.initialTransferGroupID)
+                    + advanceCase.repayments.compactMap(\.linkedTransferGroupID)
+            }
+        )
+
+        for transaction in transactions where transaction.account?.id == account.id {
+            if let groupID = transaction.transferGroupID, advanceGroupIDs.contains(groupID) {
+                continue
+            }
+            totals[transaction.currencyCode, default: 0] += transaction.amount
+        }
+
+        for advanceCase in advanceCases {
+            for participant in advanceCase.participants where participant.debtAccount?.id == account.id {
+                let remaining = participant.remainingAmount
+                guard remaining > tolerance else { continue }
+                let signedRemaining = advanceCase.payerAccount == nil ? -remaining : remaining
+                totals[advanceCase.currencyCode, default: 0] += signedRemaining
+            }
+        }
+
+        return sortedBalances(totals)
+    }
+
+    private static func sortedBalances(_ totals: [String: Decimal]) -> [DebtSettlementCurrencyBalance] {
+        totals
+            .filter { abs($0.value) > tolerance }
+            .sorted { $0.key < $1.key }
+            .map { DebtSettlementCurrencyBalance(currencyCode: $0.key, amount: $0.value) }
+    }
+}

--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct AccountDetailView: View {
     let account: Account
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
+    @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
     @Query private var advanceParticipants: [AdvanceParticipant]
     @Query private var advanceRepayments: [AdvanceRepayment]
     @Environment(\.modelContext) private var modelContext
@@ -21,8 +22,10 @@ struct AccountDetailView: View {
         let renderState = AccountDetailRenderState(
             account: account,
             allTransactions: allTransactions,
+            advanceCases: advanceCases,
             advanceParticipants: advanceParticipants,
-            advanceRepayments: advanceRepayments
+            advanceRepayments: advanceRepayments,
+            modelContext: modelContext
         )
 
         List {
@@ -165,8 +168,10 @@ private struct AccountDetailRenderState {
     init(
         account: Account,
         allTransactions: [FinancialTransaction],
+        advanceCases: [AdvanceCase],
         advanceParticipants: [AdvanceParticipant],
-        advanceRepayments: [AdvanceRepayment]
+        advanceRepayments: [AdvanceRepayment],
+        modelContext: ModelContext
     ) {
         let accountTransactions = allTransactions.filter { $0.account?.id == account.id }
         var advanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
@@ -177,27 +182,24 @@ private struct AccountDetailRenderState {
         self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: allTransactions)
         self.currencyBalances = Self.currencyBalances(
             account: account,
-            accountTransactions: accountTransactions
+            allTransactions: allTransactions,
+            advanceCases: advanceCases,
+            modelContext: modelContext
         )
     }
 
     private static func currencyBalances(
         account: Account,
-        accountTransactions: [FinancialTransaction]
+        allTransactions: [FinancialTransaction],
+        advanceCases: [AdvanceCase],
+        modelContext: ModelContext
     ) -> [AccountDetailView.CurrencyBalance] {
-        var balances: [String: Decimal] = [:]
-
-        if account.baseBalance != 0 {
-            balances[account.currency, default: 0] += account.baseBalance
-        }
-
-        for tx in accountTransactions {
-            balances[tx.currencyCode, default: 0] += tx.amount
-        }
-
-        return balances
-            .filter { $0.value != 0 }
-            .map { AccountDetailView.CurrencyBalance(currency: $0.key, amount: $0.value) }
-            .sorted { $0.currency < $1.currency }
+        DebtSettlementBalanceService.balances(
+            for: account,
+            transactions: allTransactions,
+            advanceCases: advanceCases,
+            modelContext: modelContext
+        )
+        .map { AccountDetailView.CurrencyBalance(currency: $0.currencyCode, amount: $0.amount) }
     }
 }

--- a/AI 記帳/Views/Accounts/AccountsView.swift
+++ b/AI 記帳/Views/Accounts/AccountsView.swift
@@ -4,6 +4,8 @@ import SwiftData
 struct AccountsView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
+    @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
+    @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
     
     @StateObject private var currencyService = CurrencyService.shared
     @AppStorage("mainCurrency") private var mainCurrency: String = "HKD"
@@ -163,7 +165,7 @@ struct AccountsView: View {
     }
 
     private func accountRow(_ account: Account) -> some View {
-        AccountRowLink(account: account, showArchived: showArchived) {
+        AccountRowLink(account: account, balances: balances(for: account), showArchived: showArchived) {
             toggleArchive(account)
         } deleteAction: {
             deleteAccount(account)
@@ -337,9 +339,8 @@ struct AccountsView: View {
         let activeAccounts = allAccounts.filter { !$0.isArchived }
         
         for account in activeAccounts {
-            total += currencyService.convert(amount: account.baseBalance, from: account.currency)
-            for tx in account.transactions {
-                total += currencyService.convert(amount: tx.amount, from: tx.currencyCode)
+            for balance in balances(for: account) {
+                total += currencyService.convert(amount: balance.amount, from: balance.currencyCode)
             }
         }
         return total.formatted(.currency(code: mainCurrency))
@@ -351,10 +352,20 @@ struct AccountsView: View {
         let activeAccounts = allAccounts.filter { !$0.isArchived }
         
         for account in activeAccounts {
-            if account.baseBalance != 0 { totals[account.currency, default: 0] += account.baseBalance }
-            for tx in account.transactions { totals[tx.currencyCode, default: 0] += tx.amount }
+            for balance in balances(for: account) {
+                totals[balance.currencyCode, default: 0] += balance.amount
+            }
         }
         return totals.map { CurrencyTotal(currency: $0.key, amount: $0.value) }.sorted { $0.currency < $1.currency }
+    }
+
+    private func balances(for account: Account) -> [DebtSettlementCurrencyBalance] {
+        DebtSettlementBalanceService.balances(
+            for: account,
+            transactions: allTransactions,
+            advanceCases: advanceCases,
+            modelContext: modelContext
+        )
     }
 }
 
@@ -362,13 +373,14 @@ struct AccountsView: View {
 
 struct AccountRowLink: View {
     let account: Account
+    let balances: [DebtSettlementCurrencyBalance]
     let showArchived: Bool
     let archiveAction: () -> Void
     let deleteAction: () -> Void
     let editAction: () -> Void
     
     var body: some View {
-        NavigationLink(destination: AccountDetailView(account: account)) { AccountRow(account: account) }
+        NavigationLink(destination: AccountDetailView(account: account)) { AccountRow(account: account, balances: balances) }
             .swipeActions(edge: .leading) {
                 // 🔥 左滑：歸檔/還原
                 Button(action: archiveAction) {
@@ -385,6 +397,8 @@ struct AccountRowLink: View {
 
 struct AccountRow: View {
     let account: Account
+    let balances: [DebtSettlementCurrencyBalance]
+
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
@@ -397,25 +411,17 @@ struct AccountRow: View {
             }
             Spacer()
             VStack(alignment: .trailing) {
-                let balances = calculateBalances(account: account)
                 if balances.isEmpty { Text("0.00").foregroundStyle(.secondary) }
                 else if balances.count == 1, let first = balances.first {
-                    Text(first.value.formatted(.currency(code: first.key))).bold().foregroundStyle(first.value >= 0 ? Color.primary : Color.red)
+                    Text(first.amount.formatted(.currency(code: first.currencyCode))).bold().foregroundStyle(first.amount >= 0 ? Color.primary : Color.red)
                 } else {
-                    ForEach(balances.prefix(2), id: \.key) { curr, amount in
-                        Text(amount.formatted(.currency(code: curr))).font(.subheadline).foregroundStyle(amount >= 0 ? Color.primary : Color.red)
+                    ForEach(balances.prefix(2)) { balance in
+                        Text(balance.amount.formatted(.currency(code: balance.currencyCode))).font(.subheadline).foregroundStyle(balance.amount >= 0 ? Color.primary : Color.red)
                     }
                     if balances.count > 2 { Text("...").font(.caption) }
                 }
             }
         }
         .opacity(account.isArchived ? 0.6 : 1.0) // 歸檔變淡
-    }
-    
-    func calculateBalances(account: Account) -> [(key: String, value: Decimal)] {
-        var dict: [String: Decimal] = [:]
-        if account.baseBalance != 0 { dict[account.currency] = account.baseBalance }
-        for tx in account.transactions { dict[tx.currencyCode, default: 0] += tx.amount }
-        return dict.filter { $0.value != 0 }.sorted { $0.key < $1.key }
     }
 }

--- a/AI 記帳/Views/Settlements/SettlementCenterView.swift
+++ b/AI 記帳/Views/Settlements/SettlementCenterView.swift
@@ -554,17 +554,13 @@ struct SettlementCenterView: View {
     }
 
     private func balances(for account: Account) -> [SettlementCurrencyBalance] {
-        var totals: [String: Decimal] = [:]
-        if account.baseBalance != 0 {
-            totals[account.currency, default: 0] += account.baseBalance
-        }
-        for transaction in transactions where transaction.account?.id == account.id {
-            totals[transaction.currencyCode, default: 0] += transaction.amount
-        }
-        return totals
-            .filter { $0.value != 0 }
-            .sorted { $0.key < $1.key }
-            .map { SettlementCurrencyBalance(currencyCode: $0.key, amount: $0.value) }
+        DebtSettlementBalanceService.balances(
+            for: account,
+            transactions: transactions,
+            advanceCases: advanceCases,
+            modelContext: modelContext
+        )
+        .map { SettlementCurrencyBalance(currencyCode: $0.currencyCode, amount: $0.amount) }
     }
 
     private func latestActivityDate(for account: Account) -> Date? {

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -440,6 +440,69 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(Decimal(100), exportedRepayment.normalizedAmount)
     }
 
+    func testCrossCurrencyAdvanceRepayment_semanticDebtBalanceUsesCaseCurrencyRemainingOnly() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let payerAccount = Account(name: "JPY Wallet", currency: "JPY", type: .cash, baseBalance: 0)
+        let receiveAccount = Account(name: "HKD Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        modelContext.insert(payerAccount)
+        modelContext.insert(receiveAccount)
+        modelContext.insert(debtAccount)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "日本旅行代墊",
+            date: date,
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: payerAccount,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 1000)],
+            isBorrowedByMe: false,
+            modelContext: modelContext
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+
+        _ = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 50,
+            currencyCode: "HKD",
+            date: date.addingTimeInterval(3600),
+            note: "朋友用港幣還款",
+            receiveAccount: receiveAccount,
+            category: nil,
+            tags: [],
+            currencyService: CurrencyService.shared,
+            normalizedAmountOverride: 900,
+            modelContext: modelContext
+        )
+
+        XCTAssertEqual(Decimal(100), participant.remainingAmount)
+
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let rawDebtBalances = DebtSettlementBalanceService.rawBalances(
+            for: debtAccount,
+            transactions: transactions
+        )
+        XCTAssertEqual(Decimal(1000), rawDebtBalances.first(where: { $0.currencyCode == "JPY" })?.amount)
+        XCTAssertEqual(Decimal(-50), rawDebtBalances.first(where: { $0.currencyCode == "HKD" })?.amount)
+
+        let semanticBalances = DebtSettlementBalanceService.balances(
+            for: debtAccount,
+            transactions: transactions,
+            advanceCases: [advanceCase],
+            modelContext: modelContext
+        )
+        XCTAssertEqual(1, semanticBalances.count)
+        XCTAssertEqual("JPY", semanticBalances.first?.currencyCode)
+        XCTAssertEqual(Decimal(100), semanticBalances.first?.amount)
+    }
+
     func testLegacyBorrowedAdvanceRepair_removesInflatedIncomingLegAndKeepsExpense() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/settlement/DebtSettlementBalanceCalculator.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/settlement/DebtSettlementBalanceCalculator.kt
@@ -1,0 +1,97 @@
+package org.duckdns.lhfser.aiaccounting.data.settlement
+
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import java.math.BigDecimal
+
+private val ZERO = BigDecimal.ZERO
+
+data class DebtSettlementCurrencyBalance(
+    val currencyCode: String,
+    val amount: BigDecimal
+)
+
+object DebtSettlementBalanceCalculator {
+    fun balancesFor(
+        account: AccountEntity,
+        transactions: List<TransactionWithDetails>,
+        advanceCases: List<AdvanceCaseWithDetails>
+    ): List<DebtSettlementCurrencyBalance> {
+        return if (account.type == AccountType.Debt) {
+            semanticDebtBalancesFor(account, transactions, advanceCases)
+        } else {
+            rawBalancesFor(account, transactions)
+        }
+    }
+
+    fun rawBalancesFor(
+        account: AccountEntity,
+        transactions: List<TransactionWithDetails>
+    ): List<DebtSettlementCurrencyBalance> {
+        val totals = linkedMapOf<String, BigDecimal>()
+        if (account.baseBalance != ZERO) {
+            totals[account.currency] = account.baseBalance
+        }
+        transactions
+            .filter { it.transaction.accountId == account.id }
+            .forEach { tx ->
+                val currency = tx.transaction.currencyCode
+                totals[currency] = totals.getOrDefault(currency, ZERO) + tx.transaction.amount
+            }
+        return totals.toBalances()
+    }
+
+    fun semanticDebtBalancesFor(
+        account: AccountEntity,
+        transactions: List<TransactionWithDetails>,
+        advanceCases: List<AdvanceCaseWithDetails>
+    ): List<DebtSettlementCurrencyBalance> {
+        val totals = linkedMapOf<String, BigDecimal>()
+        if (account.baseBalance != ZERO) {
+            totals[account.currency] = account.baseBalance
+        }
+
+        val advanceGroupIds = advanceCases
+            .flatMap { advanceCase ->
+                advanceCase.participants.mapNotNull { it.initialTransferGroupId } +
+                    advanceCase.repayments.mapNotNull { it.linkedTransferGroupId }
+            }
+            .toSet()
+
+        transactions
+            .filter { it.transaction.accountId == account.id }
+            .filterNot { tx -> tx.transaction.transferGroupId?.let { it in advanceGroupIds } == true }
+            .forEach { tx ->
+                val currency = tx.transaction.currencyCode
+                totals[currency] = totals.getOrDefault(currency, ZERO) + tx.transaction.amount
+            }
+
+        advanceCases.forEach { advanceCase ->
+            advanceCase.participants
+                .filter { it.debtAccountId == account.id }
+                .forEach { participant ->
+                    val remaining = (participant.owedAmount - participant.repaidAmount).max(ZERO)
+                    if (remaining > ZERO) {
+                        val signedRemaining = if (advanceCase.advanceCase.payerAccountId != null) {
+                            remaining
+                        } else {
+                            remaining.negate()
+                        }
+                        val currency = advanceCase.advanceCase.currencyCode
+                        totals[currency] = totals.getOrDefault(currency, ZERO) + signedRemaining
+                    }
+                }
+        }
+
+        return totals.toBalances()
+    }
+
+    private fun Map<String, BigDecimal>.toBalances(): List<DebtSettlementCurrencyBalance> {
+        return entries
+            .filter { it.value.compareTo(ZERO) != 0 }
+            .sortedBy { it.key }
+            .map { DebtSettlementCurrencyBalance(currencyCode = it.key, amount = it.value) }
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -29,8 +29,10 @@ import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
+import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
@@ -57,6 +59,7 @@ fun AccountDetailScreen(
     val scope = rememberCoroutineScope()
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val transactions by repository.transactions.collectAsState(initial = emptyList())
+    val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
 
     val resolvedId = remember(accountId) { accountId?.let(UUID::fromString) }
     val account = remember(accounts, resolvedId) { accounts.firstOrNull { it.id == resolvedId } }
@@ -85,7 +88,7 @@ fun AccountDetailScreen(
             .filter { it.transaction.accountId == account.id }
             .sortedByDescending { it.transaction.date }
     }
-    val balances = remember(account, accountTransactions) { calculateBalances(account, accountTransactions) }
+    val balances = remember(account, transactions, advanceCases) { calculateBalances(account, transactions, advanceCases) }
 
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
@@ -309,20 +312,11 @@ private data class AccountCurrencyBalance(
 
 private fun calculateBalances(
     account: AccountEntity,
-    transactions: List<TransactionWithDetails>
+    transactions: List<TransactionWithDetails>,
+    advanceCases: List<AdvanceCaseWithDetails>
 ): List<AccountCurrencyBalance> {
-    val totals = linkedMapOf<String, BigDecimal>()
-    if (account.baseBalance != BigDecimal.ZERO) {
-        totals[account.currency] = account.baseBalance
-    }
-    transactions.forEach { tx ->
-        val currency = tx.transaction.currencyCode
-        totals[currency] = totals.getOrDefault(currency, BigDecimal.ZERO) + tx.transaction.amount
-    }
-    return totals.entries
-        .filter { it.value != BigDecimal.ZERO }
-        .sortedBy { it.key }
-        .map { AccountCurrencyBalance(it.key, it.value) }
+    return DebtSettlementBalanceCalculator.balancesFor(account, transactions, advanceCases)
+        .map { AccountCurrencyBalance(it.currencyCode, it.amount) }
 }
 
 private fun defaultTransactionTitle(type: TransactionType): String = when (type) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountsScreen.kt
@@ -29,7 +29,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
@@ -52,12 +54,13 @@ fun AccountsScreen(
     val currencyService = LocalCurrencyService.current
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val transactions by repository.transactions.collectAsState(initial = emptyList())
+    val advanceCases by repository.advanceCases.collectAsState(initial = emptyList())
     val rateSnapshot = currencyService.rates
     val mainCurrency = currencyService.mainCurrency
     var showArchived by rememberSaveable { mutableStateOf(false) }
 
-    val accountSummaries = remember(accounts, transactions) {
-        calculateBalances(accounts, transactions)
+    val accountSummaries = remember(accounts, transactions, advanceCases) {
+        calculateBalances(accounts, transactions, advanceCases)
     }
     val activeSummaries = remember(accountSummaries) {
         accountSummaries.filter { !it.account.isArchived }
@@ -316,23 +319,12 @@ private data class CurrencyHoldingSummary(
 
 private fun calculateBalances(
     accounts: List<AccountEntity>,
-    transactions: List<TransactionWithDetails>
+    transactions: List<TransactionWithDetails>,
+    advanceCases: List<AdvanceCaseWithDetails>
 ): List<AccountBalance> {
-    val grouped = transactions.groupBy { it.transaction.accountId }
     return accounts.map { account ->
-        val totals = linkedMapOf<String, BigDecimal>()
-        if (account.baseBalance != BigDecimal.ZERO) {
-            totals[account.currency] = account.baseBalance
-        }
-        grouped[account.id]?.forEach { tx ->
-            val currency = tx.transaction.currencyCode
-            totals[currency] = totals.getOrDefault(currency, BigDecimal.ZERO) + tx.transaction.amount
-        }
-
-        val balances = totals.entries
-            .filter { it.value != BigDecimal.ZERO }
-            .sortedBy { it.key }
-            .map { CurrencyBalance(currency = it.key, amount = it.value) }
+        val balances = DebtSettlementBalanceCalculator.balancesFor(account, transactions, advanceCases)
+            .map { CurrencyBalance(currency = it.currencyCode, amount = it.amount) }
 
         AccountBalance(account = account, balances = balances)
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
@@ -37,6 +37,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
 import org.duckdns.lhfser.aiaccounting.data.repository.MutualDebtOffsetCandidate
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
@@ -441,7 +442,7 @@ private fun buildPersonSummaries(
     mainCurrency: String
 ): List<SettlementPersonSummary> {
     val debtAccounts = accounts.filter { it.type == AccountType.Debt && !it.isArchived }
-    val balancesByAccount = calculateDebtBalances(debtAccounts, transactions)
+    val balancesByAccount = calculateDebtBalances(debtAccounts, transactions, advanceCases)
     val forgivenessByAccount = transactions
         .filter { it.account?.type == AccountType.Debt && TransactionSemantics.isDebtForgiveness(it.transaction.note) }
         .groupingBy { it.account?.id }
@@ -524,22 +525,12 @@ private inline fun <T> Iterable<T>.sumOfBigDecimal(selector: (T) -> BigDecimal):
 
 private fun calculateDebtBalances(
     accounts: List<AccountEntity>,
-    transactions: List<TransactionWithDetails>
+    transactions: List<TransactionWithDetails>,
+    advanceCases: List<AdvanceCaseWithDetails>
 ): Map<UUID, List<SettlementCurrencyBalance>> {
-    val grouped = transactions.groupBy { it.transaction.accountId }
     return accounts.associate { account ->
-        val totals = linkedMapOf<String, BigDecimal>()
-        if (account.baseBalance != BigDecimal.ZERO) {
-            totals[account.currency] = account.baseBalance
-        }
-        grouped[account.id].orEmpty().forEach { tx ->
-            val currency = tx.transaction.currencyCode
-            totals[currency] = totals.getOrDefault(currency, BigDecimal.ZERO) + tx.transaction.amount
-        }
-        account.id to totals.entries
-            .filter { it.value != BigDecimal.ZERO }
-            .sortedBy { it.key }
-            .map { SettlementCurrencyBalance(it.key, it.value) }
+        account.id to DebtSettlementBalanceCalculator.balancesFor(account, transactions, advanceCases)
+            .map { SettlementCurrencyBalance(it.currencyCode, it.amount) }
     }
 }
 

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -19,6 +19,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -371,6 +372,85 @@ class BackupRoundTripTest {
         val incoming = checkNotNull(linkedTransactions.firstOrNull { it.accountId == receiveAccount.id })
         assertEquals(BigDecimal("90"), incoming.amount)
         assertEquals("CNY", incoming.currencyCode)
+    }
+
+    @Test
+    fun crossCurrencyAdvanceRepayment_semanticDebtBalanceUsesCaseCurrencyRemainingOnly() = runBlocking {
+        val payerAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "JPY Wallet",
+            currency = "JPY",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val receiveAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "HKD Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 1,
+            isArchived = false
+        )
+        val debtAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Friend A",
+            currency = "HKD",
+            type = AccountType.Debt,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 2,
+            isArchived = false
+        )
+        database.accountDao().upsertAll(listOf(payerAccount, receiveAccount, debtAccount))
+
+        val date = Instant.parse("2026-03-21T12:00:00Z")
+        val caseId = repository.createAdvanceCase(
+            title = "日本旅行代墊",
+            date = date,
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = payerAccount,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("1000"))),
+            isBorrowedByMe = false
+        )
+        val advanceCase = checkNotNull(repository.getAdvanceCase(caseId))
+        val participant = advanceCase.participants.single()
+
+        repository.recordAdvanceRepayment(
+            advanceCase = advanceCase.advanceCase,
+            participant = participant,
+            amount = BigDecimal("50"),
+            normalizedAmount = BigDecimal("900"),
+            currencyCode = "HKD",
+            date = date.plusSeconds(3600),
+            note = "朋友用港幣還款",
+            receiveAccount = receiveAccount,
+            category = null,
+            tagIds = emptyList(),
+            isBorrowedByMe = false
+        )
+
+        val updatedCase = checkNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(BigDecimal("100"), updatedCase.participants.single().owedAmount - updatedCase.participants.single().repaidAmount)
+
+        val transactions = database.transactionDao().getAllWithDetails()
+        val rawBalances = DebtSettlementBalanceCalculator.rawBalancesFor(debtAccount, transactions)
+        assertEquals(BigDecimal("1000"), rawBalances.first { it.currencyCode == "JPY" }.amount)
+        assertEquals(BigDecimal("-50"), rawBalances.first { it.currencyCode == "HKD" }.amount)
+
+        val semanticBalances = DebtSettlementBalanceCalculator.balancesFor(
+            debtAccount,
+            transactions,
+            listOf(updatedCase)
+        )
+        assertEquals(1, semanticBalances.size)
+        assertEquals("JPY", semanticBalances.single().currencyCode)
+        assertEquals(BigDecimal("100"), semanticBalances.single().amount)
     }
 
     @Test

--- a/docs/specs/parity-test-vectors.md
+++ b/docs/specs/parity-test-vectors.md
@@ -94,6 +94,21 @@ Expected import defaults:
 - `myShareAmount = 0`
 - `normalizedAmount = amount`
 
+## Vector 6: Cross-Currency Advance Repayment Settlement Balance
+
+Input:
+- Advance case currency: `JPY`
+- Participant A owes: `1000 JPY`
+- Repayment actual amount: `50 HKD`
+- Repayment normalized amount: `900 JPY`
+
+Expected:
+- Participant A remaining amount: `100 JPY`
+- Settlement center / debt account semantic balance for A: `+100 JPY`
+- The actual `50 HKD` repayment remains visible in repayment history / timeline.
+- The actual `50 HKD` repayment must not appear as a separate reverse debt balance.
+- Raw linked advance transfer legs are implementation details and must not drive settlement summary balances.
+
 ## CI Gate Recommendation
 
 When Android data layer is ready, run these vectors in both platforms and compare:


### PR DESCRIPTION
## Summary
- add semantic debt settlement balance calculators on iOS and Android
- exclude linked advance initial/repayment transfer legs from debt settlement summaries
- show outstanding advance balances in the case currency while preserving actual repayment currency in history
- update account summaries, account detail, and settlement center to use semantic debt balances
- document the JPY advance / HKD repayment parity vector

Closes #120

## Tests
- xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- ./gradlew testDebugUnitTest assembleDebug