### PR TITLE
Add manual cross-currency debt settlement

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -101,9 +101,22 @@ enum AdvanceService {
         let currencyCode: String
         let repaymentCount: Int
     }
+
+    enum ManualDebtSettlementDirection {
+        case receivable
+        case payable
+    }
+
+    struct ManualDebtSettlementResult {
+        let settlementID: UUID
+        let amount: Decimal
+        let currencyCode: String
+        let repaymentCount: Int
+    }
     
     private static let roundingTolerance = Decimal(string: "0.0001") ?? 0.0001
     static let mutualDebtOffsetMarkerPrefix = "[債務抵銷:"
+    static let manualDebtSettlementMarkerPrefix = "[跨幣種平賬:"
     
     static func totalAdvanced(for advanceCase: AdvanceCase) -> Decimal {
         advanceCase.myShareAmount + advanceCase.participants.reduce(Decimal.zero) { $0 + $1.owedAmount }
@@ -126,6 +139,20 @@ enum AdvanceService {
             return nil
         }
         let startIndex = trimmed.index(trimmed.startIndex, offsetBy: mutualDebtOffsetMarkerPrefix.count)
+        return UUID(uuidString: String(trimmed[startIndex..<closeIndex]))
+    }
+
+    static func isManualDebtSettlement(note: String) -> Bool {
+        note.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix(manualDebtSettlementMarkerPrefix)
+    }
+
+    static func manualDebtSettlementID(from note: String) -> UUID? {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix(manualDebtSettlementMarkerPrefix),
+              let closeIndex = trimmed.firstIndex(of: "]") else {
+            return nil
+        }
+        let startIndex = trimmed.index(trimmed.startIndex, offsetBy: manualDebtSettlementMarkerPrefix.count)
         return UUID(uuidString: String(trimmed[startIndex..<closeIndex]))
     }
 
@@ -229,6 +256,58 @@ enum AdvanceService {
         }
         try modelContext.save()
         return repayments.count
+    }
+
+    @MainActor
+    static func recordManualDebtSettlement(
+        debtAccount: Account,
+        currencyCode: String,
+        direction: ManualDebtSettlementDirection,
+        amount: Decimal,
+        date: Date = Date(),
+        note: String = "",
+        modelContext: ModelContext
+    ) throws -> ManualDebtSettlementResult {
+        guard amount > roundingTolerance else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+
+        let advanceCases = try modelContext.fetch(FetchDescriptor<AdvanceCase>())
+        let offsetable = offsetableParticipants(
+            debtAccount: debtAccount,
+            currencyCode: currencyCode,
+            advanceCases: advanceCases,
+            modelContext: modelContext
+        )
+        let entries = direction == .receivable ? offsetable.receivable : offsetable.payable
+        let availableAmount = entries.reduce(Decimal.zero) { $0 + $1.participant.remainingAmount }
+        guard amount <= availableAmount + roundingTolerance else {
+            throw AdvanceServiceError.repaymentExceedsRemaining
+        }
+
+        let settlementID = UUID()
+        let marker = "\(manualDebtSettlementMarkerPrefix)\(settlementID.uuidString)]"
+        let baseNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultNote = direction == .receivable
+            ? "手動結清 \(debtAccount.name) 欠你的 \(currencyCode) 代墊餘額"
+            : "手動結清你欠 \(debtAccount.name) 的 \(currencyCode) 代墊餘額"
+        let finalNote = baseNote.isEmpty ? "\(marker) \(defaultNote)" : "\(marker) \(baseNote)"
+
+        let repaymentCount = applyManualDebtSettlement(
+            amount: amount,
+            entries: entries,
+            date: date,
+            note: finalNote,
+            modelContext: modelContext
+        )
+
+        try modelContext.save()
+        return ManualDebtSettlementResult(
+            settlementID: settlementID,
+            amount: amount,
+            currencyCode: currencyCode,
+            repaymentCount: repaymentCount
+        )
     }
     
     @MainActor
@@ -732,6 +811,23 @@ enum AdvanceService {
         }
 
         return repaymentCount
+    }
+
+    @MainActor
+    private static func applyManualDebtSettlement(
+        amount: Decimal,
+        entries: [OffsetParticipantEntry],
+        date: Date,
+        note: String,
+        modelContext: ModelContext
+    ) -> Int {
+        applyMutualDebtOffset(
+            amount: amount,
+            entries: entries,
+            date: date,
+            note: note,
+            modelContext: modelContext
+        )
     }
     
     @MainActor

--- a/AI 記帳/Views/Settlements/SettlementCenterView.swift
+++ b/AI 記帳/Views/Settlements/SettlementCenterView.swift
@@ -58,6 +58,25 @@ private struct SettlementDebtRoute: Identifiable, Hashable {
     }
 }
 
+private struct ManualDebtSettlementDraft: Identifiable {
+    let id = UUID()
+    let account: Account
+    let currencyCode: String
+    let direction: AdvanceService.ManualDebtSettlementDirection
+    let suggestedAmount: Decimal
+    let maximumAmount: Decimal
+    let visibleBalance: Decimal
+
+    var directionTitle: String {
+        switch direction {
+        case .receivable:
+            "結清對方欠你的 \(currencyCode)"
+        case .payable:
+            "結清你欠對方的 \(currencyCode)"
+        }
+    }
+}
+
 struct SettlementCenterView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Account.sortOrder) private var accounts: [Account]
@@ -69,6 +88,7 @@ struct SettlementCenterView: View {
     @State private var selectedPerson: SettlementPersonSummary?
     @State private var timelineFilter: SettlementTimelineFilter?
     @State private var debtRoute: SettlementDebtRoute?
+    @State private var manualDebtSettlementDraft: ManualDebtSettlementDraft?
     @State private var statusMessage: String?
 
     private var activeDebtAccounts: [Account] {
@@ -149,7 +169,10 @@ struct SettlementCenterView: View {
         }
 
         let allRepayments = advanceCases.flatMap(\.repayments)
-        items += allRepayments.filter { !AdvanceService.isMutualDebtOffset(note: $0.note) }.map { repayment in
+        items += allRepayments.filter {
+            !AdvanceService.isMutualDebtOffset(note: $0.note)
+                && !AdvanceService.isManualDebtSettlement(note: $0.note)
+        }.map { repayment in
             SettlementTimelineItem(
                 id: "repayment-\(repayment.id.uuidString)",
                 relatedAccountID: repayment.participant?.debtAccount?.id,
@@ -159,6 +182,26 @@ struct SettlementCenterView: View {
                 amount: repayment.amount,
                 currencyCode: repayment.currencyCode,
                 tint: .green
+            )
+        }
+
+        let manualRepaymentsByID = Dictionary(grouping: allRepayments.compactMap { repayment -> (UUID, AdvanceRepayment)? in
+            guard let settlementID = AdvanceService.manualDebtSettlementID(from: repayment.note) else { return nil }
+            return (settlementID, repayment)
+        }) { $0.0 }
+        items += manualRepaymentsByID.compactMap { settlementID, entries in
+            let repayments = entries.map(\.1)
+            guard let first = repayments.first else { return nil }
+            let total = repayments.reduce(Decimal.zero) { $0 + $1.normalizedAmount }
+            return SettlementTimelineItem(
+                id: "manual-settlement-\(settlementID.uuidString)",
+                relatedAccountID: first.participant?.debtAccount?.id,
+                date: first.date,
+                title: "跨幣種平賬",
+                subtitle: first.participant?.debtAccount?.name ?? "手動結清代墊餘額",
+                amount: total,
+                currencyCode: first.currencyCode,
+                tint: .indigo
             )
         }
 
@@ -315,6 +358,12 @@ struct SettlementCenterView: View {
                         recordOffset(candidate)
                     }
                 }
+                ForEach(manualSettlementDrafts(for: summary)) { draft in
+                    Button("\(draft.directionTitle) \(draft.suggestedAmount.formatted(.currency(code: draft.currencyCode)))") {
+                        selectedPerson = nil
+                        manualDebtSettlementDraft = draft
+                    }
+                }
             }
             if let summary = selectedPerson, summary.netBalanceInMainCurrency > 0 {
                 Button("記錄對方還款") {
@@ -385,6 +434,11 @@ struct SettlementCenterView: View {
                 )
             } else {
                 ContentUnavailableView("找不到對象", systemImage: "person.crop.circle.badge.exclamationmark")
+            }
+        }
+        .sheet(item: $manualDebtSettlementDraft) { draft in
+            ManualDebtSettlementSheet(draft: draft) { amount, note in
+                recordManualDebtSettlement(draft, amount: amount, note: note)
             }
         }
     }
@@ -591,6 +645,49 @@ struct SettlementCenterView: View {
         }
     }
 
+    private func manualSettlementDrafts(for summary: SettlementPersonSummary) -> [ManualDebtSettlementDraft] {
+        summary.balances.compactMap { balance in
+            let visibleAmount = abs(balance.amount)
+            guard visibleAmount > 0 else { return nil }
+            let direction: AdvanceService.ManualDebtSettlementDirection = balance.amount > 0 ? .receivable : .payable
+            let maximum = manualSettlementAvailableAmount(
+                for: summary.account,
+                currencyCode: balance.currencyCode,
+                direction: direction
+            )
+            guard maximum > 0 else { return nil }
+            return ManualDebtSettlementDraft(
+                account: summary.account,
+                currencyCode: balance.currencyCode,
+                direction: direction,
+                suggestedAmount: min(visibleAmount, maximum),
+                maximumAmount: maximum,
+                visibleBalance: balance.amount
+            )
+        }
+    }
+
+    private func manualSettlementAvailableAmount(
+        for account: Account,
+        currencyCode: String,
+        direction: AdvanceService.ManualDebtSettlementDirection
+    ) -> Decimal {
+        advanceCases
+            .filter { $0.currencyCode == currencyCode }
+            .flatMap { advanceCase -> [Decimal] in
+                let isPayableCase = advanceCase.payerAccount == nil
+                switch (direction, isPayableCase) {
+                case (.receivable, false), (.payable, true):
+                    return advanceCase.participants
+                        .filter { $0.debtAccount?.id == account.id }
+                        .map(\.remainingAmount)
+                default:
+                    return []
+                }
+            }
+            .reduce(Decimal.zero, +)
+    }
+
     private func debtTimelineTitle(for transaction: FinancialTransaction, fallback: String) -> String {
         let note = transaction.note
         if TransactionSemantics.isDebtForgiveness(note: note) {
@@ -625,5 +722,92 @@ struct SettlementCenterView: View {
             selectedPerson = nil
             statusMessage = error.localizedDescription
         }
+    }
+
+    private func recordManualDebtSettlement(_ draft: ManualDebtSettlementDraft, amount: Decimal, note: String) {
+        do {
+            let result = try AdvanceService.recordManualDebtSettlement(
+                debtAccount: draft.account,
+                currencyCode: draft.currencyCode,
+                direction: draft.direction,
+                amount: amount,
+                note: note,
+                modelContext: modelContext
+            )
+            manualDebtSettlementDraft = nil
+            statusMessage = "已跨幣種平賬 \(result.amount.formatted(.currency(code: result.currencyCode)))。"
+        } catch {
+            statusMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct ManualDebtSettlementSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let draft: ManualDebtSettlementDraft
+    let onConfirm: (Decimal, String) -> Void
+    @State private var amountString: String
+    @State private var note: String
+    @State private var errorMessage: String?
+
+    init(draft: ManualDebtSettlementDraft, onConfirm: @escaping (Decimal, String) -> Void) {
+        self.draft = draft
+        self.onConfirm = onConfirm
+        _amountString = State(initialValue: NSDecimalNumber(decimal: draft.suggestedAmount).stringValue)
+        _note = State(initialValue: "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    LabeledContent("對象", value: draft.account.name)
+                    LabeledContent("幣種", value: draft.currencyCode)
+                    LabeledContent("結算方向", value: draft.directionTitle)
+                    LabeledContent("目前顯示淨額", value: draft.visibleBalance.formatted(.currency(code: draft.currencyCode)))
+                    LabeledContent("最多可結清", value: draft.maximumAmount.formatted(.currency(code: draft.currencyCode)))
+                } footer: {
+                    Text("這是手動平賬：不會建立現金或銀行交易，也不會計入收入/支出，只會在代墊紀錄中留下審計紀錄。")
+                }
+
+                Section("平賬金額") {
+                    TextField("金額", text: $amountString)
+                        .keyboardType(.decimalPad)
+                    TextField("備註（可選）", text: $note, axis: .vertical)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("跨幣種平賬")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("確認") {
+                        confirm()
+                    }
+                }
+            }
+        }
+    }
+
+    private func confirm() {
+        guard let amount = Decimal(string: amountString), amount > 0 else {
+            errorMessage = "請輸入有效金額。"
+            return
+        }
+        guard amount <= draft.maximumAmount else {
+            errorMessage = "平賬金額不能超過可結清金額。"
+            return
+        }
+        onConfirm(amount, note)
+        dismiss()
     }
 }

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -424,6 +424,62 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(Decimal(40), payableCase.participants.first?.remainingAmount)
     }
 
+    func testManualDebtSettlement_closesSingleCurrencyAdvanceWithoutTransactions() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let ownAccount = Account(name: "JPY Wallet", currency: "JPY", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "TKL", currency: "HKD", type: .debt, baseBalance: 0)
+        modelContext.insert(ownAccount)
+        modelContext.insert(debtAccount)
+        try modelContext.save()
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "豬骨拉麵",
+            date: date,
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: ownAccount,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 1230)],
+            isBorrowedByMe: false,
+            modelContext: modelContext
+        )
+
+        let beforeTransactionCount = try modelContext.fetch(FetchDescriptor<FinancialTransaction>()).count
+        let result = try AdvanceService.recordManualDebtSettlement(
+            debtAccount: debtAccount,
+            currencyCode: "JPY",
+            direction: .receivable,
+            amount: 1230,
+            date: date.addingTimeInterval(600),
+            note: "手動結清日元餘額",
+            modelContext: modelContext
+        )
+
+        XCTAssertEqual(Decimal(1230), result.amount)
+        XCTAssertEqual(1, result.repaymentCount)
+        XCTAssertEqual(beforeTransactionCount, try modelContext.fetch(FetchDescriptor<FinancialTransaction>()).count)
+        XCTAssertEqual(Decimal.zero, advanceCase.participants.first?.remainingAmount)
+
+        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+        XCTAssertEqual(1, repayments.count)
+        XCTAssertTrue(AdvanceService.isManualDebtSettlement(note: try XCTUnwrap(repayments.first?.note)))
+        XCTAssertNil(repayments.first?.linkedTransferGroupID)
+        XCTAssertNil(repayments.first?.receivedAccount)
+
+        let semanticBalances = DebtSettlementBalanceService.balances(
+            for: debtAccount,
+            transactions: try modelContext.fetch(FetchDescriptor<FinancialTransaction>()),
+            advanceCases: [advanceCase],
+            modelContext: modelContext
+        )
+        XCTAssertTrue(semanticBalances.isEmpty)
+    }
+
     func testCrossCurrencyAdvanceRepayment_preservesActualCurrencyAndManualSettlementAmount() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -92,10 +92,23 @@ data class MutualDebtOffsetResult(
     val repaymentCount: Int
 )
 
+enum class ManualDebtSettlementDirection {
+    Receivable,
+    Payable
+}
+
+data class ManualDebtSettlementResult(
+    val settlementId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val repaymentCount: Int
+)
+
 private const val RECURRING_STATUS_PENDING = "Pending"
 private const val RECURRING_STATUS_CONFIRMED = "Confirmed"
 private const val RECURRING_STATUS_SKIPPED = "Skipped"
 const val MUTUAL_DEBT_OFFSET_MARKER_PREFIX = "[債務抵銷:"
+const val MANUAL_DEBT_SETTLEMENT_MARKER_PREFIX = "[跨幣種平賬:"
 
 class AccountingRepository(
     private val database: AIAccountingDatabase,
@@ -225,6 +238,47 @@ class AccountingRepository(
         }
     }
 
+    suspend fun recordManualDebtSettlement(
+        debtAccountId: UUID,
+        currencyCode: String,
+        direction: ManualDebtSettlementDirection,
+        amount: BigDecimal,
+        date: Instant = Instant.now(),
+        note: String = ""
+    ): ManualDebtSettlementResult {
+        return database.withTransaction {
+            val debtAccount = accountDao.getAccount(debtAccountId) ?: error("找不到債務對象")
+            val normalizedAmount = amount.abs()
+            require(normalizedAmount > BigDecimal.ZERO) { "請輸入有效平賬金額" }
+
+            val offsetable = offsetableParticipants(debtAccountId, currencyCode, advanceDao.getAllCasesWithDetails())
+            val entries = when (direction) {
+                ManualDebtSettlementDirection.Receivable -> offsetable.receivable
+                ManualDebtSettlementDirection.Payable -> offsetable.payable
+            }
+            val availableAmount = entries.fold(BigDecimal.ZERO) { acc, entry -> acc + entry.remaining }
+            require(normalizedAmount <= availableAmount) { "平賬金額不能超過可結清金額" }
+
+            val now = Instant.now()
+            val settlementId = UUID.randomUUID()
+            val trimmedNote = note.trim()
+            val marker = "$MANUAL_DEBT_SETTLEMENT_MARKER_PREFIX$settlementId]"
+            val defaultNote = when (direction) {
+                ManualDebtSettlementDirection.Receivable -> "手動結清 ${debtAccount.name} 欠你的 $currencyCode 代墊餘額"
+                ManualDebtSettlementDirection.Payable -> "手動結清你欠 ${debtAccount.name} 的 $currencyCode 代墊餘額"
+            }
+            val finalNote = if (trimmedNote.isBlank()) "$marker $defaultNote" else "$marker $trimmedNote"
+            val repaymentCount = applyMutualDebtOffset(normalizedAmount, entries, date, finalNote, now)
+
+            ManualDebtSettlementResult(
+                settlementId = settlementId,
+                amount = normalizedAmount,
+                currencyCode = currencyCode,
+                repaymentCount = repaymentCount
+            )
+        }
+    }
+
     suspend fun buildDataHealthReport(): DataHealthReport {
         return DataHealthChecker.run(
             DataHealthSnapshot(
@@ -322,6 +376,20 @@ class AccountingRepository(
             if (end <= MUTUAL_DEBT_OFFSET_MARKER_PREFIX.length) return null
             return runCatching {
                 UUID.fromString(trimmed.substring(MUTUAL_DEBT_OFFSET_MARKER_PREFIX.length, end))
+            }.getOrNull()
+        }
+
+        fun isManualDebtSettlement(note: String): Boolean {
+            return note.trim().startsWith(MANUAL_DEBT_SETTLEMENT_MARKER_PREFIX)
+        }
+
+        fun manualDebtSettlementId(note: String): UUID? {
+            val trimmed = note.trim()
+            if (!trimmed.startsWith(MANUAL_DEBT_SETTLEMENT_MARKER_PREFIX)) return null
+            val end = trimmed.indexOf(']')
+            if (end <= MANUAL_DEBT_SETTLEMENT_MARKER_PREFIX.length) return null
+            return runCatching {
+                UUID.fromString(trimmed.substring(MANUAL_DEBT_SETTLEMENT_MARKER_PREFIX.length, end))
             }.getOrNull()
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -29,7 +30,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
 import org.duckdns.lhfser.aiaccounting.core.model.AccountType
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
@@ -38,6 +41,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
+import org.duckdns.lhfser.aiaccounting.data.repository.ManualDebtSettlementDirection
 import org.duckdns.lhfser.aiaccounting.data.repository.MutualDebtOffsetCandidate
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
@@ -89,6 +93,17 @@ private data class TimelineItem(
     val tint: Color
 )
 
+private data class ManualSettlementDraft(
+    val account: AccountEntity,
+    val currencyCode: String,
+    val direction: ManualDebtSettlementDirection,
+    val suggestedAmount: BigDecimal,
+    val maximumAmount: BigDecimal,
+    val visibleBalance: BigDecimal
+) {
+    val id: String = "${account.id}-$currencyCode-$direction"
+}
+
 @Composable
 fun SettlementCenterScreen(
     onOpenAdvanceCase: (String) -> Unit,
@@ -107,6 +122,7 @@ fun SettlementCenterScreen(
     val rateSnapshot = currencyService.rates
     var mode by rememberSaveable { mutableStateOf(SettlementMode.People) }
     var selectedPerson by remember { mutableStateOf<SettlementPersonSummary?>(null) }
+    var manualSettlementDraft by remember { mutableStateOf<ManualSettlementDraft?>(null) }
     var timelineFilter by remember { mutableStateOf<SettlementPersonSummary?>(null) }
     var message by remember { mutableStateOf<String?>(null) }
 
@@ -281,6 +297,14 @@ fun SettlementCenterScreen(
                             }
                         }) { Text("抵銷 ${candidate.amount.asCurrencyText(candidate.currencyCode)}") }
                     }
+                    buildManualSettlementDrafts(summary, advanceCases).forEach { draft ->
+                        TextButton(onClick = {
+                            selectedPerson = null
+                            manualSettlementDraft = draft
+                        }) {
+                            Text("${manualSettlementLabel(draft.direction, draft.currencyCode)} ${draft.suggestedAmount.asCurrencyText(draft.currencyCode)}")
+                        }
+                    }
                     if (summary.netInMainCurrency.signum() > 0) {
                         TextButton(onClick = {
                             selectedPerson = null
@@ -313,6 +337,31 @@ fun SettlementCenterScreen(
         )
     }
 
+    manualSettlementDraft?.let { draft ->
+        ManualDebtSettlementDialog(
+            draft = draft,
+            onDismiss = { manualSettlementDraft = null },
+            onConfirm = { amount, note ->
+                manualSettlementDraft = null
+                scope.launch {
+                    runCatching {
+                        repository.recordManualDebtSettlement(
+                            debtAccountId = draft.account.id,
+                            currencyCode = draft.currencyCode,
+                            direction = draft.direction,
+                            amount = amount,
+                            note = note
+                        )
+                    }.onSuccess {
+                        message = "已跨幣種平賬 ${it.amount.asCurrencyText(it.currencyCode)}。"
+                    }.onFailure {
+                        message = it.message ?: "跨幣種平賬失敗。"
+                    }
+                }
+            }
+        )
+    }
+
     message?.let { text ->
         AlertDialog(
             onDismissRequest = { message = null },
@@ -323,6 +372,75 @@ fun SettlementCenterScreen(
             }
         )
     }
+}
+
+@Composable
+private fun ManualDebtSettlementDialog(
+    draft: ManualSettlementDraft,
+    onDismiss: () -> Unit,
+    onConfirm: (BigDecimal, String) -> Unit
+) {
+    var amountText by remember(draft.id) { mutableStateOf(draft.suggestedAmount.stripTrailingZeros().toPlainString()) }
+    var note by remember(draft.id) { mutableStateOf("") }
+    var errorText by remember(draft.id) { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("跨幣種平賬") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text("對象：${draft.account.name}", style = MaterialTheme.typography.bodyMedium)
+                Text("方向：${manualSettlementLabel(draft.direction, draft.currencyCode)}", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    "目前顯示淨額：${draft.visibleBalance.asCurrencyText(draft.currencyCode)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    "最多可結清：${draft.maximumAmount.asCurrencyText(draft.currencyCode)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    "這不會建立現金或銀行交易，也不會計入收入/支出，只會留下代墊審計紀錄。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TextField(
+                    value = amountText,
+                    onValueChange = { amountText = it },
+                    label = { Text("平賬金額") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                TextField(
+                    value = note,
+                    onValueChange = { note = it },
+                    label = { Text("備註（可選）") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                errorText?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val amount = runCatching { BigDecimal(amountText.trim()) }.getOrNull()
+                when {
+                    amount == null || amount <= BigDecimal.ZERO -> errorText = "請輸入有效金額。"
+                    amount > draft.maximumAmount -> errorText = "平賬金額不能超過可結清金額。"
+                    else -> onConfirm(amount, note)
+                }
+            }) {
+                Text("確認")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("取消") }
+        }
+    )
 }
 
 @Composable
@@ -558,7 +676,10 @@ private fun buildTimelineItems(
             tint = Color(0xFFFF9800)
         )
         advanceCase.repayments
-            .filter { !AccountingRepository.isMutualDebtOffset(it.note) }
+            .filter {
+                !AccountingRepository.isMutualDebtOffset(it.note) &&
+                    !AccountingRepository.isManualDebtSettlement(it.note)
+            }
             .forEach { repayment ->
             val participant = advanceCase.participants.firstOrNull { it.id == repayment.participantId }
             items += TimelineItem(
@@ -573,6 +694,33 @@ private fun buildTimelineItems(
             )
         }
     }
+
+    advanceCases
+        .flatMap { advanceCase -> advanceCase.repayments.map { repayment -> advanceCase to repayment } }
+        .mapNotNull { (advanceCase, repayment) ->
+            AccountingRepository.manualDebtSettlementId(repayment.note)?.let { settlementId ->
+                settlementId to (advanceCase to repayment)
+            }
+        }
+        .groupBy { it.first }
+        .forEach { (settlementId, grouped) ->
+            val repayments = grouped.map { it.second.second }
+            val firstCase = grouped.firstOrNull()?.second?.first
+            val first = repayments.firstOrNull()
+            if (first != null) {
+                val participant = firstCase?.participants?.firstOrNull { it.id == first.participantId }
+                items += TimelineItem(
+                    id = "manual-settlement-$settlementId",
+                    relatedAccountId = participant?.debtAccountId,
+                    date = first.date,
+                    title = "跨幣種平賬",
+                    subtitle = participant?.name ?: "手動結清代墊餘額",
+                    amount = repayments.sumOfBigDecimal { it.normalizedAmount },
+                    currencyCode = first.currencyCode,
+                    tint = Color(0xFF3F51B5)
+                )
+            }
+        }
 
     advanceCases
         .flatMap { advanceCase -> advanceCase.repayments.map { repayment -> advanceCase to repayment } }
@@ -659,6 +807,63 @@ private fun topOutstandingParticipantText(advanceCase: AdvanceCaseWithDetails): 
     val outstanding = participant?.let { (it.owedAmount - it.repaidAmount).max(BigDecimal.ZERO) } ?: return null
     if (outstanding <= BigDecimal.ZERO) return null
     return "主要未清：${participant.name} ${outstanding.asCurrencyText(advanceCase.advanceCase.currencyCode)}"
+}
+
+private fun buildManualSettlementDrafts(
+    summary: SettlementPersonSummary,
+    advanceCases: List<AdvanceCaseWithDetails>
+): List<ManualSettlementDraft> {
+    return summary.balances.mapNotNull { balance ->
+        val visibleAmount = balance.amount.abs()
+        if (visibleAmount <= BigDecimal.ZERO) return@mapNotNull null
+        val direction = if (balance.amount.signum() > 0) {
+            ManualDebtSettlementDirection.Receivable
+        } else {
+            ManualDebtSettlementDirection.Payable
+        }
+        val maximum = manualSettlementAvailableAmount(summary.account, balance.currency, direction, advanceCases)
+        if (maximum <= BigDecimal.ZERO) return@mapNotNull null
+        ManualSettlementDraft(
+            account = summary.account,
+            currencyCode = balance.currency,
+            direction = direction,
+            suggestedAmount = visibleAmount.min(maximum),
+            maximumAmount = maximum,
+            visibleBalance = balance.amount
+        )
+    }
+}
+
+private fun manualSettlementAvailableAmount(
+    account: AccountEntity,
+    currencyCode: String,
+    direction: ManualDebtSettlementDirection,
+    advanceCases: List<AdvanceCaseWithDetails>
+): BigDecimal {
+    return advanceCases
+        .filter { it.advanceCase.currencyCode == currencyCode }
+        .flatMap { advanceCase ->
+            val isPayableCase = advanceCase.advanceCase.payerAccountId == null
+            val directionMatches = when (direction) {
+                ManualDebtSettlementDirection.Receivable -> !isPayableCase
+                ManualDebtSettlementDirection.Payable -> isPayableCase
+            }
+            if (!directionMatches) {
+                emptyList()
+            } else {
+                advanceCase.participants
+                    .filter { it.debtAccountId == account.id }
+                    .map { (it.owedAmount - it.repaidAmount).max(BigDecimal.ZERO) }
+            }
+        }
+        .sumOfBigDecimal { it }
+}
+
+private fun manualSettlementLabel(direction: ManualDebtSettlementDirection, currencyCode: String): String {
+    return when (direction) {
+        ManualDebtSettlementDirection.Receivable -> "結清對方欠你的 $currencyCode"
+        ManualDebtSettlementDirection.Payable -> "結清你欠對方的 $currencyCode"
+    }
 }
 
 private fun latestActivityDate(

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -19,6 +19,7 @@ import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.ManualDebtSettlementDirection
 import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -295,6 +296,73 @@ class BackupRoundTripTest {
         val rolledBackPayable = checkNotNull(repository.getAdvanceCase(payableCaseId))
         assertEquals(BigDecimal("100"), rolledBackReceivable.participants.single().owedAmount - rolledBackReceivable.participants.single().repaidAmount)
         assertEquals(BigDecimal("40"), rolledBackPayable.participants.single().owedAmount - rolledBackPayable.participants.single().repaidAmount)
+    }
+
+    @Test
+    fun manualDebtSettlement_closesSingleCurrencyAdvanceWithoutTransactions() = runBlocking {
+        val ownAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "JPY Wallet",
+            currency = "JPY",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val debtAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "TKL",
+            currency = "HKD",
+            type = AccountType.Debt,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 1,
+            isArchived = false
+        )
+        database.accountDao().upsertAll(listOf(ownAccount, debtAccount))
+
+        val date = Instant.parse("2026-03-21T12:00:00Z")
+        val caseId = repository.createAdvanceCase(
+            title = "豬骨拉麵",
+            date = date,
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = ownAccount,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("1230"))),
+            isBorrowedByMe = false
+        )
+
+        val beforeTransactionCount = database.transactionDao().getAll().size
+        val result = repository.recordManualDebtSettlement(
+            debtAccountId = debtAccount.id,
+            currencyCode = "JPY",
+            direction = ManualDebtSettlementDirection.Receivable,
+            amount = BigDecimal("1230"),
+            date = date.plusSeconds(600),
+            note = "手動結清日元餘額"
+        )
+
+        assertEquals(BigDecimal("1230"), result.amount)
+        assertEquals(1, result.repaymentCount)
+        assertEquals(beforeTransactionCount, database.transactionDao().getAll().size)
+
+        val advanceCase = checkNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(BigDecimal.ZERO, advanceCase.participants.single().owedAmount - advanceCase.participants.single().repaidAmount)
+        assertTrue(advanceCase.repayments.single().note.contains("[跨幣種平賬:"))
+        assertNull(advanceCase.repayments.single().linkedTransferGroupId)
+        assertNull(advanceCase.repayments.single().receivedAccountId)
+
+        val semanticBalances = DebtSettlementBalanceCalculator.balancesFor(
+            debtAccount,
+            database.transactionDao().getAllWithDetails(),
+            listOf(advanceCase)
+        )
+        assertTrue(semanticBalances.isEmpty())
+
+        val exported = BackupJsonAdapter.gson.fromJson(repository.exportBackupJson(), FullBackupData::class.java)
+        assertEquals(1, exported.advanceRepayments?.count { it.note?.contains("[跨幣種平賬:") == true })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add manual cross-currency settlement markers for advance repayments on iOS and Android
- expose settlement actions from the settlement centre with a confirmation amount dialog/sheet
- keep manual settlements out of cash/bank transactions and income/expense reports
- add iOS and Android tests proving settlement closes advance balances without creating transactions

## Test Plan
- xcodebuild test -project '/Users/lhf/Documents/AI 記帳/AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO
- cd android && ./gradlew testDebugUnitTest assembleDebug

## Notes
- Generated repaired local backup for TKL data at /Users/lhf/Downloads/Backup 下午10.15.53 - TKL修復.json; this file is not committed.