### PR TITLE
Extract cross-platform report aggregation

### DIFF
--- a/AI 記帳/Services/ReportAggregationService.swift
+++ b/AI 記帳/Services/ReportAggregationService.swift
@@ -1,0 +1,267 @@
+import Foundation
+
+enum ReportFlow {
+    case expense
+    case income
+
+    var transactionType: TransactionType {
+        switch self {
+        case .expense: return .expense
+        case .income: return .income
+        }
+    }
+}
+
+enum ReportGroupingMode {
+    case category
+    case tag
+}
+
+enum ReportEstimateStatus: Equatable {
+    case exact
+    case live
+    case cached
+    case partial
+    case unavailable
+
+    var label: String? {
+        switch self {
+        case .exact:
+            return nil
+        case .live:
+            return "即時匯率"
+        case .cached:
+            return "上次匯率"
+        case .partial, .unavailable:
+            return "估算不完整"
+        }
+    }
+}
+
+struct ReportConversion {
+    let amount: Decimal
+    let status: ReportEstimateStatus
+}
+
+protocol ReportCurrencyConverting {
+    var mainCurrency: String { get }
+    func estimateInMainCurrency(amount: Decimal, from currencyCode: String) -> ReportConversion?
+}
+
+struct ReportTransactionSnapshot {
+    let id: UUID
+    let amount: Decimal
+    let currencyCode: String
+    let date: Date
+    let type: TransactionType
+    let categoryID: UUID?
+    let categoryName: String?
+    let categoryColorHex: String?
+    let tagNames: [String]
+}
+
+struct ReportCurrencyTotal: Equatable {
+    let currencyCode: String
+    let amount: Decimal
+}
+
+struct ReportSlice: Identifiable, Equatable {
+    let key: String
+    let name: String
+    let categoryColorHex: String?
+    let estimatedAmount: Decimal
+    let originalCurrencyTotals: [ReportCurrencyTotal]
+    let estimateStatus: ReportEstimateStatus
+    let transactionIDs: [UUID]
+
+    var id: String { key }
+
+    var detailSummary: ReportDetailSummary {
+        ReportDetailSummary(
+            estimatedAmount: estimatedAmount,
+            originalCurrencyTotals: originalCurrencyTotals,
+            estimateStatus: estimateStatus,
+            transactionIDs: transactionIDs
+        )
+    }
+}
+
+struct ReportDetailSummary: Equatable {
+    let estimatedAmount: Decimal
+    let originalCurrencyTotals: [ReportCurrencyTotal]
+    let estimateStatus: ReportEstimateStatus
+    let transactionIDs: [UUID]
+
+    var transactionCount: Int { transactionIDs.count }
+}
+
+struct ReportAggregationRequest {
+    let transactions: [ReportTransactionSnapshot]
+    let flow: ReportFlow
+    let grouping: ReportGroupingMode
+    let startDate: Date?
+    let endDate: Date?
+    let tagFilter: String?
+
+    init(
+        transactions: [ReportTransactionSnapshot],
+        flow: ReportFlow,
+        grouping: ReportGroupingMode,
+        startDate: Date?,
+        endDate: Date?,
+        tagFilter: String? = nil
+    ) {
+        self.transactions = transactions
+        self.flow = flow
+        self.grouping = grouping
+        self.startDate = startDate
+        self.endDate = endDate
+        self.tagFilter = tagFilter
+    }
+}
+
+struct ReportAggregationResult {
+    let slices: [ReportSlice]
+
+    var totalEstimatedAmount: Decimal {
+        slices.reduce(Decimal.zero) { $0 + $1.estimatedAmount }
+    }
+}
+
+enum ReportAggregationService {
+    static func aggregate(
+        request: ReportAggregationRequest,
+        currencyConverter: ReportCurrencyConverting
+    ) -> ReportAggregationResult {
+        let filtered = request.transactions.filter { transaction in
+            guard transaction.type == request.flow.transactionType else { return false }
+            if let startDate = request.startDate, transaction.date < startDate { return false }
+            if let endDate = request.endDate, transaction.date >= endDate { return false }
+            if let tagFilter = request.tagFilter {
+                if tagFilter == "無標籤" {
+                    return transaction.tagNames.isEmpty
+                }
+                return transaction.tagNames.contains(tagFilter)
+            }
+            return true
+        }
+
+        let grouped: [String: [ReportTransactionSnapshot]]
+        switch request.grouping {
+        case .category:
+            grouped = Dictionary(grouping: filtered) { transaction in
+                transaction.categoryID?.uuidString ?? "uncategorized"
+            }
+        case .tag:
+            var tagGroups: [String: [ReportTransactionSnapshot]] = [:]
+            for transaction in filtered {
+                if transaction.tagNames.isEmpty {
+                    tagGroups["無標籤", default: []].append(transaction)
+                } else {
+                    for tagName in transaction.tagNames {
+                        tagGroups[tagName, default: []].append(transaction)
+                    }
+                }
+            }
+            grouped = tagGroups
+        }
+
+        let slices = grouped.map { key, transactions in
+            makeSlice(
+                key: key,
+                transactions: transactions,
+                grouping: request.grouping,
+                currencyConverter: currencyConverter
+            )
+        }
+        .sorted {
+            if $0.estimatedAmount == $1.estimatedAmount {
+                return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
+            return $0.estimatedAmount > $1.estimatedAmount
+        }
+
+        return ReportAggregationResult(slices: slices)
+    }
+
+    private static func makeSlice(
+        key: String,
+        transactions: [ReportTransactionSnapshot],
+        grouping: ReportGroupingMode,
+        currencyConverter: ReportCurrencyConverting
+    ) -> ReportSlice {
+        var estimatedAmount = Decimal.zero
+        var originalTotals: [String: Decimal] = [:]
+        var conversionStatuses: [ReportEstimateStatus] = []
+        var unavailableCount = 0
+
+        for transaction in transactions {
+            let amount = abs(transaction.amount)
+            let currencyCode = transaction.currencyCode.uppercased()
+            originalTotals[currencyCode, default: 0] += amount
+
+            if let conversion = currencyConverter.estimateInMainCurrency(
+                amount: amount,
+                from: currencyCode
+            ) {
+                estimatedAmount += conversion.amount
+                conversionStatuses.append(conversion.status)
+            } else {
+                unavailableCount += 1
+            }
+        }
+
+        let status: ReportEstimateStatus
+        if unavailableCount == transactions.count {
+            status = .unavailable
+        } else if unavailableCount > 0 {
+            status = .partial
+        } else if conversionStatuses.contains(.cached) {
+            status = .cached
+        } else if conversionStatuses.contains(.live) {
+            status = .live
+        } else {
+            status = .exact
+        }
+
+        let first = transactions.first
+        let name: String
+        let colorHex: String?
+        switch grouping {
+        case .category:
+            name = first?.categoryName ?? "未分類"
+            colorHex = first?.categoryColorHex
+        case .tag:
+            name = key
+            colorHex = nil
+        }
+
+        return ReportSlice(
+            key: key,
+            name: name,
+            categoryColorHex: colorHex,
+            estimatedAmount: estimatedAmount,
+            originalCurrencyTotals: originalTotals
+                .sorted { $0.key < $1.key }
+                .map { ReportCurrencyTotal(currencyCode: $0.key, amount: $0.value) },
+            estimateStatus: status,
+            transactionIDs: transactions
+                .sorted { $0.date > $1.date }
+                .map(\.id)
+        )
+    }
+}
+
+extension CurrencyService: ReportCurrencyConverting {
+    func estimateInMainCurrency(amount: Decimal, from currencyCode: String) -> ReportConversion? {
+        let normalizedCurrency = currencyCode.uppercased()
+        if normalizedCurrency == mainCurrency.uppercased() {
+            return ReportConversion(amount: amount, status: .exact)
+        }
+        guard let estimate = estimate(amount: amount, from: normalizedCurrency, to: mainCurrency) else {
+            return nil
+        }
+        let status: ReportEstimateStatus = estimate.source == .cached ? .cached : .live
+        return ReportConversion(amount: estimate.amount, status: status)
+    }
+}

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -395,12 +395,17 @@ struct ChartsView: View {
     }
 }
 
+@MainActor
 private struct ChartsRenderState {
-    let filteredTransactions: [FinancialTransaction]
     let currentData: [ChartsView.ChartData]
     let budgetAlerts: [BudgetStatus]
 
+    private let snapshots: [ReportTransactionSnapshot]
+    private let transactionsByID: [UUID: FinancialTransaction]
     private let currencyService: CurrencyService
+    private let flow: ReportFlow
+    private let startDate: Date?
+    private let endDate: Date?
 
     init(
         transactions: [FinancialTransaction],
@@ -413,20 +418,32 @@ private struct ChartsRenderState {
         chartMode: ChartsView.ChartMode,
         flowMode: ChartsView.FlowMode
     ) {
-        let filteredTransactions = Self.filteredTransactions(
-            from: transactions,
-            filterType: filterType,
+        let interval = filterType.dateInterval(
             selectedDate: selectedDate,
             customStartDate: customStartDate,
-            customEndDate: customEndDate,
-            flowMode: flowMode
+            customEndDate: customEndDate
+        )
+        let snapshots = transactions.map(ReportTransactionSnapshot.init)
+        let transactionsByID = Dictionary(
+            uniqueKeysWithValues: transactions.map { ($0.id, $0) }
+        )
+        let flow: ReportFlow = flowMode == .expense ? .expense : .income
+        let grouping: ReportGroupingMode = chartMode == .category ? .category : .tag
+        let aggregation = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: snapshots,
+                flow: flow,
+                grouping: grouping,
+                startDate: interval?.start,
+                endDate: interval?.end
+            ),
+            currencyConverter: currencyService
         )
 
-        self.filteredTransactions = filteredTransactions
-        self.currentData = Self.currentData(
-            from: filteredTransactions,
-            chartMode: chartMode,
-            currencyService: currencyService
+        self.currentData = Self.chartData(
+            from: aggregation.slices,
+            transactionsByID: transactionsByID,
+            chartMode: chartMode
         )
         self.budgetAlerts = BudgetService.statuses(
             for: BudgetService.monthKey(from: Date()),
@@ -435,159 +452,85 @@ private struct ChartsRenderState {
             currencyService: currencyService
         )
         .filter { $0.ratio >= 1 }
+        self.snapshots = snapshots
+        self.transactionsByID = transactionsByID
         self.currencyService = currencyService
+        self.flow = flow
+        self.startDate = interval?.start
+        self.endDate = interval?.end
     }
 
     func categoryBreakdown(for tagName: String?) -> [ChartsView.ChartData] {
         guard let tagName else { return [] }
 
-        let tagTransactions = filteredTransactions.filter { tx in
-            if tagName == "無標籤" { return tx.tags.isEmpty }
-            return tx.tags.contains { $0.name == tagName }
-        }
-        return Self.categoryBreakdown(
-            from: tagTransactions,
-            currencyService: currencyService
+        let aggregation = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: snapshots,
+                flow: flow,
+                grouping: .category,
+                startDate: startDate,
+                endDate: endDate,
+                tagFilter: tagName
+            ),
+            currencyConverter: currencyService
+        )
+        return Self.chartData(
+            from: aggregation.slices,
+            transactionsByID: transactionsByID,
+            chartMode: .category
         )
     }
 
-    private static func filteredTransactions(
-        from transactions: [FinancialTransaction],
-        filterType: FilterType,
-        selectedDate: Date,
-        customStartDate: Date,
-        customEndDate: Date,
-        flowMode: ChartsView.FlowMode
-    ) -> [FinancialTransaction] {
-        return transactions.filter { tx in
-            if tx.type != flowMode.transactionType { return false }
-            return filterType.matches(
-                date: tx.date,
-                selectedDate: selectedDate,
-                customStartDate: customStartDate,
-                customEndDate: customEndDate
-            )
-        }
-    }
-
-    private static func currentData(
-        from transactions: [FinancialTransaction],
-        chartMode: ChartsView.ChartMode,
-        currencyService: CurrencyService
+    private static func chartData(
+        from slices: [ReportSlice],
+        transactionsByID: [UUID: FinancialTransaction],
+        chartMode: ChartsView.ChartMode
     ) -> [ChartsView.ChartData] {
-        switch chartMode {
-        case .category:
-            return categoryBreakdown(from: transactions, currencyService: currencyService)
-        case .tag:
-            return tagBreakdown(from: transactions, currencyService: currencyService)
-        }
-    }
-
-    private static func categoryBreakdown(
-        from transactions: [FinancialTransaction],
-        currencyService: CurrencyService
-    ) -> [ChartsView.ChartData] {
-        let grouped = Dictionary(grouping: transactions) { $0.category?.id.uuidString ?? "uncategorized" }
-        let mapped = grouped.map { item -> ChartsView.ChartData in
-            let aggregate = currencyAggregate(from: item.value, currencyService: currencyService)
-            let category = item.value.compactMap { $0.category }.first
-            let displayColor = category.map { Color(hex: $0.colorHex) } ?? .gray
-            return ChartsView.ChartData(
-                key: item.key,
-                name: category?.name ?? "未分類",
-                amount: aggregate.estimatedAmount,
-                color: displayColor,
-                transactions: item.value,
-                originalCurrencySummary: aggregate.originalCurrencySummary,
-                estimateFootnote: aggregate.estimateFootnote
-            )
-        }
-        return mapped.sorted { $0.amount > $1.amount }
-    }
-
-    private static func tagBreakdown(
-        from transactions: [FinancialTransaction],
-        currencyService: CurrencyService
-    ) -> [ChartsView.ChartData] {
-        var tagTransactions: [String: [FinancialTransaction]] = [:]
-        for tx in transactions {
-            if tx.tags.isEmpty {
-                tagTransactions["無標籤", default: []].append(tx)
+        slices.enumerated().map { index, slice in
+            let detail = slice.detailSummary
+            let displayColor: Color
+            if let colorHex = slice.categoryColorHex {
+                displayColor = Color(hex: colorHex)
+            } else if chartMode == .tag {
+                displayColor = Color.generateDistinctColor(index: index, total: slices.count)
             } else {
-                for tag in tx.tags {
-                    tagTransactions[tag.name, default: []].append(tx)
-                }
+                displayColor = .gray
             }
-        }
-        let sorted = tagTransactions
-            .map { item -> (key: String, aggregate: CurrencyReportAggregate, transactions: [FinancialTransaction]) in
-                (item.key, currencyAggregate(from: item.value, currencyService: currencyService), item.value)
-            }
-            .sorted { $0.aggregate.estimatedAmount > $1.aggregate.estimatedAmount }
-        return sorted.enumerated().map { index, item in
-            ChartsView.ChartData(
-                key: item.key,
-                name: item.key,
-                amount: item.aggregate.estimatedAmount,
-                color: Color.generateDistinctColor(index: index, total: sorted.count),
-                transactions: item.transactions,
-                originalCurrencySummary: item.aggregate.originalCurrencySummary,
-                estimateFootnote: item.aggregate.estimateFootnote
+            return ChartsView.ChartData(
+                key: slice.key,
+                name: slice.name,
+                amount: detail.estimatedAmount,
+                color: displayColor,
+                transactions: detail.transactionIDs.compactMap { transactionsByID[$0] },
+                originalCurrencySummary: reportCurrencySummary(detail.originalCurrencyTotals),
+                estimateFootnote: detail.estimateStatus.label
             )
         }
     }
 }
 
-private struct CurrencyReportAggregate {
-    let estimatedAmount: Decimal
-    let originalCurrencySummary: String
-    let estimateFootnote: String?
+private extension ReportTransactionSnapshot {
+    init(transaction: FinancialTransaction) {
+        self.init(
+            id: transaction.id,
+            amount: transaction.amount,
+            currencyCode: transaction.currencyCode,
+            date: transaction.date,
+            type: transaction.type,
+            categoryID: transaction.category?.id,
+            categoryName: transaction.category?.name,
+            categoryColorHex: transaction.category?.colorHex,
+            tagNames: transaction.tags.map(\.name)
+        )
+    }
 }
 
-private func currencyAggregate(
-    from transactions: [FinancialTransaction],
-    currencyService: CurrencyService
-) -> CurrencyReportAggregate {
-    var estimatedAmount = Decimal.zero
-    var originalTotals: [String: Decimal] = [:]
-    var usesEstimate = false
-    var hasUnavailableRate = false
-    let mainCurrency = currencyService.mainCurrency.uppercased()
-
-    for transaction in transactions {
-        let amount = abs(transaction.amount)
-        let currency = transaction.currencyCode.uppercased()
-        originalTotals[currency, default: 0] += amount
-
-        if currency == mainCurrency {
-            estimatedAmount += amount
-        } else if let estimate = currencyService.estimate(amount: amount, from: currency, to: mainCurrency) {
-            estimatedAmount += estimate.amount
-            usesEstimate = true
-        } else {
-            hasUnavailableRate = true
+private func reportCurrencySummary(_ totals: [ReportCurrencyTotal]) -> String {
+    totals
+        .map { total in
+            total.amount.formatted(.currency(code: total.currencyCode))
         }
-    }
-
-    let originalSummary = originalTotals
-        .sorted { $0.key < $1.key }
-        .map { amount in amount.value.formatted(.currency(code: amount.key)) }
         .joined(separator: " · ")
-
-    let footnote: String?
-    if hasUnavailableRate {
-        footnote = "估算不完整"
-    } else if usesEstimate {
-        footnote = currencyService.resolvedRateSourceState.label
-    } else {
-        footnote = nil
-    }
-
-    return CurrencyReportAggregate(
-        estimatedAmount: estimatedAmount,
-        originalCurrencySummary: originalSummary,
-        estimateFootnote: footnote
-    )
 }
 
 private struct ReportTransactionListView: View {

--- a/AI 記帳/Views/Common/SharedDateFilter.swift
+++ b/AI 記帳/Views/Common/SharedDateFilter.swift
@@ -8,6 +8,33 @@ enum DateFilterPreferenceKeys {
 }
 
 extension FilterType {
+    func dateInterval(
+        selectedDate: Date,
+        customStartDate: Date,
+        customEndDate: Date,
+        calendar: Calendar = .current
+    ) -> DateInterval? {
+        switch self {
+        case .all:
+            return nil
+        case .year:
+            return calendar.dateInterval(of: .year, for: selectedDate)
+        case .month:
+            return calendar.dateInterval(of: .month, for: selectedDate)
+        case .day:
+            return calendar.dateInterval(of: .day, for: selectedDate)
+        case .custom:
+            let range = normalizedCustomRange(start: customStartDate, end: customEndDate)
+            let start = calendar.startOfDay(for: range.start)
+            let end = calendar.date(
+                byAdding: .day,
+                value: 1,
+                to: calendar.startOfDay(for: range.end)
+            ) ?? range.end
+            return DateInterval(start: start, end: end)
+        }
+    }
+
     func displayString(
         selectedDate: Date,
         customStartDate: Date,
@@ -40,21 +67,15 @@ extension FilterType {
         customEndDate: Date,
         calendar: Calendar = .current
     ) -> Bool {
-        switch self {
-        case .all:
+        guard let interval = dateInterval(
+            selectedDate: selectedDate,
+            customStartDate: customStartDate,
+            customEndDate: customEndDate,
+            calendar: calendar
+        ) else {
             return true
-        case .year:
-            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .year)
-        case .month:
-            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .month)
-        case .day:
-            return calendar.isDate(date, equalTo: selectedDate, toGranularity: .day)
-        case .custom:
-            let range = normalizedCustomRange(start: customStartDate, end: customEndDate)
-            let startOfDay = calendar.startOfDay(for: range.start)
-            let exclusiveEnd = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: range.end)) ?? range.end
-            return date >= startOfDay && date < exclusiveEnd
         }
+        return date >= interval.start && date < interval.end
     }
 }
 

--- a/AI 記帳Tests/ReportAggregationServiceTests.swift
+++ b/AI 記帳Tests/ReportAggregationServiceTests.swift
@@ -1,0 +1,238 @@
+import XCTest
+@testable import AI_記帳
+
+@MainActor
+final class ReportAggregationServiceTests: XCTestCase {
+    func testCategoryAggregation_preservesOriginalCurrencyAndEstimatesMainCurrency() {
+        let foodID = UUID()
+        let transactionID = UUID()
+        let request = ReportAggregationRequest(
+            transactions: [
+                ReportTransactionSnapshot(
+                    id: transactionID,
+                    amount: -50,
+                    currencyCode: "USD",
+                    date: Date(timeIntervalSince1970: 1_700_000_000),
+                    type: .expense,
+                    categoryID: foodID,
+                    categoryName: "餐飲",
+                    categoryColorHex: "#FF0000",
+                    tagNames: ["旅行"]
+                )
+            ],
+            flow: .expense,
+            grouping: .category,
+            startDate: nil,
+            endDate: nil
+        )
+
+        let result = ReportAggregationService.aggregate(
+            request: request,
+            currencyConverter: FixedReportCurrencyConverter(
+                mainCurrency: "HKD",
+                ratesToMain: ["USD": 7.8],
+                source: .live
+            )
+        )
+
+        XCTAssertEqual(1, result.slices.count)
+        XCTAssertEqual("餐飲", result.slices[0].name)
+        XCTAssertEqual(Decimal(390), result.slices[0].estimatedAmount)
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "USD", amount: 50)],
+            result.slices[0].originalCurrencyTotals
+        )
+        XCTAssertEqual(.live, result.slices[0].estimateStatus)
+        XCTAssertEqual([transactionID], result.slices[0].transactionIDs)
+        XCTAssertEqual(1, result.slices[0].detailSummary.transactionCount)
+    }
+
+    func testTagAggregation_filtersFlowAndDateAndSupportsCategoryDrillDown() {
+        let startDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let endDate = startDate.addingTimeInterval(86_400)
+        let foodID = UUID()
+        let travelExpenseID = UUID()
+        let ignoredIncomeID = UUID()
+        let converter = FixedReportCurrencyConverter(
+            mainCurrency: "HKD",
+            ratesToMain: [:],
+            source: .live
+        )
+        let transactions = [
+            ReportTransactionSnapshot(
+                id: travelExpenseID,
+                amount: -80,
+                currencyCode: "HKD",
+                date: startDate.addingTimeInterval(60),
+                type: .expense,
+                categoryID: foodID,
+                categoryName: "餐飲",
+                categoryColorHex: "#FF0000",
+                tagNames: ["旅行", "朋友"]
+            ),
+            ReportTransactionSnapshot(
+                id: ignoredIncomeID,
+                amount: 500,
+                currencyCode: "HKD",
+                date: startDate.addingTimeInterval(120),
+                type: .income,
+                categoryID: nil,
+                categoryName: nil,
+                categoryColorHex: nil,
+                tagNames: ["旅行"]
+            ),
+            ReportTransactionSnapshot(
+                id: UUID(),
+                amount: -30,
+                currencyCode: "HKD",
+                date: endDate,
+                type: .expense,
+                categoryID: foodID,
+                categoryName: "餐飲",
+                categoryColorHex: "#FF0000",
+                tagNames: ["旅行"]
+            )
+        ]
+
+        let tagResult = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: transactions,
+                flow: .expense,
+                grouping: .tag,
+                startDate: startDate,
+                endDate: endDate
+            ),
+            currencyConverter: converter
+        )
+        let travelSlice = tagResult.slices.first { $0.name == "旅行" }
+        let friendSlice = tagResult.slices.first { $0.name == "朋友" }
+
+        XCTAssertEqual([travelExpenseID], travelSlice?.transactionIDs)
+        XCTAssertEqual([travelExpenseID], friendSlice?.transactionIDs)
+
+        let drillDown = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: transactions,
+                flow: .expense,
+                grouping: .category,
+                startDate: startDate,
+                endDate: endDate,
+                tagFilter: "旅行"
+            ),
+            currencyConverter: converter
+        )
+
+        XCTAssertEqual("餐飲", drillDown.slices.first?.name)
+        XCTAssertEqual([travelExpenseID], drillDown.slices.first?.transactionIDs)
+    }
+
+    func testEstimateStatus_distinguishesCachedPartialAndUnavailable() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let transactions = [
+            snapshot(amount: -100, currency: "HKD", date: date),
+            snapshot(amount: -10, currency: "USD", date: date),
+            snapshot(amount: -1_000, currency: "JPY", date: date)
+        ]
+        let cachedConverter = FixedReportCurrencyConverter(
+            mainCurrency: "HKD",
+            ratesToMain: ["USD": 7.8],
+            source: .cached
+        )
+
+        let partial = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: transactions,
+                flow: .expense,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: cachedConverter
+        )
+        XCTAssertEqual(Decimal(178), partial.slices.first?.estimatedAmount)
+        XCTAssertEqual(.partial, partial.slices.first?.estimateStatus)
+
+        let unavailable = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: [snapshot(amount: -1_000, currency: "JPY", date: date)],
+                flow: .expense,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: cachedConverter
+        )
+        XCTAssertEqual(.unavailable, unavailable.slices.first?.estimateStatus)
+
+        let cached = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: [snapshot(amount: -10, currency: "USD", date: date)],
+                flow: .expense,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: cachedConverter
+        )
+        XCTAssertEqual(.cached, cached.slices.first?.estimateStatus)
+    }
+
+    func testSharedDateFilter_excludesExclusiveEndBoundary() {
+        let calendar = Calendar(identifier: .gregorian)
+        let selectedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let interval = FilterType.day.dateInterval(
+            selectedDate: selectedDate,
+            customStartDate: selectedDate,
+            customEndDate: selectedDate,
+            calendar: calendar
+        )
+
+        XCTAssertNotNil(interval)
+        XCTAssertTrue(
+            FilterType.day.matches(
+                date: interval!.start,
+                selectedDate: selectedDate,
+                customStartDate: selectedDate,
+                customEndDate: selectedDate,
+                calendar: calendar
+            )
+        )
+        XCTAssertFalse(
+            FilterType.day.matches(
+                date: interval!.end,
+                selectedDate: selectedDate,
+                customStartDate: selectedDate,
+                customEndDate: selectedDate,
+                calendar: calendar
+            )
+        )
+    }
+
+    private func snapshot(amount: Decimal, currency: String, date: Date) -> ReportTransactionSnapshot {
+        ReportTransactionSnapshot(
+            id: UUID(),
+            amount: amount,
+            currencyCode: currency,
+            date: date,
+            type: .expense,
+            categoryID: nil,
+            categoryName: nil,
+            categoryColorHex: nil,
+            tagNames: []
+        )
+    }
+}
+
+private struct FixedReportCurrencyConverter: ReportCurrencyConverting {
+    let mainCurrency: String
+    let ratesToMain: [String: Decimal]
+    let source: ReportEstimateStatus
+
+    func estimateInMainCurrency(amount: Decimal, from currencyCode: String) -> ReportConversion? {
+        if currencyCode.uppercased() == mainCurrency.uppercased() {
+            return ReportConversion(amount: amount, status: .exact)
+        }
+        guard let rate = ratesToMain[currencyCode.uppercased()] else { return nil }
+        return ReportConversion(amount: amount * rate, status: source)
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregation.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregation.kt
@@ -1,0 +1,229 @@
+package org.duckdns.lhfser.aiaccounting.core.report
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.transactions.RateSourceState
+
+enum class ReportFlow(val transactionType: TransactionType) {
+    Expense(TransactionType.Expense),
+    Income(TransactionType.Income)
+}
+
+enum class ReportGroupingMode {
+    Category,
+    Tag
+}
+
+enum class ReportEstimateStatus(val label: String?) {
+    Exact(null),
+    Live("即時匯率"),
+    Cached("上次匯率"),
+    Partial("估算不完整"),
+    Unavailable("估算不完整")
+}
+
+data class ReportConversion(
+    val amount: BigDecimal,
+    val status: ReportEstimateStatus
+)
+
+interface ReportCurrencyConverting {
+    val mainCurrency: String
+    fun estimateInMainCurrency(amount: BigDecimal, currencyCode: String): ReportConversion?
+}
+
+data class ReportTransactionSnapshot(
+    val id: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val date: Instant,
+    val type: TransactionType,
+    val categoryId: UUID?,
+    val categoryName: String?,
+    val categoryColorHex: String?,
+    val tagNames: List<String>
+)
+
+data class ReportCurrencyTotal(
+    val currencyCode: String,
+    val amount: BigDecimal
+)
+
+data class ReportSlice(
+    val key: String,
+    val name: String,
+    val categoryColorHex: String?,
+    val estimatedAmount: BigDecimal,
+    val originalCurrencyTotals: List<ReportCurrencyTotal>,
+    val estimateStatus: ReportEstimateStatus,
+    val transactionIds: List<UUID>
+) {
+    val detailSummary: ReportDetailSummary
+        get() = ReportDetailSummary(
+            estimatedAmount = estimatedAmount,
+            originalCurrencyTotals = originalCurrencyTotals,
+            estimateStatus = estimateStatus,
+            transactionIds = transactionIds
+        )
+}
+
+data class ReportDetailSummary(
+    val estimatedAmount: BigDecimal,
+    val originalCurrencyTotals: List<ReportCurrencyTotal>,
+    val estimateStatus: ReportEstimateStatus,
+    val transactionIds: List<UUID>
+) {
+    val transactionCount: Int
+        get() = transactionIds.size
+}
+
+data class ReportAggregationRequest(
+    val transactions: List<ReportTransactionSnapshot>,
+    val flow: ReportFlow,
+    val grouping: ReportGroupingMode,
+    val startDate: Instant? = null,
+    val endDate: Instant? = null,
+    val tagFilter: String? = null
+)
+
+data class ReportAggregationResult(
+    val slices: List<ReportSlice>
+) {
+    val totalEstimatedAmount: BigDecimal
+        get() = slices.fold(BigDecimal.ZERO) { total, slice -> total + slice.estimatedAmount }
+}
+
+object ReportAggregationService {
+    fun aggregate(
+        request: ReportAggregationRequest,
+        currencyConverter: ReportCurrencyConverting
+    ): ReportAggregationResult {
+        val filtered = request.transactions.filter { transaction ->
+            transaction.type == request.flow.transactionType &&
+                (request.startDate == null || transaction.date >= request.startDate) &&
+                (request.endDate == null || transaction.date < request.endDate) &&
+                matchesTagFilter(transaction, request.tagFilter)
+        }
+
+        val grouped = when (request.grouping) {
+            ReportGroupingMode.Category -> filtered.groupBy {
+                it.categoryId?.toString() ?: "uncategorized"
+            }
+            ReportGroupingMode.Tag -> buildMap<String, MutableList<ReportTransactionSnapshot>> {
+                filtered.forEach { transaction ->
+                    val tags = transaction.tagNames.ifEmpty { listOf("無標籤") }
+                    tags.forEach { tagName ->
+                        getOrPut(tagName) { mutableListOf() }.add(transaction)
+                    }
+                }
+            }
+        }
+
+        return ReportAggregationResult(
+            slices = grouped.map { (key, transactions) ->
+                makeSlice(
+                    key = key,
+                    transactions = transactions,
+                    grouping = request.grouping,
+                    currencyConverter = currencyConverter
+                )
+            }.sortedWith(
+                compareByDescending<ReportSlice> { it.estimatedAmount }
+                    .thenBy { it.name.lowercase() }
+            )
+        )
+    }
+
+    private fun matchesTagFilter(
+        transaction: ReportTransactionSnapshot,
+        tagFilter: String?
+    ): Boolean {
+        if (tagFilter == null) return true
+        return if (tagFilter == "無標籤") {
+            transaction.tagNames.isEmpty()
+        } else {
+            tagFilter in transaction.tagNames
+        }
+    }
+
+    private fun makeSlice(
+        key: String,
+        transactions: List<ReportTransactionSnapshot>,
+        grouping: ReportGroupingMode,
+        currencyConverter: ReportCurrencyConverting
+    ): ReportSlice {
+        var estimatedAmount = BigDecimal.ZERO
+        val originalTotals = mutableMapOf<String, BigDecimal>()
+        val statuses = mutableListOf<ReportEstimateStatus>()
+        var unavailableCount = 0
+
+        transactions.forEach { transaction ->
+            val amount = transaction.amount.abs()
+            val currencyCode = transaction.currencyCode.uppercase()
+            originalTotals[currencyCode] = (originalTotals[currencyCode] ?: BigDecimal.ZERO) + amount
+
+            val conversion = currencyConverter.estimateInMainCurrency(amount, currencyCode)
+            if (conversion == null) {
+                unavailableCount += 1
+            } else {
+                estimatedAmount += conversion.amount
+                statuses += conversion.status
+            }
+        }
+
+        val status = when {
+            unavailableCount == transactions.size -> ReportEstimateStatus.Unavailable
+            unavailableCount > 0 -> ReportEstimateStatus.Partial
+            ReportEstimateStatus.Cached in statuses -> ReportEstimateStatus.Cached
+            ReportEstimateStatus.Live in statuses -> ReportEstimateStatus.Live
+            else -> ReportEstimateStatus.Exact
+        }
+        val first = transactions.firstOrNull()
+
+        return ReportSlice(
+            key = key,
+            name = when (grouping) {
+                ReportGroupingMode.Category -> first?.categoryName ?: "未分類"
+                ReportGroupingMode.Tag -> key
+            },
+            categoryColorHex = when (grouping) {
+                ReportGroupingMode.Category -> first?.categoryColorHex
+                ReportGroupingMode.Tag -> null
+            },
+            estimatedAmount = estimatedAmount,
+            originalCurrencyTotals = originalTotals.entries
+                .sortedBy { it.key }
+                .map { ReportCurrencyTotal(currencyCode = it.key, amount = it.value) },
+            estimateStatus = status,
+            transactionIds = transactions
+                .sortedByDescending { it.date }
+                .map { it.id }
+        )
+    }
+}
+
+class CurrencyServiceReportConverter(
+    private val currencyService: CurrencyService
+) : ReportCurrencyConverting {
+    override val mainCurrency: String
+        get() = currencyService.mainCurrency
+
+    override fun estimateInMainCurrency(
+        amount: BigDecimal,
+        currencyCode: String
+    ): ReportConversion? {
+        if (currencyCode.equals(mainCurrency, ignoreCase = true)) {
+            return ReportConversion(amount = amount, status = ReportEstimateStatus.Exact)
+        }
+        val estimate = currencyService.estimate(amount, currencyCode, mainCurrency) ?: return null
+        val status = when (estimate.source) {
+            RateSourceState.Live -> ReportEstimateStatus.Live
+            RateSourceState.Cached -> ReportEstimateStatus.Cached
+            RateSourceState.Unavailable -> return null
+        }
+        return ReportConversion(amount = estimate.amount, status = status)
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -61,6 +60,13 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.preferences.SharedDateFilterType
 import org.duckdns.lhfser.aiaccounting.core.preferences.resolveSharedDateRange
 import org.duckdns.lhfser.aiaccounting.core.preferences.sharedDateFilterLabel
+import org.duckdns.lhfser.aiaccounting.core.report.CurrencyServiceReportConverter
+import org.duckdns.lhfser.aiaccounting.core.report.ReportAggregationRequest
+import org.duckdns.lhfser.aiaccounting.core.report.ReportAggregationResult
+import org.duckdns.lhfser.aiaccounting.core.report.ReportAggregationService
+import org.duckdns.lhfser.aiaccounting.core.report.ReportFlow
+import org.duckdns.lhfser.aiaccounting.core.report.ReportGroupingMode
+import org.duckdns.lhfser.aiaccounting.core.report.ReportTransactionSnapshot
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryMonthlyBudgetEntity
@@ -83,28 +89,28 @@ import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import org.duckdns.lhfser.aiaccounting.ui.utils.asCurrencyText
 import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 
-private enum class ReportChartMode(val label: String) {
-    Category("依分類"),
-    Tag("依標籤")
+private enum class ReportChartMode(
+    val label: String,
+    val groupingMode: ReportGroupingMode
+) {
+    Category("依分類", ReportGroupingMode.Category),
+    Tag("依標籤", ReportGroupingMode.Tag)
 }
 
-private enum class ReportFlowMode(val label: String, val type: TransactionType) {
-    Expense("支出", TransactionType.Expense),
-    Income("收入", TransactionType.Income)
+private enum class ReportFlowMode(
+    val label: String,
+    val reportFlow: ReportFlow
+) {
+    Expense("支出", ReportFlow.Expense),
+    Income("收入", ReportFlow.Income)
 }
 
-private data class ReportSlice(
+private data class ReportChartSlice(
     val key: String,
     val name: String,
     val amount: BigDecimal,
     val color: Color,
     val transactions: List<TransactionWithDetails>,
-    val originalCurrencySummary: String,
-    val estimateFootnote: String?
-)
-
-private data class CurrencyReportAggregate(
-    val estimatedAmount: BigDecimal,
     val originalCurrencySummary: String,
     val estimateFootnote: String?
 )
@@ -158,33 +164,77 @@ fun ReportsScreen(
     val (rangeStart, rangeEnd) = remember(filterType, selectedDate, customStartDate, customEndDate) {
         resolveSharedDateRange(filterType, selectedDate, customStartDate, customEndDate)
     }
-    val filteredTransactions = remember(transactions, flowMode, rangeStart, rangeEnd) {
-        filterTransactions(transactions, flowMode.type, rangeStart, rangeEnd)
-    }
     val baseCurrency = currencyService.mainCurrency
+    val reportConverter = remember(currencyService) {
+        CurrencyServiceReportConverter(currencyService)
+    }
+    val reportSnapshots = remember(transactions) {
+        transactions.map { it.toReportSnapshot() }
+    }
+    val transactionsById = remember(transactions) {
+        transactions.associateBy { it.transaction.id }
+    }
+    val rateSourceState = currencyService.resolvedRateSourceState
+    val rates = currencyService.rates
 
-    val chartData = remember(filteredTransactions, categories, chartMode, baseCurrency) {
-        when (chartMode) {
-            ReportChartMode.Category -> categoryBreakdown(filteredTransactions, categories, currencyService, baseCurrency)
-            ReportChartMode.Tag -> tagBreakdown(filteredTransactions, currencyService, baseCurrency)
-        }
+    val chartData = remember(
+        reportSnapshots,
+        transactionsById,
+        flowMode,
+        chartMode,
+        rangeStart,
+        rangeEnd,
+        baseCurrency,
+        rateSourceState,
+        rates
+    ) {
+        val result = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = reportSnapshots,
+                flow = flowMode.reportFlow,
+                grouping = chartMode.groupingMode,
+                startDate = rangeStart,
+                endDate = rangeEnd
+            ),
+            currencyConverter = reportConverter
+        )
+        result.toChartSlices(
+            transactionsById = transactionsById,
+            chartMode = chartMode
+        )
     }
 
-    val tagDetailData = remember(filteredTransactions, categories, selectedTag, baseCurrency) {
+    val tagDetailData = remember(
+        reportSnapshots,
+        transactionsById,
+        flowMode,
+        selectedTag,
+        rangeStart,
+        rangeEnd,
+        baseCurrency,
+        rateSourceState,
+        rates
+    ) {
         if (chartMode == ReportChartMode.Tag && selectedTag != null) {
-            categoryBreakdown(
-                transactions = filteredTransactions.filter { tx ->
-                    if (selectedTag == "無標籤") tx.tags.isEmpty() else tx.tags.any { it.name == selectedTag }
-                },
-                categories = categories,
-                currencyService = currencyService,
-                baseCurrency = baseCurrency
+            ReportAggregationService.aggregate(
+                request = ReportAggregationRequest(
+                    transactions = reportSnapshots,
+                    flow = flowMode.reportFlow,
+                    grouping = ReportGroupingMode.Category,
+                    startDate = rangeStart,
+                    endDate = rangeEnd,
+                    tagFilter = selectedTag
+                ),
+                currencyConverter = reportConverter
+            ).toChartSlices(
+                transactionsById = transactionsById,
+                chartMode = ReportChartMode.Category
             )
         } else emptyList()
     }
 
-    val budgetAlerts = remember(budgets, categories, filteredTransactions, currencyService) {
-        buildBudgetAlerts(budgets, categories, filteredTransactions, currencyService)
+    val budgetAlerts = remember(budgets, categories, transactions, currencyService) {
+        buildBudgetAlerts(budgets, categories, transactions, currencyService)
     }
 
     @Composable
@@ -411,7 +461,7 @@ fun ReportsScreen(
 
 @Composable
 private fun ReportRow(
-    item: ReportSlice,
+    item: ReportChartSlice,
     total: BigDecimal,
     baseCurrency: String,
     trailingLabel: String,
@@ -475,7 +525,7 @@ private fun ReportRow(
 }
 
 @Composable
-private fun DonutChart(data: List<ReportSlice>, baseCurrency: String, title: String) {
+private fun DonutChart(data: List<ReportChartSlice>, baseCurrency: String, title: String) {
     val total = totalAmount(data)
     val trackColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.72f)
     Surface(
@@ -801,127 +851,51 @@ private fun routeTransactionEdit(
     }
 }
 
-private fun filterTransactions(
-    transactions: List<TransactionWithDetails>,
-    type: TransactionType,
-    rangeStart: Instant?,
-    rangeEnd: Instant?
-): List<TransactionWithDetails> {
-    return transactions.filter { tx ->
-        if (tx.transaction.type != type) return@filter false
-        val date = tx.transaction.date
-        when {
-            rangeStart == null || rangeEnd == null -> true
-            else -> date >= rangeStart && date < rangeEnd
-        }
-    }
-}
-
-private fun categoryBreakdown(
-    transactions: List<TransactionWithDetails>,
-    categories: List<CategoryEntity>,
-    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
-    baseCurrency: String
-): List<ReportSlice> {
-	val grouped = transactions.groupBy { it.category?.id }
-	return grouped.mapNotNull { (categoryId, items) ->
-	    val category = categories.firstOrNull { it.id == categoryId }
-	    val aggregate = currencyAggregate(items, currencyService, baseCurrency)
-	    ReportSlice(
-	        key = categoryId?.toString() ?: "uncategorized",
-	        name = category?.name ?: "未分類",
-	        amount = aggregate.estimatedAmount,
-	        color = parseColor(category?.colorHex ?: "#90A4AE"),
-	        transactions = items,
-	        originalCurrencySummary = aggregate.originalCurrencySummary,
-	        estimateFootnote = aggregate.estimateFootnote
-	    )
-	}.sortedByDescending { it.amount }
-}
-
-private fun tagBreakdown(
-    transactions: List<TransactionWithDetails>,
-	currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
-	baseCurrency: String
-): List<ReportSlice> {
-	val tagTransactions = mutableMapOf<String, MutableList<TransactionWithDetails>>()
-	transactions.forEach { tx ->
-	    if (tx.tags.isEmpty()) {
-	        tagTransactions.getOrPut("無標籤") { mutableListOf() }.add(tx)
-	    } else {
-	        tx.tags.forEach { tag ->
-	            tagTransactions.getOrPut(tag.name) { mutableListOf() }.add(tx)
-	        }
-	    }
-	}
-	val sorted = tagTransactions.entries
-	    .map { entry -> entry.key to currencyAggregate(entry.value, currencyService, baseCurrency) }
-	    .sortedByDescending { it.second.estimatedAmount }
-	return sorted.mapIndexed { index, entry ->
-	    ReportSlice(
-	        key = entry.first,
-	        name = entry.first,
-	        amount = entry.second.estimatedAmount,
-	        color = generateDistinctColor(index),
-	        transactions = tagTransactions[entry.first]?.toList().orEmpty(),
-	        originalCurrencySummary = entry.second.originalCurrencySummary,
-	        estimateFootnote = entry.second.estimateFootnote
-	    )
-	}
-}
-
-private fun currencyAggregate(
-    transactions: List<TransactionWithDetails>,
-    currencyService: org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService,
-    baseCurrency: String
-): CurrencyReportAggregate {
-    var estimatedAmount = BigDecimal.ZERO
-    val originalTotals = mutableMapOf<String, BigDecimal>()
-    var usesEstimate = false
-    var hasUnavailableRate = false
-    val mainCurrency = baseCurrency.uppercase()
-
-    transactions.forEach { tx ->
-        val amount = tx.transaction.amount.abs()
-        val currency = tx.transaction.currencyCode.uppercase()
-        originalTotals[currency] = (originalTotals[currency] ?: BigDecimal.ZERO) + amount
-
-        if (currency == mainCurrency) {
-            estimatedAmount += amount
-        } else {
-            val estimate = currencyService.estimate(amount, currency, mainCurrency)
-            if (estimate != null) {
-                estimatedAmount += estimate.amount
-                usesEstimate = true
-            } else {
-                hasUnavailableRate = true
-            }
-        }
-    }
-
-    val originalSummary = originalTotals.entries
-        .sortedBy { it.key }
-        .joinToString(" · ") { it.value.asCurrencyText(it.key) }
-    val footnote = when {
-        hasUnavailableRate -> "估算不完整"
-        usesEstimate -> currencyService.resolvedRateSourceState.label
-        else -> null
-    }
-
-    return CurrencyReportAggregate(
-        estimatedAmount = estimatedAmount,
-        originalCurrencySummary = originalSummary,
-        estimateFootnote = footnote
+private fun TransactionWithDetails.toReportSnapshot(): ReportTransactionSnapshot {
+    return ReportTransactionSnapshot(
+        id = transaction.id,
+        amount = transaction.amount,
+        currencyCode = transaction.currencyCode,
+        date = transaction.date,
+        type = transaction.type,
+        categoryId = category?.id,
+        categoryName = category?.name,
+        categoryColorHex = category?.colorHex,
+        tagNames = tags.map { it.name }
     )
 }
 
-private fun totalAmount(data: List<ReportSlice>): BigDecimal {
+private fun ReportAggregationResult.toChartSlices(
+    transactionsById: Map<java.util.UUID, TransactionWithDetails>,
+    chartMode: ReportChartMode
+): List<ReportChartSlice> {
+    return slices.mapIndexed { index, slice ->
+        val detail = slice.detailSummary
+        ReportChartSlice(
+            key = slice.key,
+            name = slice.name,
+            amount = detail.estimatedAmount,
+            color = when {
+                slice.categoryColorHex != null -> parseColor(slice.categoryColorHex)
+                chartMode == ReportChartMode.Tag -> generateDistinctColor(index)
+                else -> parseColor("#90A4AE")
+            },
+            transactions = detail.transactionIds.mapNotNull(transactionsById::get),
+            originalCurrencySummary = detail.originalCurrencyTotals.joinToString(" · ") {
+                it.amount.asCurrencyText(it.currencyCode)
+            },
+            estimateFootnote = detail.estimateStatus.label
+        )
+    }
+}
+
+private fun totalAmount(data: List<ReportChartSlice>): BigDecimal {
     return data.fold(BigDecimal.ZERO) { acc, row -> acc + row.amount }
 }
 
 private fun presentTransactions(
     flowMode: ReportFlowMode,
-    item: ReportSlice,
+    item: ReportChartSlice,
     tagName: String?,
     baseCurrency: String
 ): ReportDetail {

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregationTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregationTest.kt
@@ -1,0 +1,198 @@
+package org.duckdns.lhfser.aiaccounting.core.report
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReportAggregationTest {
+    @Test
+    fun categoryAggregation_preservesOriginalCurrencyAndEstimatesMainCurrency() {
+        val categoryId = UUID.randomUUID()
+        val transactionId = UUID.randomUUID()
+        val result = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = listOf(
+                    ReportTransactionSnapshot(
+                        id = transactionId,
+                        amount = BigDecimal("-50"),
+                        currencyCode = "USD",
+                        date = Instant.parse("2026-02-01T12:00:00Z"),
+                        type = TransactionType.Expense,
+                        categoryId = categoryId,
+                        categoryName = "餐飲",
+                        categoryColorHex = "#FF0000",
+                        tagNames = listOf("旅行")
+                    )
+                ),
+                flow = ReportFlow.Expense,
+                grouping = ReportGroupingMode.Category
+            ),
+            currencyConverter = FixedReportCurrencyConverter(
+                mainCurrency = "HKD",
+                ratesToMain = mapOf("USD" to BigDecimal("7.8")),
+                source = ReportEstimateStatus.Live
+            )
+        )
+
+        assertEquals(1, result.slices.size)
+        val slice = result.slices.single()
+        assertEquals("餐飲", slice.name)
+        assertMoneyEquals("390", slice.estimatedAmount)
+        assertEquals(
+            listOf(ReportCurrencyTotal(currencyCode = "USD", amount = BigDecimal("50"))),
+            slice.originalCurrencyTotals
+        )
+        assertEquals(ReportEstimateStatus.Live, slice.estimateStatus)
+        assertEquals(listOf(transactionId), slice.transactionIds)
+        assertEquals(1, slice.detailSummary.transactionCount)
+    }
+
+    @Test
+    fun tagAggregation_filtersFlowAndDateAndSupportsCategoryDrillDown() {
+        val start = Instant.parse("2026-02-01T00:00:00Z")
+        val end = Instant.parse("2026-02-02T00:00:00Z")
+        val categoryId = UUID.randomUUID()
+        val expenseId = UUID.randomUUID()
+        val transactions = listOf(
+            snapshot(
+                id = expenseId,
+                amount = "-80",
+                date = start.plusSeconds(60),
+                type = TransactionType.Expense,
+                categoryId = categoryId,
+                tags = listOf("旅行", "朋友")
+            ),
+            snapshot(
+                amount = "500",
+                date = start.plusSeconds(120),
+                type = TransactionType.Income,
+                categoryId = null,
+                tags = listOf("旅行")
+            ),
+            snapshot(
+                amount = "-30",
+                date = end,
+                type = TransactionType.Expense,
+                categoryId = categoryId,
+                tags = listOf("旅行")
+            )
+        )
+        val converter = FixedReportCurrencyConverter(mainCurrency = "HKD")
+
+        val tags = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = transactions,
+                flow = ReportFlow.Expense,
+                grouping = ReportGroupingMode.Tag,
+                startDate = start,
+                endDate = end
+            ),
+            currencyConverter = converter
+        )
+        assertEquals(listOf(expenseId), tags.slices.first { it.name == "旅行" }.transactionIds)
+        assertEquals(listOf(expenseId), tags.slices.first { it.name == "朋友" }.transactionIds)
+
+        val drillDown = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = transactions,
+                flow = ReportFlow.Expense,
+                grouping = ReportGroupingMode.Category,
+                startDate = start,
+                endDate = end,
+                tagFilter = "旅行"
+            ),
+            currencyConverter = converter
+        )
+
+        assertEquals("餐飲", drillDown.slices.single().name)
+        assertEquals(listOf(expenseId), drillDown.slices.single().transactionIds)
+    }
+
+    @Test
+    fun estimateStatus_distinguishesCachedPartialAndUnavailable() {
+        val date = Instant.parse("2026-02-01T12:00:00Z")
+        val transactions = listOf(
+            snapshot(amount = "-100", currency = "HKD", date = date, categoryId = null),
+            snapshot(amount = "-10", currency = "USD", date = date, categoryId = null),
+            snapshot(amount = "-1000", currency = "JPY", date = date, categoryId = null)
+        )
+        val converter = FixedReportCurrencyConverter(
+            mainCurrency = "HKD",
+            ratesToMain = mapOf("USD" to BigDecimal("7.8")),
+            source = ReportEstimateStatus.Cached
+        )
+
+        val partial = aggregate(transactions, converter)
+        assertMoneyEquals("178", partial.slices.single().estimatedAmount)
+        assertEquals(ReportEstimateStatus.Partial, partial.slices.single().estimateStatus)
+
+        val unavailable = aggregate(
+            listOf(snapshot(amount = "-1000", currency = "JPY", date = date, categoryId = null)),
+            converter
+        )
+        assertEquals(ReportEstimateStatus.Unavailable, unavailable.slices.single().estimateStatus)
+
+        val cached = aggregate(
+            listOf(snapshot(amount = "-10", currency = "USD", date = date, categoryId = null)),
+            converter
+        )
+        assertEquals(ReportEstimateStatus.Cached, cached.slices.single().estimateStatus)
+    }
+
+    private fun aggregate(
+        transactions: List<ReportTransactionSnapshot>,
+        converter: ReportCurrencyConverting
+    ): ReportAggregationResult {
+        return ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = transactions,
+                flow = ReportFlow.Expense,
+                grouping = ReportGroupingMode.Category
+            ),
+            currencyConverter = converter
+        )
+    }
+
+    private fun snapshot(
+        id: UUID = UUID.randomUUID(),
+        amount: String,
+        currency: String = "HKD",
+        date: Instant,
+        type: TransactionType = TransactionType.Expense,
+        categoryId: UUID? = UUID.randomUUID(),
+        tags: List<String> = emptyList()
+    ): ReportTransactionSnapshot {
+        return ReportTransactionSnapshot(
+            id = id,
+            amount = BigDecimal(amount),
+            currencyCode = currency,
+            date = date,
+            type = type,
+            categoryId = categoryId,
+            categoryName = categoryId?.let { "餐飲" },
+            categoryColorHex = categoryId?.let { "#FF0000" },
+            tagNames = tags
+        )
+    }
+
+    private fun assertMoneyEquals(expected: String, actual: BigDecimal) {
+        assertEquals(0, BigDecimal(expected).compareTo(actual))
+    }
+}
+
+private data class FixedReportCurrencyConverter(
+    override val mainCurrency: String,
+    val ratesToMain: Map<String, BigDecimal> = emptyMap(),
+    val source: ReportEstimateStatus = ReportEstimateStatus.Live
+) : ReportCurrencyConverting {
+    override fun estimateInMainCurrency(amount: BigDecimal, currencyCode: String): ReportConversion? {
+        if (currencyCode.equals(mainCurrency, ignoreCase = true)) {
+            return ReportConversion(amount = amount, status = ReportEstimateStatus.Exact)
+        }
+        val rate = ratesToMain[currencyCode.uppercase()] ?: return null
+        return ReportConversion(amount = amount * rate, status = source)
+    }
+}


### PR DESCRIPTION
## Summary
- extract report aggregation from SwiftUI and Compose screens into pure cross-platform modules
- return category/tag slices, drill-down summaries, original-currency totals, and estimate status
- keep report interactions unchanged while fixing duplicate iOS original-currency totals and exclusive date-range boundaries

## Architecture
- UI maps immutable transaction snapshots into the aggregation service
- aggregation owns flow/date/tag filtering, grouping, currency estimates, and stable ordering
- report screens only map IDs back to editable transactions and render platform UI

## Validation
- iOS: `xcodebuild test -project 'AI 記帳.xcodeproj' -scheme 'AI 記帳' -destination 'platform=iOS Simulator,name=iPhone 13' CODE_SIGNING_ALLOWED=NO` (19 tests passed)
- Android: `./gradlew testDebugUnitTest assembleDebug`
- targeted report tests cover category/tag grouping, drill-down, live/cached/unavailable estimates, original currencies, and end-date exclusion

Closes #116
