### PR TITLE
Add cross-platform ledger semantic vectors

### DIFF
--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -315,6 +315,75 @@ final class BackupCompatibilityTests: XCTestCase {
         let report = DataHealthCheckService.run(modelContext: modelContext)
         XCTAssertEqual(0, report.errorCount)
         XCTAssertEqual(0, report.warningCount)
+
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        _ = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 150,
+            currencyCode: "HKD",
+            date: date.addingTimeInterval(3_600),
+            note: "還款",
+            receiveAccount: ownAccount,
+            category: nil,
+            tags: [],
+            currencyService: CurrencyService.shared,
+            normalizedAmountOverride: 150,
+            direction: .othersAdvancedMe,
+            modelContext: modelContext
+        )
+
+        let transactionsAfterRepayment = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let ownAccountAfterRepayment = transactionsAfterRepayment.filter { $0.account?.id == ownAccount.id }
+        let expenseTransactions = transactionsAfterRepayment.filter { $0.type == .expense }
+
+        XCTAssertEqual(1, ownAccountAfterRepayment.count)
+        XCTAssertEqual(.transfer, ownAccountAfterRepayment.first?.type)
+        XCTAssertEqual(Decimal(-150), ownAccountAfterRepayment.first?.amount)
+        XCTAssertEqual(1, expenseTransactions.count)
+        XCTAssertEqual(Decimal(-150), expenseTransactions.first?.amount)
+        XCTAssertEqual(Decimal.zero, participant.remainingAmount)
+    }
+
+    func testAdvancedOthersCreation_recordsFullOutflowAndOnlySelfShareExpense() throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-03-21T12:00:00Z"))
+
+        let ownAccount = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let debtAccount = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        let category = Category(name: "Food", icon: "fork.knife", colorHex: "#FF8800", kind: .expense)
+        modelContext.insert(ownAccount)
+        modelContext.insert(debtAccount)
+        modelContext.insert(category)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "代付晚餐",
+            date: date,
+            currencyCode: "HKD",
+            myShareAmount: 50,
+            note: "晚餐",
+            payerAccount: ownAccount,
+            category: category,
+            tags: [],
+            participants: [.init(debtAccount: debtAccount, owedAmount: 100)],
+            isBorrowedByMe: false,
+            modelContext: modelContext
+        )
+
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let ownAccountTransactions = transactions.filter { $0.account?.id == ownAccount.id }
+        let debtTransactions = transactions.filter { $0.account?.id == debtAccount.id }
+        let expenseTransactions = transactions.filter { $0.type == .expense }
+
+        XCTAssertEqual(Decimal(-150), ownAccountTransactions.reduce(0) { $0 + $1.amount })
+        XCTAssertEqual(1, expenseTransactions.count)
+        XCTAssertEqual(Decimal(-50), expenseTransactions.first?.amount)
+        XCTAssertEqual(category.id, expenseTransactions.first?.category?.id)
+        XCTAssertEqual(1, debtTransactions.count)
+        XCTAssertEqual(.transfer, debtTransactions.first?.type)
+        XCTAssertEqual(Decimal(100), debtTransactions.first?.amount)
+        XCTAssertEqual(Decimal(100), advanceCase.participants.first?.remainingAmount)
     }
 
     func testBorrowedAdvanceWithoutCategory_reportsUncategorisedExpenseWarning() throws {

--- a/AI 記帳Tests/LedgerSemanticVectorsTests.swift
+++ b/AI 記帳Tests/LedgerSemanticVectorsTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import AI_記帳
+
+@MainActor
+final class LedgerSemanticVectorsTests: XCTestCase {
+    private let date = Date(timeIntervalSince1970: 1_772_366_400)
+
+    func testVector6_crossCurrencyRepayment_usesNormalisedAmountForOutstanding() {
+        let participant = AdvanceParticipant(
+            name: "Friend A",
+            owedAmount: 1_000,
+            repaidAmount: 900
+        )
+        let repayment = AdvanceRepayment(
+            amount: 50,
+            currencyCode: "HKD",
+            normalizedAmount: 900,
+            date: date,
+            note: "朋友用港幣還款"
+        )
+
+        XCTAssertEqual(Decimal(50), repayment.amount)
+        XCTAssertEqual("HKD", repayment.currencyCode)
+        XCTAssertEqual(Decimal(900), repayment.normalizedAmount)
+        XCTAssertEqual(Decimal(100), participant.remainingAmount)
+    }
+
+    func testVector7_iAdvancedOthers_reportsOnlyUserShare() {
+        let transactions = [
+            snapshot(amount: -50, type: .expense),
+            snapshot(amount: -100, type: .transfer),
+            snapshot(amount: 100, type: .transfer)
+        ]
+        let participant = AdvanceParticipant(
+            name: "Friend A",
+            owedAmount: 100
+        )
+
+        XCTAssertEqual(Decimal(50), total(for: .expense, transactions: transactions))
+        XCTAssertEqual(Decimal.zero, total(for: .income, transactions: transactions))
+        XCTAssertEqual(Decimal(100), participant.remainingAmount)
+    }
+
+    func testVector8_othersAdvancedMe_repaymentDoesNotDoubleCountExpense() {
+        let transactions = [
+            snapshot(amount: -150, type: .expense),
+            snapshot(amount: -150, type: .transfer),
+            snapshot(amount: 150, type: .transfer)
+        ]
+        let participant = AdvanceParticipant(
+            name: "Friend A",
+            owedAmount: 150,
+            repaidAmount: 150
+        )
+
+        XCTAssertEqual(Decimal(150), total(for: .expense, transactions: transactions))
+        XCTAssertEqual(Decimal.zero, total(for: .income, transactions: transactions))
+        XCTAssertEqual(Decimal.zero, participant.remainingAmount)
+    }
+
+    func testVector13_settlementRecordsAreExcludedFromReports() {
+        let forgivenessNote = TransactionSemantics.debtForgivenessNote(
+            baseNote: "",
+            debtAccountName: "Friend A",
+            direction: .forgivenByOthers
+        )
+        let offsetID = UUID(uuidString: "13131313-1313-1313-1313-131313131313")!
+        let offsetNote = "[債務抵銷:\(offsetID.uuidString)] 與對方代墊互相抵銷"
+        let transactions = [
+            snapshot(amount: -20, type: .expense),
+            snapshot(amount: -40, type: .transfer),
+            snapshot(amount: 40, type: .transfer),
+            snapshot(amount: 40, type: .transfer),
+            snapshot(amount: -100, currency: "HKD", type: .transfer),
+            snapshot(amount: 92, currency: "CNY", type: .transfer),
+            snapshot(amount: 1_000, currency: "JPY", type: .transfer)
+        ]
+
+        XCTAssertTrue(TransactionSemantics.isDebtForgiveness(note: forgivenessNote))
+        XCTAssertTrue(AdvanceService.isMutualDebtOffset(note: offsetNote))
+        XCTAssertEqual(Decimal(20), total(for: .expense, transactions: transactions))
+        XCTAssertEqual(Decimal.zero, total(for: .income, transactions: transactions))
+    }
+
+    private func total(
+        for flow: ReportFlow,
+        transactions: [ReportTransactionSnapshot]
+    ) -> Decimal {
+        ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: transactions,
+                flow: flow,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: SemanticVectorCurrencyConverter()
+        ).totalEstimatedAmount
+    }
+
+    private func snapshot(
+        amount: Decimal,
+        currency: String = "HKD",
+        type: TransactionType
+    ) -> ReportTransactionSnapshot {
+        return ReportTransactionSnapshot(
+            id: UUID(),
+            amount: amount,
+            currencyCode: currency,
+            date: date,
+            type: type,
+            categoryID: nil,
+            categoryName: nil,
+            categoryColorHex: nil,
+            tagNames: []
+        )
+    }
+}
+
+private struct SemanticVectorCurrencyConverter: ReportCurrencyConverting {
+    let mainCurrency = "HKD"
+
+    func estimateInMainCurrency(amount: Decimal, from currencyCode: String) -> ReportConversion? {
+        let rate: Decimal
+        switch currencyCode.uppercased() {
+        case "HKD":
+            rate = 1
+        case "USD":
+            rate = Decimal(string: "7.8")!
+        case "CNY":
+            rate = Decimal(string: "1.08")!
+        default:
+            return nil
+        }
+        return ReportConversion(amount: amount * rate, status: .exact)
+    }
+}

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/ParityVectorsTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/ParityVectorsTest.kt
@@ -16,6 +16,8 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.report.CategoryFilter
 import org.duckdns.lhfser.aiaccounting.core.report.IncomeExpenseCalculator
 import org.duckdns.lhfser.aiaccounting.core.report.transferGroupNet
+import org.duckdns.lhfser.aiaccounting.core.transactions.DebtForgivenessDirection
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -112,6 +114,105 @@ class ParityVectorsTest {
                 )
             ).setScale(2)
         )
+    }
+
+    @Test
+    fun vector6_crossCurrencyRepayment_usesNormalizedAmountForOutstanding() {
+        val progress = AdvanceProgressCalculator.compute(
+            listOf(
+                AdvanceParticipant(
+                    name = "Friend A",
+                    owedAmount = BigDecimal("1000"),
+                    repaidAmount = BigDecimal("900")
+                )
+            )
+        )
+
+        assertMoneyEquals("100.00", progress.outstandingTotal)
+    }
+
+    @Test
+    fun vector7_iAdvancedOthers_reportsOnlyUserShare() {
+        val calculator = IncomeExpenseCalculator(baseCurrencyCode = "HKD", fxRatesToBase = fxRates)
+        val now = Instant.parse("2026-03-01T00:00:00Z")
+        val transactions = listOf(
+            FinancialTransaction(amount = BigDecimal("-50"), currencyCode = "HKD", date = now, type = TransactionType.Expense),
+            FinancialTransaction(amount = BigDecimal("-100"), currencyCode = "HKD", date = now, type = TransactionType.Transfer),
+            FinancialTransaction(amount = BigDecimal("100"), currencyCode = "HKD", date = now, type = TransactionType.Transfer)
+        )
+        val progress = AdvanceProgressCalculator.compute(
+            listOf(
+                AdvanceParticipant(
+                    name = "Friend A",
+                    owedAmount = BigDecimal("100"),
+                    repaidAmount = BigDecimal.ZERO
+                )
+            )
+        )
+
+        val totals = calculator.totals(transactions)
+
+        assertMoneyEquals("50.00", totals.expenseBase)
+        assertMoneyEquals("0.00", totals.incomeBase)
+        assertMoneyEquals("100.00", progress.outstandingTotal)
+    }
+
+    @Test
+    fun vector8_othersAdvancedMe_repaymentDoesNotDoubleCountExpense() {
+        val calculator = IncomeExpenseCalculator(baseCurrencyCode = "HKD", fxRatesToBase = fxRates)
+        val now = Instant.parse("2026-03-01T00:00:00Z")
+        val transactions = listOf(
+            FinancialTransaction(amount = BigDecimal("-150"), currencyCode = "HKD", date = now, type = TransactionType.Expense),
+            FinancialTransaction(amount = BigDecimal("-150"), currencyCode = "HKD", date = now, type = TransactionType.Transfer),
+            FinancialTransaction(amount = BigDecimal("150"), currencyCode = "HKD", date = now, type = TransactionType.Transfer)
+        )
+        val progress = AdvanceProgressCalculator.compute(
+            listOf(
+                AdvanceParticipant(
+                    name = "Friend A",
+                    owedAmount = BigDecimal("150"),
+                    repaidAmount = BigDecimal("150")
+                )
+            )
+        )
+
+        val totals = calculator.totals(transactions)
+
+        assertMoneyEquals("150.00", totals.expenseBase)
+        assertMoneyEquals("0.00", totals.incomeBase)
+        assertMoneyEquals("0.00", progress.outstandingTotal)
+    }
+
+    @Test
+    fun vector13_settlementRecordsAreExcludedFromReports() {
+        val calculator = IncomeExpenseCalculator(baseCurrencyCode = "HKD", fxRatesToBase = fxRates)
+        val now = Instant.parse("2026-03-01T00:00:00Z")
+        val forgivenessNote = TransactionSemantics.debtForgivenessNote(
+            baseNote = "",
+            debtAccountName = "Friend A",
+            direction = DebtForgivenessDirection.ForgivenByOthers
+        )
+        val transactions = listOf(
+            FinancialTransaction(amount = BigDecimal("-20"), currencyCode = "HKD", date = now, type = TransactionType.Expense),
+            FinancialTransaction(amount = BigDecimal("-40"), currencyCode = "HKD", date = now, type = TransactionType.Transfer),
+            FinancialTransaction(amount = BigDecimal("40"), currencyCode = "HKD", date = now, type = TransactionType.Transfer),
+            FinancialTransaction(amount = BigDecimal("40"), currencyCode = "HKD", date = now, note = forgivenessNote, type = TransactionType.Transfer),
+            FinancialTransaction(amount = BigDecimal("-100"), currencyCode = "HKD", date = now, type = TransactionType.Transfer),
+            FinancialTransaction(amount = BigDecimal("92"), currencyCode = "CNY", date = now, type = TransactionType.Transfer),
+            FinancialTransaction(
+                amount = BigDecimal("1000"),
+                currencyCode = "JPY",
+                date = now,
+                note = "${TransactionSemantics.ASSET_ADJUSTMENT_MARKER} JPY",
+                type = TransactionType.Transfer
+            )
+        )
+
+        val totals = calculator.totals(transactions)
+
+        assertTrue(TransactionSemantics.isDebtForgiveness(forgivenessNote))
+        assertMoneyEquals("20.00", totals.expenseBase)
+        assertMoneyEquals("0.00", totals.incomeBase)
     }
 
     private fun assertMoneyEquals(expected: String, actual: BigDecimal) {

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -222,6 +222,105 @@ class BackupRoundTripTest {
         val report = repository.buildDataHealthReport()
         assertEquals(0, report.errorCount)
         assertEquals(0, report.warningCount)
+
+        val participant = advanceCase.participants.single()
+        repository.recordAdvanceRepayment(
+            advanceCase = advanceCase.advanceCase,
+            participant = participant,
+            amount = BigDecimal("150"),
+            normalizedAmount = BigDecimal("150"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-03-21T13:00:00Z"),
+            note = "還款",
+            receiveAccount = ownAccount,
+            category = null,
+            tagIds = emptyList(),
+            isBorrowedByMe = true
+        )
+
+        val updatedCase = checkNotNull(repository.getAdvanceCase(caseId))
+        val transactionsAfterRepayment = database.transactionDao().getAllWithDetails()
+        val ownAccountAfterRepayment = transactionsAfterRepayment.filter { it.transaction.accountId == ownAccount.id }
+        val expenseTransactions = transactionsAfterRepayment.filter {
+            it.transaction.type == TransactionType.Expense
+        }
+
+        assertEquals(1, ownAccountAfterRepayment.size)
+        assertEquals(TransactionType.Transfer, ownAccountAfterRepayment.single().transaction.type)
+        assertEquals(BigDecimal("-150"), ownAccountAfterRepayment.single().transaction.amount)
+        assertEquals(1, expenseTransactions.size)
+        assertEquals(BigDecimal("-150"), expenseTransactions.single().transaction.amount)
+        assertEquals(
+            BigDecimal.ZERO,
+            updatedCase.participants.single().owedAmount - updatedCase.participants.single().repaidAmount
+        )
+    }
+
+    @Test
+    fun advancedOthersCreation_recordsFullOutflowAndOnlySelfShareExpense() = runBlocking {
+        val ownAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val debtAccount = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Friend A",
+            currency = "HKD",
+            type = AccountType.Debt,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 1,
+            isArchived = false
+        )
+        val category = CategoryEntity(
+            id = UUID.randomUUID(),
+            name = "Food",
+            icon = "fork.knife",
+            colorHex = "#FF8800",
+            kind = CategoryKind.Expense
+        )
+        database.accountDao().upsertAll(listOf(ownAccount, debtAccount))
+        database.categoryDao().upsert(category)
+
+        val caseId = repository.createAdvanceCase(
+            title = "代付晚餐",
+            date = Instant.parse("2026-03-21T12:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal("50"),
+            note = "晚餐",
+            payerAccount = ownAccount,
+            expenseCategory = category,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(debtAccount, BigDecimal("100"))),
+            isBorrowedByMe = false
+        )
+
+        val advanceCase = checkNotNull(repository.getAdvanceCase(caseId))
+        val transactions = database.transactionDao().getAllWithDetails()
+        val ownAccountTransactions = transactions.filter { it.transaction.accountId == ownAccount.id }
+        val debtTransactions = transactions.filter { it.transaction.accountId == debtAccount.id }
+        val expenseTransactions = transactions.filter { it.transaction.type == TransactionType.Expense }
+
+        assertEquals(
+            BigDecimal("-150"),
+            ownAccountTransactions.fold(BigDecimal.ZERO) { total, transaction ->
+                total + transaction.transaction.amount
+            }
+        )
+        assertEquals(1, expenseTransactions.size)
+        assertEquals(BigDecimal("-50"), expenseTransactions.single().transaction.amount)
+        assertEquals(category.id, expenseTransactions.single().transaction.categoryId)
+        assertEquals(1, debtTransactions.size)
+        assertEquals(TransactionType.Transfer, debtTransactions.single().transaction.type)
+        assertEquals(BigDecimal("100"), debtTransactions.single().transaction.amount)
+        assertEquals(
+            BigDecimal("100"),
+            advanceCase.participants.single().owedAmount - advanceCase.participants.single().repaidAmount
+        )
     }
 
     @Test

--- a/docs/specs/parity-test-vectors.md
+++ b/docs/specs/parity-test-vectors.md
@@ -1,7 +1,7 @@
 # Cross-Platform Parity Test Vectors
 
 Status: Active  
-Last updated: 2026-03-03
+Last updated: 2026-06-06
 
 This document defines deterministic input/output vectors for iOS and Android parity checks.
 
@@ -108,6 +108,118 @@ Expected:
 - The actual `50 HKD` repayment remains visible in repayment history / timeline.
 - The actual `50 HKD` repayment must not appear as a separate reverse debt balance.
 - Raw linked advance transfer legs are implementation details and must not drive settlement summary balances.
+
+## Vector 7: 我代墊他人
+
+Input:
+- Own account A pays `150 HKD`.
+- User share: `50 HKD`.
+- Participant P owes: `100 HKD`.
+
+Expected:
+- Own account A ledger delta: `-150 HKD`.
+- Expense report contribution: `50 HKD` only.
+- Participant P outstanding receivable: `100 HKD`.
+- The participant transfer legs contribute `0` to income/expense reports.
+
+## Vector 8: 他人代墊我 + Repayment
+
+Input:
+- Participant P pays `150 HKD` for the user.
+- No own account is selected at case creation.
+- The user later repays `150 HKD` from own account A.
+
+Expected after creation:
+- Own account A ledger delta: `0`.
+- Debt account P contains one `Expense -150 HKD`.
+- Expense report contribution: `150 HKD`.
+- Participant P outstanding payable: `150 HKD`.
+
+Expected after repayment:
+- Own account A repayment delta: `-150 HKD`.
+- Participant P outstanding payable: `0`.
+- Expense report contribution remains `150 HKD`; repayment does not count again.
+- Income report contribution remains `0`.
+
+## Vector 9: Mutual Debt Offset
+
+Input for the same participant and currency:
+- Participant P owes the user `100 HKD`.
+- The user owes participant P `40 HKD`.
+
+Expected after offset:
+- Offset amount: `40 HKD`.
+- Remaining receivable: `60 HKD`.
+- Remaining payable: `0 HKD`.
+- No `FinancialTransaction` is created.
+- Income/expense reports are unchanged.
+- Two auditable `AdvanceRepayment` records share one `[債務抵銷:<UUID>]` marker.
+
+## Vector 10: Debt Forgiveness
+
+Input:
+- Forgiveness amount: `40 HKD`.
+- Direction A: another person forgives what the user owes.
+- Direction B: the user forgives what another person owes.
+
+Expected:
+- The debt balance decreases in the selected direction.
+- No own cash/bank account moves.
+- Transaction persistence uses `Transfer` semantics and the `[免除債務]` marker.
+- Income report contribution: `0`.
+- Expense report contribution: `0`.
+
+## Vector 11: Same-Account Cross-Currency Transfer
+
+Input transfer group `G2` on account A:
+- Outgoing leg: `-100 HKD`.
+- Incoming leg: `+92 CNY`.
+
+Expected:
+- Both legs reference account A and group `G2`.
+- Linked transaction IDs and `Outgoing` / `Incoming` sides are preserved.
+- Income/expense reports are unaffected.
+- Backup export/import preserves both currencies, account ID, group ID, linked IDs, and transfer sides.
+
+## Vector 12: Asset Adjustment
+
+Input:
+- Asset adjustment record: `+1000 JPY`.
+- Persistence type: `Transfer`.
+- Note begins with `[資產調整]`.
+
+Expected:
+- Account asset estimate includes the adjustment according to account-balance rules.
+- Income report contribution: `0`.
+- Expense report contribution: `0`.
+- The ledger labels the record as an asset adjustment rather than ordinary income.
+
+## Vector 13: Settlement Report Exclusion Set
+
+Input:
+- One ordinary expense: `-20 HKD`.
+- One repayment transfer group.
+- One debt-forgiveness transfer.
+- One same-account cross-currency transfer group.
+- One asset adjustment transfer.
+- One mutual debt offset represented only by repayment markers.
+
+Expected:
+- Total expense: `20 HKD`.
+- Total income: `0 HKD`.
+- Settlement and transfer records remain auditable but never inflate income/expense totals.
+
+## Automated Coverage
+
+| Vector | iOS | Android |
+|---|---|---|
+| 1-5 | `BackupCompatibilityTests`, `LedgerSemanticVectorsTests` | `ParityVectorsTest`, `BackupRoundTripTest` |
+| 6 | `testCrossCurrencyAdvanceRepayment_semanticDebtBalanceUsesCaseCurrencyRemainingOnly` | `crossCurrencyAdvanceRepayment_semanticDebtBalanceUsesCaseCurrencyRemainingOnly` |
+| 7 | `testAdvancedOthersCreation_recordsFullOutflowAndOnlySelfShareExpense`, `LedgerSemanticVectorsTests.testVector7_iAdvancedOthers_reportsOnlyUserShare` | `advancedOthersCreation_recordsFullOutflowAndOnlySelfShareExpense`, `ParityVectorsTest.vector7_iAdvancedOthers_reportsOnlyUserShare` |
+| 8 | `testBorrowedAdvanceCreation_recordsDebtExpenseWithoutInflatingOwnAccount` | `borrowedAdvanceCreation_recordsDebtExpenseWithoutInflatingOwnAccount` |
+| 9 | `testMutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions` | `mutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions` |
+| 10, 12, 13 | `LedgerSemanticVectorsTests.testVector13_settlementRecordsAreExcludedFromReports` | `ParityVectorsTest.vector13_settlementRecordsAreExcludedFromReports` |
+| 11 | `testExportImport_preservesSameAccountCrossCurrencyTransferAndBudgetHistory_excludesUIPreferences` | `backupRoundTrip_preservesSameAccountCrossCurrencyTransferAndBudgetHistory` |
 
 ## CI Gate Recommendation
 


### PR DESCRIPTION
## Summary
- document deterministic ledger semantics for advances, settlement, forgiveness, offsets, same-account FX transfers, and asset adjustments
- add matching iOS and Android parity vector tests
- strengthen repository integration tests for both advance directions and ensure repayments do not double-count expenses

## Validation
- iOS: 25 tests passed on iPhone 13 Simulator
- Android: `./gradlew testDebugUnitTest assembleDebug`

Closes #117