### PR TITLE
Repair legacy transaction enum values before launch

### DIFF
--- a/AI 記帳/AI___App.swift
+++ b/AI 記帳/AI___App.swift
@@ -237,7 +237,9 @@ struct AI___App: App {
         
         // 4. 啟動前先修復舊資料的 Category.kind，避免 enum 強制轉型崩潰
         repairLegacyCategoryKindsIfNeeded(storeURL: storeURL)
-        // 5. 啟動前修復舊版「其他幣種餘額/餘額修正」被誤記為收支的資料
+        // 5. 啟動前修復舊資料的 FinancialTransaction enum 欄位，避免 enum 強制轉型崩潰
+        LegacyStoreRepairService.repairLegacyFinancialTransactionEnumsIfNeeded(storeURL: storeURL)
+        // 6. 啟動前修復舊版「其他幣種餘額/餘額修正」被誤記為收支的資料
         repairLegacyAssetAdjustmentTransactionsIfNeeded(storeURL: storeURL)
         
         let modelConfiguration = ModelConfiguration(

--- a/AI 記帳/Services/LegacyStoreRepairService.swift
+++ b/AI 記帳/Services/LegacyStoreRepairService.swift
@@ -1,0 +1,170 @@
+import Foundation
+import SQLite3
+
+enum LegacyStoreRepairService {
+    static func repairLegacyFinancialTransactionEnumsIfNeeded(storeURL: URL) {
+        guard FileManager.default.fileExists(atPath: storeURL.path) else {
+            return
+        }
+
+        var db: OpaquePointer?
+        let openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        let openResult = sqlite3_open_v2(storeURL.path, &db, openFlags, nil)
+        guard openResult == SQLITE_OK, let db else {
+            if let errorMessage = sqlite3_errmsg(db) {
+                print("⚠️ 無法開啟資料庫修復交易 enum 欄位: \(String(cString: errorMessage))")
+            }
+            if db != nil {
+                sqlite3_close(db)
+            }
+            return
+        }
+        defer { sqlite3_close(db) }
+
+        repairLegacyFinancialTransactionEnums(db: db)
+    }
+
+    private static func repairLegacyFinancialTransactionEnums(db: OpaquePointer) {
+        guard tableExists("ZFINANCIALTRANSACTION", db: db) else {
+            return
+        }
+
+        if !columnExists("ZTYPE", in: "ZFINANCIALTRANSACTION", db: db) {
+            let addColumnSQL = "ALTER TABLE ZFINANCIALTRANSACTION ADD COLUMN ZTYPE VARCHAR;"
+            let addResult = sqlite3_exec(db, addColumnSQL, nil, nil, nil)
+            if addResult != SQLITE_OK {
+                if let errorMessage = sqlite3_errmsg(db) {
+                    let message = String(cString: errorMessage)
+                    if !message.localizedCaseInsensitiveContains("duplicate column name") {
+                        print("⚠️ 補建 FinancialTransaction.type 欄位失敗: \(message)")
+                        return
+                    }
+                } else {
+                    return
+                }
+            }
+            print("ℹ️ 已補建缺失欄位 ZFINANCIALTRANSACTION.ZTYPE")
+        }
+
+        let beforeChanges = sqlite3_total_changes(db)
+        repairTransactionType(db: db)
+        repairTransferSide(db: db)
+
+        let changed = sqlite3_total_changes(db) - beforeChanges
+        if changed > 0 {
+            print("✅ 已修復 FinancialTransaction enum 舊資料 \(changed) 筆")
+        }
+    }
+
+    private static func repairTransactionType(db: OpaquePointer) {
+        guard columnExists("ZTYPE", in: "ZFINANCIALTRANSACTION", db: db) else {
+            return
+        }
+
+        let amountExpression = columnExists("ZAMOUNT", in: "ZFINANCIALTRANSACTION", db: db)
+            ? "COALESCE(ZAMOUNT, 0)"
+            : "0"
+        let transferPredicate = transferShapePredicates(db: db).joined(separator: " OR ")
+        let transferCondition = transferPredicate.isEmpty ? "0" : transferPredicate
+
+        let sql = """
+        UPDATE ZFINANCIALTRANSACTION
+        SET ZTYPE = CASE
+            WHEN \(transferCondition) THEN 'Transfer'
+            WHEN \(amountExpression) >= 0 THEN 'Income'
+            ELSE 'Expense'
+        END
+        WHERE ZTYPE IS NULL
+           OR TRIM(CAST(ZTYPE AS TEXT)) = ''
+           OR ZTYPE NOT IN ('Income', 'Expense', 'Transfer');
+        """
+
+        let result = sqlite3_exec(db, sql, nil, nil, nil)
+        if result != SQLITE_OK, let errorMessage = sqlite3_errmsg(db) {
+            print("⚠️ FinancialTransaction.type 舊資料修復失敗: \(String(cString: errorMessage))")
+        }
+    }
+
+    private static func repairTransferSide(db: OpaquePointer) {
+        guard columnExists("ZTRANSFERSIDE", in: "ZFINANCIALTRANSACTION", db: db) else {
+            return
+        }
+
+        let amountExpression = columnExists("ZAMOUNT", in: "ZFINANCIALTRANSACTION", db: db)
+            ? "COALESCE(ZAMOUNT, 0)"
+            : "0"
+
+        let sql = """
+        UPDATE ZFINANCIALTRANSACTION
+        SET ZTRANSFERSIDE = CASE
+            WHEN ZTYPE = 'Transfer' AND \(amountExpression) >= 0 THEN 'Incoming'
+            WHEN ZTYPE = 'Transfer' THEN 'Outgoing'
+            ELSE NULL
+        END
+        WHERE ZTRANSFERSIDE IS NOT NULL
+          AND (
+                TRIM(CAST(ZTRANSFERSIDE AS TEXT)) = ''
+             OR ZTRANSFERSIDE NOT IN ('Incoming', 'Outgoing')
+          );
+        """
+
+        let result = sqlite3_exec(db, sql, nil, nil, nil)
+        if result != SQLITE_OK, let errorMessage = sqlite3_errmsg(db) {
+            print("⚠️ FinancialTransaction.transferSide 舊資料修復失敗: \(String(cString: errorMessage))")
+        }
+    }
+
+    private static func transferShapePredicates(db: OpaquePointer) -> [String] {
+        var predicates: [String] = []
+        if columnExists("ZLINKEDTRANSACTIONID", in: "ZFINANCIALTRANSACTION", db: db) {
+            predicates.append("(ZLINKEDTRANSACTIONID IS NOT NULL AND TRIM(CAST(ZLINKEDTRANSACTIONID AS TEXT)) <> '')")
+        }
+        if columnExists("ZTRANSFERGROUPID", in: "ZFINANCIALTRANSACTION", db: db) {
+            predicates.append("(ZTRANSFERGROUPID IS NOT NULL AND TRIM(CAST(ZTRANSFERGROUPID AS TEXT)) <> '')")
+        }
+        if columnExists("ZTRANSFERSIDE", in: "ZFINANCIALTRANSACTION", db: db) {
+            predicates.append("ZTRANSFERSIDE IN ('Incoming', 'Outgoing')")
+        }
+        return predicates
+    }
+
+    private static func tableExists(_ name: String, db: OpaquePointer) -> Bool {
+        let sql = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1;"
+        var statement: OpaquePointer?
+        defer {
+            if statement != nil {
+                sqlite3_finalize(statement)
+            }
+        }
+
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return false
+        }
+
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, name, -1, transient)
+        return sqlite3_step(statement) == SQLITE_ROW
+    }
+
+    private static func columnExists(_ columnName: String, in tableName: String, db: OpaquePointer) -> Bool {
+        let sql = "PRAGMA table_info(\(tableName));"
+        var statement: OpaquePointer?
+        defer {
+            if statement != nil {
+                sqlite3_finalize(statement)
+            }
+        }
+
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return false
+        }
+
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let cString = sqlite3_column_text(statement, 1) else { continue }
+            if String(cString: cString) == columnName {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -1,9 +1,55 @@
 import XCTest
 import SwiftData
+import SQLite3
 @testable import AI_記帳
 
 @MainActor
 final class BackupCompatibilityTests: XCTestCase {
+    func testLegacyStoreRepair_repairsInvalidFinancialTransactionEnumColumnsBeforeSwiftDataLoads() throws {
+        let storeURL = try makeTemporarySQLiteStoreURL(named: "legacy-transaction-enums.sqlite")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        try withSQLiteDatabase(at: storeURL) { db in
+            try execSQL(
+                """
+                CREATE TABLE ZFINANCIALTRANSACTION (
+                    Z_PK INTEGER PRIMARY KEY,
+                    ZTYPE VARCHAR,
+                    ZAMOUNT NUMERIC,
+                    ZLINKEDTRANSACTIONID VARCHAR,
+                    ZTRANSFERGROUPID VARCHAR,
+                    ZTRANSFERSIDE VARCHAR
+                );
+                INSERT INTO ZFINANCIALTRANSACTION (Z_PK, ZTYPE, ZAMOUNT, ZLINKEDTRANSACTIONID, ZTRANSFERGROUPID, ZTRANSFERSIDE)
+                VALUES
+                    (1, NULL, -120, NULL, NULL, NULL),
+                    (2, '', 250, NULL, NULL, NULL),
+                    (3, 'BadType', 500, NULL, 'group-1', NULL),
+                    (4, 'Transfer', -10, NULL, NULL, 'BadSide'),
+                    (5, 'Expense', -20, NULL, NULL, 'BadSide');
+                """,
+                db: db
+            )
+        }
+
+        LegacyStoreRepairService.repairLegacyFinancialTransactionEnumsIfNeeded(storeURL: storeURL)
+
+        let rows = try withSQLiteDatabase(at: storeURL) { db in
+            try queryTransactionEnumRows(db: db)
+        }
+
+        XCTAssertEqual("Expense", rows[1]?.type)
+        XCTAssertNil(rows[1]?.transferSide)
+        XCTAssertEqual("Income", rows[2]?.type)
+        XCTAssertNil(rows[2]?.transferSide)
+        XCTAssertEqual("Transfer", rows[3]?.type)
+        XCTAssertNil(rows[3]?.transferSide)
+        XCTAssertEqual("Transfer", rows[4]?.type)
+        XCTAssertEqual("Outgoing", rows[4]?.transferSide)
+        XCTAssertEqual("Expense", rows[5]?.type)
+        XCTAssertNil(rows[5]?.transferSide)
+    }
+
     func testLegacyAdvanceFixture_roundTripsWithBorrowedAdvanceWarning() async throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)
@@ -619,6 +665,60 @@ final class BackupCompatibilityTests: XCTestCase {
         encoder.dateEncodingStrategy = .iso8601
         try encoder.encode(backup).write(to: tempURL, options: .atomic)
         return tempURL
+    }
+
+    private func makeTemporarySQLiteStoreURL(named name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func withSQLiteDatabase<T>(at url: URL, body: (OpaquePointer) throws -> T) throws -> T {
+        var db: OpaquePointer?
+        let result = sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nil)
+        guard result == SQLITE_OK, let db else {
+            let message = db.flatMap { sqlite3_errmsg($0) }.map { String(cString: $0) } ?? "unknown sqlite error"
+            if db != nil {
+                sqlite3_close(db)
+            }
+            throw NSError(domain: "BackupCompatibilitySQLite", code: Int(result), userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        defer { sqlite3_close(db) }
+        return try body(db)
+    }
+
+    private func execSQL(_ sql: String, db: OpaquePointer) throws {
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(db, sql, nil, nil, &errorMessage)
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map { String(cString: $0) } ?? "unknown sqlite exec error"
+            if errorMessage != nil {
+                sqlite3_free(errorMessage)
+            }
+            throw NSError(domain: "BackupCompatibilitySQLite", code: Int(result), userInfo: [NSLocalizedDescriptionKey: message])
+        }
+    }
+
+    private func queryTransactionEnumRows(db: OpaquePointer) throws -> [Int: (type: String?, transferSide: String?)] {
+        let sql = "SELECT Z_PK, ZTYPE, ZTRANSFERSIDE FROM ZFINANCIALTRANSACTION ORDER BY Z_PK;"
+        var statement: OpaquePointer?
+        let prepareResult = sqlite3_prepare_v2(db, sql, -1, &statement, nil)
+        guard prepareResult == SQLITE_OK, let statement else {
+            let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "unknown sqlite prepare error"
+            throw NSError(domain: "BackupCompatibilitySQLite", code: Int(prepareResult), userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var rows: [Int: (type: String?, transferSide: String?)] = [:]
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let id = Int(sqlite3_column_int(statement, 0))
+            let type = sqlite3_column_text(statement, 1).map { String(cString: $0) }
+            let transferSide = sqlite3_column_text(statement, 2).map { String(cString: $0) }
+            rows[id] = (type, transferSide)
+        }
+        return rows
     }
 }
 


### PR DESCRIPTION
## Summary
- add a pre-SwiftData SQLite repair for invalid FinancialTransaction enum columns
- repair nil/blank/invalid transaction type values before any SwiftData getter can crash
- repair invalid transferSide values to valid transfer sides or nil
- call the repair before the ModelContainer loads the persistent store
- add a SQLite-level regression test for invalid ZTYPE/ZTRANSFERSIDE rows

## Why
The crash stack shows FinancialTransaction.type.getter failing while TransactionRow renders. That means the persisted enum value is invalid before UI code can safely inspect it.

## Tests
- xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO