### PR TITLE
Add refund semantic vectors

### DIFF
--- a/AI 記帳/Services/RefundSemanticsService.swift
+++ b/AI 記帳/Services/RefundSemanticsService.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+enum RefundSemanticsError: Error, Equatable {
+    case invalidRefundAmount
+    case invalidOriginalExpenseRemaining
+}
+
+enum RefundDestinationKind: Equatable {
+    case ownAccount
+    case debtAccount
+}
+
+struct RefundSemanticInput: Equatable {
+    let amount: Decimal
+    let destination: RefundDestinationKind
+    let originalExpenseRemaining: Decimal?
+
+    init(
+        amount: Decimal,
+        destination: RefundDestinationKind,
+        originalExpenseRemaining: Decimal? = nil
+    ) {
+        self.amount = amount
+        self.destination = destination
+        self.originalExpenseRemaining = originalExpenseRemaining
+    }
+}
+
+struct RefundSemanticEffect: Equatable {
+    let ownAccountDelta: Decimal
+    let debtBalanceDelta: Decimal
+    let expenseReduction: Decimal
+    let incomeContribution: Decimal
+    let settlementOnlyAmount: Decimal
+
+    var reportNetExpenseDelta: Decimal {
+        -expenseReduction
+    }
+}
+
+enum RefundSemanticsService {
+    static func effect(for input: RefundSemanticInput) throws -> RefundSemanticEffect {
+        guard input.amount > 0 else {
+            throw RefundSemanticsError.invalidRefundAmount
+        }
+        if let originalExpenseRemaining = input.originalExpenseRemaining,
+           originalExpenseRemaining < 0 {
+            throw RefundSemanticsError.invalidOriginalExpenseRemaining
+        }
+
+        let expenseReduction = min(input.amount, input.originalExpenseRemaining ?? input.amount)
+        let settlementOnlyAmount = max(0, input.amount - expenseReduction)
+
+        let ownAccountDelta: Decimal
+        let debtBalanceDelta: Decimal
+        switch input.destination {
+        case .ownAccount:
+            ownAccountDelta = input.amount
+            debtBalanceDelta = 0
+        case .debtAccount:
+            ownAccountDelta = 0
+            debtBalanceDelta = input.amount
+        }
+
+        return RefundSemanticEffect(
+            ownAccountDelta: ownAccountDelta,
+            debtBalanceDelta: debtBalanceDelta,
+            expenseReduction: expenseReduction,
+            incomeContribution: 0,
+            settlementOnlyAmount: settlementOnlyAmount
+        )
+    }
+}

--- a/AI 記帳Tests/RefundSemanticsServiceTests.swift
+++ b/AI 記帳Tests/RefundSemanticsServiceTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import AI_記帳
+
+@MainActor
+final class RefundSemanticsServiceTests: XCTestCase {
+    func testRefundToOwnAccount_reducesExpenseWithoutIncome() throws {
+        let effect = try RefundSemanticsService.effect(
+            for: RefundSemanticInput(
+                amount: 2_550,
+                destination: .ownAccount,
+                originalExpenseRemaining: 20_650
+            )
+        )
+
+        XCTAssertEqual(Decimal(2_550), effect.ownAccountDelta)
+        XCTAssertEqual(Decimal.zero, effect.debtBalanceDelta)
+        XCTAssertEqual(Decimal(2_550), effect.expenseReduction)
+        XCTAssertEqual(Decimal(-2_550), effect.reportNetExpenseDelta)
+        XCTAssertEqual(Decimal.zero, effect.incomeContribution)
+        XCTAssertEqual(Decimal.zero, effect.settlementOnlyAmount)
+    }
+
+    func testRefundToDebtAccount_reducesExpenseAndCreatesReceivableOrReducesPayable() throws {
+        let effect = try RefundSemanticsService.effect(
+            for: RefundSemanticInput(
+                amount: 2_550,
+                destination: .debtAccount,
+                originalExpenseRemaining: 20_650
+            )
+        )
+
+        XCTAssertEqual(Decimal.zero, effect.ownAccountDelta)
+        XCTAssertEqual(Decimal(2_550), effect.debtBalanceDelta)
+        XCTAssertEqual(Decimal(2_550), effect.expenseReduction)
+        XCTAssertEqual(Decimal(-2_550), effect.reportNetExpenseDelta)
+        XCTAssertEqual(Decimal.zero, effect.incomeContribution)
+        XCTAssertEqual(Decimal.zero, effect.settlementOnlyAmount)
+    }
+
+    func testRefundReductionIsCappedAtOriginalExpenseRemaining() throws {
+        let effect = try RefundSemanticsService.effect(
+            for: RefundSemanticInput(
+                amount: 2_550,
+                destination: .debtAccount,
+                originalExpenseRemaining: 2_000
+            )
+        )
+
+        XCTAssertEqual(Decimal(2_550), effect.debtBalanceDelta)
+        XCTAssertEqual(Decimal(2_000), effect.expenseReduction)
+        XCTAssertEqual(Decimal(-2_000), effect.reportNetExpenseDelta)
+        XCTAssertEqual(Decimal.zero, effect.incomeContribution)
+        XCTAssertEqual(Decimal(550), effect.settlementOnlyAmount)
+    }
+
+    func testRefundAmountMustBePositive() {
+        XCTAssertThrowsError(
+            try RefundSemanticsService.effect(
+                for: RefundSemanticInput(amount: 0, destination: .ownAccount)
+            )
+        ) { error in
+            XCTAssertEqual(error as? RefundSemanticsError, .invalidRefundAmount)
+        }
+    }
+}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,7 @@ The app is not a double-entry accounting system. It still needs strict semantic 
 - **Transfer** does not count toward income or expense reports. It moves value between accounts or records settlement semantics.
 - **Asset adjustment** is represented as transfer-like bookkeeping and must not affect income/expense charts.
 - **Debt forgiveness** and **mutual debt offset** are not regular income/expense. They settle debt semantics without changing own-account cash flow.
+- **Refund / rebate** is not regular income. It reverses or reduces a previously recorded expense. If the refund is received by an own account, the own account increases. If the refund is received by a debt account holder, that person's debt balance moves in the user's favour.
 
 ## Advances
 
@@ -40,6 +41,7 @@ The app is not a double-entry accounting system. It still needs strict semantic 
 - **Advance repayment**: A settlement record for a participant. If real money moves, it may link to a transfer group. If it is a ledger-only offset, it can exist without a received account or transfer group.
 - **Cross-currency advance repayment**: The amount actually received or paid can use a different currency from the advance case. The repayment stores the actual currency amount and a normalized amount in the case currency for remaining-balance calculations.
 - **Mutual debt offset (`債務抵銷`)**: Ledger-only settlement between opposing advance balances for the same person and currency. It is not repayment by cash and not debt forgiveness.
+- **Refund on an advance (`退款`)**: A merchant or provider returns value related to a prior expense or advance. It reduces net expense for the linked category/tag up to the remaining original expense amount. Any excess is settlement-only, not income.
 
 ## Debt Management
 
@@ -55,6 +57,8 @@ The app is not a double-entry accounting system. It still needs strict semantic 
 - **Estimated main-currency total**: A report display amount converted into the main currency using the current rate system. It is a display estimate, not a stored historical FX snapshot.
 - **Estimate status**: Report UI should make clear whether conversion used live, cached, partial, or unavailable rates.
 - **Report drill-down**: Category/tag detail sheets should show both estimated main-currency totals and original-currency breakdowns so users can audit the estimate.
+- **Gross expense** is the original spending before refunds.
+- **Net expense** is gross expense minus refund reductions. Refunds must not be displayed as income to make net expense look better.
 
 ## Backup Roundtrip
 
@@ -76,3 +80,4 @@ Current ADRs:
 - `docs/adr/0001-ledger-classification.md`
 - `docs/adr/0002-advance-and-debt-settlement.md`
 - `docs/adr/0003-report-currency-estimates.md`
+- `docs/adr/0004-refund-semantics.md`

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/refund/RefundSemantics.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/refund/RefundSemantics.kt
@@ -1,0 +1,59 @@
+package org.duckdns.lhfser.aiaccounting.core.refund
+
+import java.math.BigDecimal
+
+enum class RefundDestinationKind {
+    OwnAccount,
+    DebtAccount
+}
+
+data class RefundSemanticInput(
+    val amount: BigDecimal,
+    val destination: RefundDestinationKind,
+    val originalExpenseRemaining: BigDecimal? = null
+)
+
+data class RefundSemanticEffect(
+    val ownAccountDelta: BigDecimal,
+    val debtBalanceDelta: BigDecimal,
+    val expenseReduction: BigDecimal,
+    val incomeContribution: BigDecimal,
+    val settlementOnlyAmount: BigDecimal
+) {
+    val reportNetExpenseDelta: BigDecimal = expenseReduction.negate()
+}
+
+object RefundSemantics {
+    fun effect(input: RefundSemanticInput): RefundSemanticEffect {
+        require(input.amount > BigDecimal.ZERO) { "Refund amount must be positive." }
+        input.originalExpenseRemaining?.let { remaining ->
+            require(remaining >= BigDecimal.ZERO) { "Original expense remaining must not be negative." }
+        }
+
+        val expenseReduction = input.originalExpenseRemaining
+            ?.min(input.amount)
+            ?: input.amount
+        val settlementOnlyAmount = (input.amount - expenseReduction).max(BigDecimal.ZERO)
+
+        val ownAccountDelta: BigDecimal
+        val debtBalanceDelta: BigDecimal
+        when (input.destination) {
+            RefundDestinationKind.OwnAccount -> {
+                ownAccountDelta = input.amount
+                debtBalanceDelta = BigDecimal.ZERO
+            }
+            RefundDestinationKind.DebtAccount -> {
+                ownAccountDelta = BigDecimal.ZERO
+                debtBalanceDelta = input.amount
+            }
+        }
+
+        return RefundSemanticEffect(
+            ownAccountDelta = ownAccountDelta,
+            debtBalanceDelta = debtBalanceDelta,
+            expenseReduction = expenseReduction,
+            incomeContribution = BigDecimal.ZERO,
+            settlementOnlyAmount = settlementOnlyAmount
+        )
+    }
+}

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/RefundSemanticsTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/RefundSemanticsTest.kt
@@ -1,0 +1,80 @@
+package org.duckdns.lhfser.aiaccounting.core
+
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundDestinationKind
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundSemanticInput
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundSemantics
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.math.BigDecimal
+
+class RefundSemanticsTest {
+    @Test
+    fun refundToOwnAccount_reducesExpenseWithoutIncome() {
+        val effect = RefundSemantics.effect(
+            RefundSemanticInput(
+                amount = BigDecimal("2550"),
+                destination = RefundDestinationKind.OwnAccount,
+                originalExpenseRemaining = BigDecimal("20650")
+            )
+        )
+
+        assertMoneyEquals("2550", effect.ownAccountDelta)
+        assertMoneyEquals("0", effect.debtBalanceDelta)
+        assertMoneyEquals("2550", effect.expenseReduction)
+        assertMoneyEquals("-2550", effect.reportNetExpenseDelta)
+        assertMoneyEquals("0", effect.incomeContribution)
+        assertMoneyEquals("0", effect.settlementOnlyAmount)
+    }
+
+    @Test
+    fun refundToDebtAccount_reducesExpenseAndCreatesReceivableOrReducesPayable() {
+        val effect = RefundSemantics.effect(
+            RefundSemanticInput(
+                amount = BigDecimal("2550"),
+                destination = RefundDestinationKind.DebtAccount,
+                originalExpenseRemaining = BigDecimal("20650")
+            )
+        )
+
+        assertMoneyEquals("0", effect.ownAccountDelta)
+        assertMoneyEquals("2550", effect.debtBalanceDelta)
+        assertMoneyEquals("2550", effect.expenseReduction)
+        assertMoneyEquals("-2550", effect.reportNetExpenseDelta)
+        assertMoneyEquals("0", effect.incomeContribution)
+        assertMoneyEquals("0", effect.settlementOnlyAmount)
+    }
+
+    @Test
+    fun refundReductionIsCappedAtOriginalExpenseRemaining() {
+        val effect = RefundSemantics.effect(
+            RefundSemanticInput(
+                amount = BigDecimal("2550"),
+                destination = RefundDestinationKind.DebtAccount,
+                originalExpenseRemaining = BigDecimal("2000")
+            )
+        )
+
+        assertMoneyEquals("2550", effect.debtBalanceDelta)
+        assertMoneyEquals("2000", effect.expenseReduction)
+        assertMoneyEquals("-2000", effect.reportNetExpenseDelta)
+        assertMoneyEquals("0", effect.incomeContribution)
+        assertMoneyEquals("550", effect.settlementOnlyAmount)
+    }
+
+    @Test
+    fun refundAmountMustBePositive() {
+        assertThrows(IllegalArgumentException::class.java) {
+            RefundSemantics.effect(
+                RefundSemanticInput(
+                    amount = BigDecimal.ZERO,
+                    destination = RefundDestinationKind.OwnAccount
+                )
+            )
+        }
+    }
+
+    private fun assertMoneyEquals(expected: String, actual: BigDecimal) {
+        assertEquals(0, BigDecimal(expected).compareTo(actual))
+    }
+}

--- a/docs/adr/0001-ledger-classification.md
+++ b/docs/adr/0001-ledger-classification.md
@@ -5,7 +5,7 @@ Date: 2026-06-05
 
 ## Context
 
-The app stores financial records as `Income`, `Expense`, or `Transfer`. Several flows look like income or expense at the UI level but must not be counted in reports, including transfers, asset adjustments, debt forgiveness, and mutual debt offsets.
+The app stores financial records as `Income`, `Expense`, or `Transfer`. Several flows look like income or expense at the UI level but must not be counted in reports, including transfers, asset adjustments, debt forgiveness, mutual debt offsets, and refunds.
 
 Without a written rule, future changes can accidentally inflate income, expense, or asset totals.
 
@@ -19,6 +19,7 @@ Use the transaction type and flow marker semantics to decide report inclusion:
 - Asset-adjustment legacy records are transfer-like and excluded from income/expense reports.
 - Debt forgiveness is a settlement event and excluded from income/expense reports.
 - Mutual debt offset is a ledger-only settlement event and excluded from income/expense reports.
+- Refunds are expense reversals, not income. A linked refund reduces net expense up to the remaining original expense amount; any excess is settlement-only and must not be counted as income.
 
 Normal income entry points must only allow own accounts. Debt accounts are handled through debt or advance flows.
 
@@ -26,6 +27,7 @@ Normal income entry points must only allow own accounts. Debt accounts are handl
 
 - Report code must not infer income/expense from note text alone.
 - Transfer groups can carry settlement semantics but must remain excluded from income/expense totals.
+- Report code that displays refunds should show enough gross/refund/net detail for users to understand why a category total changed.
 - Data health checks should flag old data where normal income was recorded into a debt account.
 - Shortcut creation and editing must obey the same own-account/debt-account boundary as full entry forms.
 

--- a/docs/adr/0003-report-currency-estimates.md
+++ b/docs/adr/0003-report-currency-estimates.md
@@ -22,6 +22,7 @@ Report drill-down sheets should show the same information as the top-level repor
 - original currency breakdown;
 - transaction count;
 - estimate status when conversion is cached, partial, or unavailable.
+- gross expense, refund reduction, and net expense when a report slice contains linked refunds.
 
 Cross-currency advance repayments should preserve both actual payment currency and normalized case-currency amount. Reports should use transaction semantics for income/expense inclusion and should not treat repayment transfer movement as new spending.
 
@@ -29,6 +30,7 @@ Cross-currency advance repayments should preserve both actual payment currency a
 
 - Main-currency report totals are estimates unless the transaction currency already equals the main currency.
 - UI should avoid presenting converted totals as exact historical accounting facts.
+- Refund-aware reports should not hide the original gross spending; users need both gross and net numbers to audit travel or shared-expense categories.
 - Tests should use fixed exchange rates and exact decimal arithmetic.
 - Future work that stores historical FX snapshots must update this ADR, the data model contract, backup compatibility, and parity vectors.
 

--- a/docs/adr/0004-refund-semantics.md
+++ b/docs/adr/0004-refund-semantics.md
@@ -1,0 +1,50 @@
+# ADR 0004: Refund And Rebate Semantics
+
+Status: Accepted
+Date: 2026-06-09
+
+## Context
+
+Travel and shared-expense flows can receive refunds after the original expense has already been recorded. A refund can arrive in the user's own account, or it can arrive with a debt account holder such as a friend who paid or received money on the user's behalf.
+
+Treating refunds as ordinary income makes reports misleading. Treating a refund received by another person as if it entered the user's own account inflates assets. Treating every refund as a debt settlement hides the fact that the original category's net expense changed.
+
+## Decision
+
+Refunds are expense reversals, not income.
+
+### Refund received by an own account
+
+- The own account increases by the actual refund amount.
+- The linked category/tag net expense decreases by the refund amount.
+- Income contribution is `0`.
+
+### Refund received by a debt account holder
+
+- The user's own account does not move.
+- The debt balance moves in the user's favour by the refund amount.
+  - If the user still owes that person, the payable decreases.
+  - If nothing is owed, that person now owes the user.
+- The linked category/tag net expense decreases by the refund amount.
+- Income contribution is `0`.
+
+### Refund cap and excess
+
+When a refund is linked to a known original expense, report reduction is capped at the remaining original expense amount. Any excess is settlement-only and must not be counted as income.
+
+## Consequences
+
+- Refund forms should prefill as much as possible from the original expense or advance case.
+- Refund records must be auditable and reversible, because they can alter both reports and debt balances.
+- Report drill-down should show gross expense, refund reduction, net expense, original-currency totals, and estimate status.
+- Cross-platform parity vectors must cover own-account refunds, debt-account refunds, capped reductions, and cross-currency display expectations.
+- v1 does not require a SwiftData or Room schema migration; persistence can be designed in a later PR after this semantic seam is stable.
+
+## Related Specs
+
+- `CONTEXT.md`
+- `docs/specs/data-model.md`
+- `docs/specs/parity-test-vectors.md`
+- `docs/adr/0001-ledger-classification.md`
+- `docs/adr/0002-advance-and-debt-settlement.md`
+- `docs/adr/0003-report-currency-estimates.md`

--- a/docs/specs/data-model.md
+++ b/docs/specs/data-model.md
@@ -81,6 +81,7 @@ Invariants:
 - Expense should be negative amount.
 - Transfer should not be counted as income/expense.
 - For transfer groups, legs should share `transferGroupID`.
+- Refund semantics are not represented by a dedicated persisted type yet. Until a future schema is defined, refund domain logic must treat refunds as expense reversals, never ordinary income.
 
 ### `Shortcut`
 - `id: UUID` (unique)
@@ -170,6 +171,7 @@ Compatibility behavior currently implemented on import:
 - Currency conversion is based on each transaction's `currencyCode`, not account default currency.
 - Asset-adjustment legacy records are represented as transfers and must not affect income/expense charts.
 - Multi-leg transfer editing must preserve `transferGroupID`.
+- Refunds are expense reversals. If a refund lands in an own account, the own account increases. If a refund lands with a debt account holder, the debt balance moves in the user's favour. Linked report reduction is capped at the remaining original expense amount.
 
 ## Change Policy
 

--- a/docs/specs/parity-test-vectors.md
+++ b/docs/specs/parity-test-vectors.md
@@ -1,7 +1,7 @@
 # Cross-Platform Parity Test Vectors
 
 Status: Active  
-Last updated: 2026-06-06
+Last updated: 2026-06-09
 
 This document defines deterministic input/output vectors for iOS and Android parity checks.
 
@@ -209,6 +209,48 @@ Expected:
 - Total income: `0 HKD`.
 - Settlement and transfer records remain auditable but never inflate income/expense totals.
 
+## Vector 14: Refund To Own Account
+
+Input:
+- Original linked expense remaining: `20650 JPY`.
+- Refund amount: `2550 JPY`.
+- Refund destination: own account A.
+
+Expected:
+- Own account A ledger delta: `+2550 JPY`.
+- Debt balance delta: `0`.
+- Expense report reduction: `2550 JPY`.
+- Net expense delta: `-2550 JPY`.
+- Income report contribution: `0`.
+
+## Vector 15: Refund To Debt Account Holder
+
+Input:
+- Original linked expense remaining: `20650 JPY`.
+- Refund amount: `2550 JPY`.
+- Refund destination: debt account Colin.
+
+Expected:
+- Own account ledger delta: `0`.
+- Colin debt balance delta: `+2550 JPY` in the user's favour.
+- If the user still owes Colin, payable decreases by `2550 JPY`.
+- If the case is already settled, Colin now owes the user `2550 JPY`.
+- Expense report reduction: `2550 JPY`.
+- Income report contribution: `0`.
+
+## Vector 16: Refund Larger Than Remaining Expense
+
+Input:
+- Original linked expense remaining: `2000 JPY`.
+- Refund amount: `2550 JPY`.
+- Refund destination: debt account Colin.
+
+Expected:
+- Colin debt balance delta: `+2550 JPY` in the user's favour.
+- Expense report reduction is capped at `2000 JPY`.
+- Settlement-only amount: `550 JPY`.
+- Income report contribution: `0`.
+
 ## Automated Coverage
 
 | Vector | iOS | Android |
@@ -220,6 +262,7 @@ Expected:
 | 9 | `testMutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions` | `mutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions` |
 | 10, 12, 13 | `LedgerSemanticVectorsTests.testVector13_settlementRecordsAreExcludedFromReports` | `ParityVectorsTest.vector13_settlementRecordsAreExcludedFromReports` |
 | 11 | `testExportImport_preservesSameAccountCrossCurrencyTransferAndBudgetHistory_excludesUIPreferences` | `backupRoundTrip_preservesSameAccountCrossCurrencyTransferAndBudgetHistory` |
+| 14-16 | `RefundSemanticsServiceTests` | `RefundSemanticsTest` |
 
 ## CI Gate Recommendation
 


### PR DESCRIPTION
## Summary
- define refund / rebate as an expense reversal, not ordinary income
- add iOS and Android pure refund semantics modules and parity tests
- document own-account refunds, debt-account-holder refunds, capped report reductions, and settlement-only excess

## Guidelines used
- Apple HIG Entering Data: minimise user-entered data and make required data clear
- Apple HIG Undo and Redo: settlement/refund actions need predictable, auditable reversal semantics
- Apple HIG Charts: report views should expose enough gross/refund/net detail for users to understand data
- Android Architecture UI/Data layer guidance: business logic belongs in domain/data layers, not screen UI

## Validation
- Android targeted: `./gradlew testDebugUnitTest --tests org.duckdns.lhfser.aiaccounting.core.RefundSemanticsTest`
- Android full: `./gradlew testDebugUnitTest assembleDebug`
- Docs/whitespace: `git diff --check`

## iOS local validation note
Local iOS test/build is currently blocked by the local Xcode destination environment: Xcode 26.5 only exposes ineligible iOS device destinations while installed simulators are iOS 26.2. GitHub CI should provide the authoritative iOS build/test signal for this PR.