### PR TITLE
Repair understated advance repayment totals

### DIFF
--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
     @State private var idleBackupTask: Task<Void, Never>?
     @State private var showingUserGuide = false
     @State private var initialGuideChecked = false
+    @State private var didReconcileAdvanceRepayments = false
 #if DEBUG
     @State private var uiTestSeeded = false
 #endif
@@ -176,6 +177,18 @@ struct ContentView: View {
         .task(id: recurringSyncToken) {
             guard !isRunningXCTest else { return }
             syncRecurringOccurrences()
+        }
+        .task {
+            guard !isRunningXCTest, !didReconcileAdvanceRepayments else { return }
+            didReconcileAdvanceRepayments = true
+            do {
+                let result = try AdvanceService.reconcileUnderstatedRepaymentTotals(modelContext: modelContext)
+                if result.updatedParticipantCount > 0 {
+                    print("✅ 已修復代墊還款累計 \(result.updatedParticipantCount) 筆")
+                }
+            } catch {
+                print("⚠️ 修復代墊還款累計失敗: \(error)")
+            }
         }
     }
 

--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -84,6 +84,11 @@ enum AdvanceService {
         let removedInflatedAccountTransactionCount: Int
     }
 
+    struct RepaymentReconciliationResult {
+        let checkedParticipantCount: Int
+        let updatedParticipantCount: Int
+    }
+
     struct MutualDebtOffsetCandidate: Identifiable {
         let id = UUID()
         let debtAccount: Account
@@ -126,6 +131,50 @@ enum AdvanceService {
         advanceCase.participants.reduce(Decimal.zero) { partial, participant in
             partial + participant.remainingAmount
         }
+    }
+
+    @MainActor
+    static func reconcileUnderstatedRepaymentTotals(
+        modelContext: ModelContext
+    ) throws -> RepaymentReconciliationResult {
+        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+        let groupedTotals = Dictionary(grouping: repayments.compactMap { repayment -> (UUID, Decimal)? in
+            guard let participantID = repayment.participant?.id,
+                  repayment.normalizedAmount > 0 else {
+                return nil
+            }
+            return (participantID, repayment.normalizedAmount)
+        }, by: \.0)
+        .mapValues { entries in
+            entries.reduce(Decimal.zero) { $0 + $1.1 }
+        }
+
+        guard !groupedTotals.isEmpty else {
+            return RepaymentReconciliationResult(
+                checkedParticipantCount: 0,
+                updatedParticipantCount: 0
+            )
+        }
+
+        let participants = try modelContext.fetch(FetchDescriptor<AdvanceParticipant>())
+        var updatedCount = 0
+        for participant in participants {
+            guard let recordedTotal = groupedTotals[participant.id] else { continue }
+            let expectedTotal = min(recordedTotal, participant.owedAmount)
+            guard expectedTotal - participant.repaidAmount > roundingTolerance else { continue }
+            participant.repaidAmount = expectedTotal
+            participant.updatedAt = Date()
+            participant.advanceCase?.updatedAt = Date()
+            updatedCount += 1
+        }
+
+        if updatedCount > 0 {
+            try modelContext.save()
+        }
+        return RepaymentReconciliationResult(
+            checkedParticipantCount: groupedTotals.count,
+            updatedParticipantCount: updatedCount
+        )
     }
 
     static func isMutualDebtOffset(note: String) -> Bool {

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -683,6 +683,8 @@ class BackupManager: NSObject, ObservableObject {
             }
         }
 
+        try modelContext.save()
+        _ = try AdvanceService.reconcileUnderstatedRepaymentTotals(modelContext: modelContext)
         try BudgetHistoryService.shared.syncAll(modelContext: modelContext, currencyService: CurrencyService.shared)
         try modelContext.save()
     }

--- a/AI 記帳/Services/DataHealthCheckService.swift
+++ b/AI 記帳/Services/DataHealthCheckService.swift
@@ -317,6 +317,33 @@ enum DataHealthCheckService {
                 )
             )
         }
+
+        let repaymentTotals = Dictionary(grouping: repayments.compactMap { repayment -> (UUID, Decimal)? in
+            guard let participantID = repayment.participant?.id,
+                  repayment.normalizedAmount > 0 else {
+                return nil
+            }
+            return (participantID, repayment.normalizedAmount)
+        }, by: \.0)
+        .mapValues { entries in
+            entries.reduce(Decimal.zero) { $0 + $1.1 }
+        }
+        let tolerance = Decimal(string: "0.0001") ?? 0.0001
+        let understatedRepaymentTotals = participants.filter { participant in
+            guard let repaymentTotal = repaymentTotals[participant.id] else { return false }
+            let expected = min(repaymentTotal, participant.owedAmount)
+            return expected - participant.repaidAmount > tolerance
+        }
+        if !understatedRepaymentTotals.isEmpty {
+            issues.append(
+                HealthIssue(
+                    severity: .warning,
+                    title: "代墊還款累計偏低",
+                    detail: "共有 \(understatedRepaymentTotals.count) 位對象的已還金額低於還款紀錄總和。",
+                    recommendation: "請執行「修復代墊還款累計」，再確認結算中心餘額。"
+                )
+            )
+        }
         
         let emptyCurrencyCases = cases.filter { $0.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
         if !emptyCurrencyCases.isEmpty {

--- a/AI 記帳/Views/Tools/DataHealthCheckView.swift
+++ b/AI 記帳/Views/Tools/DataHealthCheckView.swift
@@ -40,6 +40,15 @@ struct DataHealthCheckView: View {
                 Text("移除舊版他人代墊我誤寫入自己帳戶的入帳，改為借貸帳戶支出。")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Button(isRunning ? "處理中..." : "修復代墊還款累計") {
+                    repairAdvanceRepaymentTotals()
+                }
+                .disabled(isRunning)
+
+                Text("依還款紀錄補回被低估的已還金額，不會自動降低既有已還金額。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             legacyDebtIncomeSection
@@ -234,6 +243,19 @@ struct DataHealthCheckView: View {
             alertMessage = "修復失敗：\(error.localizedDescription)"
         }
 
+        isRunning = false
+        showingAlert = true
+    }
+
+    private func repairAdvanceRepaymentTotals() {
+        isRunning = true
+        do {
+            let result = try AdvanceService.reconcileUnderstatedRepaymentTotals(modelContext: modelContext)
+            report = DataHealthCheckService.run(modelContext: modelContext)
+            alertMessage = "已檢查 \(result.checkedParticipantCount) 位有還款紀錄的對象，修復 \(result.updatedParticipantCount) 位。"
+        } catch {
+            alertMessage = "修復失敗：\(error.localizedDescription)"
+        }
         isRunning = false
         showingAlert = true
     }

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -480,6 +480,52 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertTrue(semanticBalances.isEmpty)
     }
 
+    func testRepaymentReconciliation_repairsUnderstatedParticipantTotal() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-06-05T12:00:00Z"))
+
+        let debtAccount = Account(name: "TKL", currency: "HKD", type: .debt, baseBalance: 0)
+        let advanceCase = AdvanceCase(
+            title: "とり天定食",
+            date: date,
+            currencyCode: "JPY"
+        )
+        let participant = AdvanceParticipant(
+            name: "TKL",
+            owedAmount: 1510,
+            repaidAmount: 0,
+            advanceCase: advanceCase,
+            debtAccount: debtAccount
+        )
+        let repayment = AdvanceRepayment(
+            amount: 75,
+            currencyCode: "HKD",
+            normalizedAmount: 1510,
+            date: date,
+            note: "跨幣種還款",
+            advanceCase: advanceCase,
+            participant: participant
+        )
+        modelContext.insert(debtAccount)
+        modelContext.insert(advanceCase)
+        modelContext.insert(participant)
+        modelContext.insert(repayment)
+        try modelContext.save()
+
+        let reportBeforeRepair = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertTrue(reportBeforeRepair.issues.contains { $0.title == "代墊還款累計偏低" })
+
+        let result = try AdvanceService.reconcileUnderstatedRepaymentTotals(modelContext: modelContext)
+
+        XCTAssertEqual(1, result.checkedParticipantCount)
+        XCTAssertEqual(1, result.updatedParticipantCount)
+        XCTAssertEqual(Decimal(1510), participant.repaidAmount)
+        XCTAssertEqual(Decimal.zero, participant.remainingAmount)
+        let reportAfterRepair = DataHealthCheckService.run(modelContext: modelContext)
+        XCTAssertFalse(reportAfterRepair.issues.contains { $0.title == "代墊還款累計偏低" })
+    }
+
     func testCrossCurrencyAdvanceRepayment_preservesActualCurrencyAndManualSettlementAmount() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)


### PR DESCRIPTION
## Summary
- reconcile participant repayment totals from persisted repayment records on launch and after backup restore
- surface and repair understated repayment totals in data health checks
- add regression coverage for cross-currency repayments whose denormalized total was lost

## Root cause
The repayment records retained their normalized amounts, but two imported participants had `repaidAmount = 0`. Settlement rendering trusted that denormalized field and incorrectly showed fully settled JPY advances as outstanding.

## Verification
- `xcodebuild test -project "AI 記帳.xcodeproj" -scheme "AI 記帳" -destination "platform=iOS Simulator,name=iPhone 13" CODE_SIGNING_ALLOWED=NO`
- 16 tests passed
- installed over the existing app on the connected iPhone 13 without deleting its data
- post-launch database check: repayment mismatches 2 -> 0
- TKL semantic balance: HKD -24; no JPY balance