### PR TITLE
Add refund-aware report aggregation

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -42,9 +42,9 @@ jobs:
         run: chmod +x android/gradlew
 
       - name: Build Debug APK
-        run: ./gradlew :app:assembleDebug --stacktrace
+        run: ./gradlew :app:assembleDebug --no-daemon --console=plain --stacktrace
         working-directory: android
 
       - name: Run Unit Tests
-        run: ./gradlew :app:testDebugUnitTest --stacktrace
+        run: ./gradlew :app:testDebugUnitTest --no-daemon --console=plain --stacktrace
         working-directory: android

--- a/AI 記帳/Services/ReportAggregationService.swift
+++ b/AI 記帳/Services/ReportAggregationService.swift
@@ -58,6 +58,36 @@ struct ReportTransactionSnapshot {
     let categoryName: String?
     let categoryColorHex: String?
     let tagNames: [String]
+    let semantic: ReportTransactionSemantic
+
+    init(
+        id: UUID,
+        amount: Decimal,
+        currencyCode: String,
+        date: Date,
+        type: TransactionType,
+        categoryID: UUID?,
+        categoryName: String?,
+        categoryColorHex: String?,
+        tagNames: [String],
+        semantic: ReportTransactionSemantic = .regular
+    ) {
+        self.id = id
+        self.amount = amount
+        self.currencyCode = currencyCode
+        self.date = date
+        self.type = type
+        self.categoryID = categoryID
+        self.categoryName = categoryName
+        self.categoryColorHex = categoryColorHex
+        self.tagNames = tagNames
+        self.semantic = semantic
+    }
+}
+
+enum ReportTransactionSemantic: Equatable {
+    case regular
+    case refund(destination: RefundDestinationKind, originalExpenseRemaining: Decimal?)
 }
 
 struct ReportCurrencyTotal: Equatable {
@@ -71,6 +101,12 @@ struct ReportSlice: Identifiable, Equatable {
     let categoryColorHex: String?
     let estimatedAmount: Decimal
     let originalCurrencyTotals: [ReportCurrencyTotal]
+    let grossEstimatedAmount: Decimal
+    let grossOriginalCurrencyTotals: [ReportCurrencyTotal]
+    let refundReductionEstimatedAmount: Decimal
+    let refundReductionOriginalCurrencyTotals: [ReportCurrencyTotal]
+    let refundSettlementOnlyEstimatedAmount: Decimal
+    let refundSettlementOnlyOriginalCurrencyTotals: [ReportCurrencyTotal]
     let estimateStatus: ReportEstimateStatus
     let transactionIDs: [UUID]
 
@@ -80,6 +116,12 @@ struct ReportSlice: Identifiable, Equatable {
         ReportDetailSummary(
             estimatedAmount: estimatedAmount,
             originalCurrencyTotals: originalCurrencyTotals,
+            grossEstimatedAmount: grossEstimatedAmount,
+            grossOriginalCurrencyTotals: grossOriginalCurrencyTotals,
+            refundReductionEstimatedAmount: refundReductionEstimatedAmount,
+            refundReductionOriginalCurrencyTotals: refundReductionOriginalCurrencyTotals,
+            refundSettlementOnlyEstimatedAmount: refundSettlementOnlyEstimatedAmount,
+            refundSettlementOnlyOriginalCurrencyTotals: refundSettlementOnlyOriginalCurrencyTotals,
             estimateStatus: estimateStatus,
             transactionIDs: transactionIDs
         )
@@ -89,6 +131,12 @@ struct ReportSlice: Identifiable, Equatable {
 struct ReportDetailSummary: Equatable {
     let estimatedAmount: Decimal
     let originalCurrencyTotals: [ReportCurrencyTotal]
+    let grossEstimatedAmount: Decimal
+    let grossOriginalCurrencyTotals: [ReportCurrencyTotal]
+    let refundReductionEstimatedAmount: Decimal
+    let refundReductionOriginalCurrencyTotals: [ReportCurrencyTotal]
+    let refundSettlementOnlyEstimatedAmount: Decimal
+    let refundSettlementOnlyOriginalCurrencyTotals: [ReportCurrencyTotal]
     let estimateStatus: ReportEstimateStatus
     let transactionIDs: [UUID]
 
@@ -133,33 +181,34 @@ enum ReportAggregationService {
         request: ReportAggregationRequest,
         currencyConverter: ReportCurrencyConverting
     ) -> ReportAggregationResult {
-        let filtered = request.transactions.filter { transaction in
-            guard transaction.type == request.flow.transactionType else { return false }
-            if let startDate = request.startDate, transaction.date < startDate { return false }
-            if let endDate = request.endDate, transaction.date >= endDate { return false }
+        let filtered = request.transactions.compactMap { transaction -> ReportAggregationItem? in
+            guard let contribution = contribution(for: transaction, flow: request.flow) else { return nil }
+            if let startDate = request.startDate, transaction.date < startDate { return nil }
+            if let endDate = request.endDate, transaction.date >= endDate { return nil }
             if let tagFilter = request.tagFilter {
                 if tagFilter == "無標籤" {
-                    return transaction.tagNames.isEmpty
+                    guard transaction.tagNames.isEmpty else { return nil }
+                } else {
+                    guard transaction.tagNames.contains(tagFilter) else { return nil }
                 }
-                return transaction.tagNames.contains(tagFilter)
             }
-            return true
+            return ReportAggregationItem(transaction: transaction, contribution: contribution)
         }
 
-        let grouped: [String: [ReportTransactionSnapshot]]
+        let grouped: [String: [ReportAggregationItem]]
         switch request.grouping {
         case .category:
-            grouped = Dictionary(grouping: filtered) { transaction in
-                transaction.categoryID?.uuidString ?? "uncategorized"
+            grouped = Dictionary(grouping: filtered) { item in
+                item.transaction.categoryID?.uuidString ?? "uncategorized"
             }
         case .tag:
-            var tagGroups: [String: [ReportTransactionSnapshot]] = [:]
-            for transaction in filtered {
-                if transaction.tagNames.isEmpty {
-                    tagGroups["無標籤", default: []].append(transaction)
+            var tagGroups: [String: [ReportAggregationItem]] = [:]
+            for item in filtered {
+                if item.transaction.tagNames.isEmpty {
+                    tagGroups["無標籤", default: []].append(item)
                 } else {
-                    for tagName in transaction.tagNames {
-                        tagGroups[tagName, default: []].append(transaction)
+                    for tagName in item.transaction.tagNames {
+                        tagGroups[tagName, default: []].append(item)
                     }
                 }
             }
@@ -184,35 +233,85 @@ enum ReportAggregationService {
         return ReportAggregationResult(slices: slices)
     }
 
+    private static func contribution(
+        for transaction: ReportTransactionSnapshot,
+        flow: ReportFlow
+    ) -> ReportContribution? {
+        switch transaction.semantic {
+        case .regular:
+            guard transaction.type == flow.transactionType else { return nil }
+            return .regular(amount: abs(transaction.amount))
+        case let .refund(destination, originalExpenseRemaining):
+            guard flow == .expense else { return nil }
+            let input = RefundSemanticInput(
+                amount: abs(transaction.amount),
+                destination: destination,
+                originalExpenseRemaining: originalExpenseRemaining
+            )
+            guard let effect = try? RefundSemanticsService.effect(for: input) else { return nil }
+            return .refund(
+                reductionAmount: effect.expenseReduction,
+                settlementOnlyAmount: effect.settlementOnlyAmount
+            )
+        }
+    }
+
     private static func makeSlice(
         key: String,
-        transactions: [ReportTransactionSnapshot],
+        transactions: [ReportAggregationItem],
         grouping: ReportGroupingMode,
         currencyConverter: ReportCurrencyConverting
     ) -> ReportSlice {
-        var estimatedAmount = Decimal.zero
-        var originalTotals: [String: Decimal] = [:]
+        var gross = ReportAmountAccumulator()
+        var refundReduction = ReportAmountAccumulator()
+        var refundSettlementOnly = ReportAmountAccumulator()
+        var netOriginalTotals: [String: Decimal] = [:]
         var conversionStatuses: [ReportEstimateStatus] = []
         var unavailableCount = 0
+        var conversionAttemptCount = 0
 
-        for transaction in transactions {
-            let amount = abs(transaction.amount)
-            let currencyCode = transaction.currencyCode.uppercased()
-            originalTotals[currencyCode, default: 0] += amount
-
-            if let conversion = currencyConverter.estimateInMainCurrency(
-                amount: amount,
-                from: currencyCode
-            ) {
-                estimatedAmount += conversion.amount
-                conversionStatuses.append(conversion.status)
-            } else {
-                unavailableCount += 1
+        for item in transactions {
+            let currencyCode = item.transaction.currencyCode.uppercased()
+            switch item.contribution {
+            case let .regular(amount):
+                netOriginalTotals[currencyCode, default: 0] += amount
+                add(
+                    amount: amount,
+                    currencyCode: currencyCode,
+                    to: &gross,
+                    currencyConverter: currencyConverter,
+                    conversionStatuses: &conversionStatuses,
+                    unavailableCount: &unavailableCount,
+                    conversionAttemptCount: &conversionAttemptCount
+                )
+            case let .refund(reductionAmount, settlementOnlyAmount):
+                netOriginalTotals[currencyCode, default: 0] -= reductionAmount
+                add(
+                    amount: reductionAmount,
+                    currencyCode: currencyCode,
+                    to: &refundReduction,
+                    currencyConverter: currencyConverter,
+                    conversionStatuses: &conversionStatuses,
+                    unavailableCount: &unavailableCount,
+                    conversionAttemptCount: &conversionAttemptCount
+                )
+                add(
+                    amount: settlementOnlyAmount,
+                    currencyCode: currencyCode,
+                    to: &refundSettlementOnly,
+                    currencyConverter: currencyConverter,
+                    conversionStatuses: &conversionStatuses,
+                    unavailableCount: &unavailableCount,
+                    conversionAttemptCount: &conversionAttemptCount
+                )
             }
         }
+        let estimatedAmount = gross.estimatedAmount - refundReduction.estimatedAmount
 
         let status: ReportEstimateStatus
-        if unavailableCount == transactions.count {
+        if conversionAttemptCount == 0 {
+            status = .exact
+        } else if unavailableCount == conversionAttemptCount {
             status = .unavailable
         } else if unavailableCount > 0 {
             status = .partial
@@ -224,7 +323,7 @@ enum ReportAggregationService {
             status = .exact
         }
 
-        let first = transactions.first
+        let first = transactions.first?.transaction
         let name: String
         let colorHex: String?
         switch grouping {
@@ -241,14 +340,67 @@ enum ReportAggregationService {
             name: name,
             categoryColorHex: colorHex,
             estimatedAmount: estimatedAmount,
-            originalCurrencyTotals: originalTotals
-                .sorted { $0.key < $1.key }
-                .map { ReportCurrencyTotal(currencyCode: $0.key, amount: $0.value) },
+            originalCurrencyTotals: totals(from: netOriginalTotals),
+            grossEstimatedAmount: gross.estimatedAmount,
+            grossOriginalCurrencyTotals: gross.originalCurrencyTotals,
+            refundReductionEstimatedAmount: refundReduction.estimatedAmount,
+            refundReductionOriginalCurrencyTotals: refundReduction.originalCurrencyTotals,
+            refundSettlementOnlyEstimatedAmount: refundSettlementOnly.estimatedAmount,
+            refundSettlementOnlyOriginalCurrencyTotals: refundSettlementOnly.originalCurrencyTotals,
             estimateStatus: status,
             transactionIDs: transactions
-                .sorted { $0.date > $1.date }
-                .map(\.id)
+                .sorted { $0.transaction.date > $1.transaction.date }
+                .map(\.transaction.id)
         )
+    }
+
+    private static func add(
+        amount: Decimal,
+        currencyCode: String,
+        to accumulator: inout ReportAmountAccumulator,
+        currencyConverter: ReportCurrencyConverting,
+        conversionStatuses: inout [ReportEstimateStatus],
+        unavailableCount: inout Int,
+        conversionAttemptCount: inout Int
+    ) {
+        guard amount != 0 else { return }
+        accumulator.originalTotals[currencyCode, default: 0] += amount
+        conversionAttemptCount += 1
+        if let conversion = currencyConverter.estimateInMainCurrency(amount: amount, from: currencyCode) {
+            accumulator.estimatedAmount += conversion.amount
+            conversionStatuses.append(conversion.status)
+        } else {
+            unavailableCount += 1
+        }
+    }
+
+    private static func totals(from values: [String: Decimal]) -> [ReportCurrencyTotal] {
+        values
+            .filter { $0.value != 0 }
+            .sorted { $0.key < $1.key }
+            .map { ReportCurrencyTotal(currencyCode: $0.key, amount: $0.value) }
+    }
+}
+
+private struct ReportAggregationItem {
+    let transaction: ReportTransactionSnapshot
+    let contribution: ReportContribution
+}
+
+private enum ReportContribution {
+    case regular(amount: Decimal)
+    case refund(reductionAmount: Decimal, settlementOnlyAmount: Decimal)
+}
+
+private struct ReportAmountAccumulator {
+    var estimatedAmount: Decimal = 0
+    var originalTotals: [String: Decimal] = [:]
+
+    var originalCurrencyTotals: [ReportCurrencyTotal] {
+        originalTotals
+            .filter { $0.value != 0 }
+            .sorted { $0.key < $1.key }
+            .map { ReportCurrencyTotal(currencyCode: $0.key, amount: $0.value) }
     }
 }
 

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -57,8 +57,18 @@ struct ChartsView: View {
         let estimatedAmount: Decimal
         let mainCurrency: String
         let originalCurrencySummary: String
+        let grossEstimatedAmount: Decimal
+        let grossOriginalCurrencySummary: String
+        let refundReductionEstimatedAmount: Decimal
+        let refundReductionOriginalCurrencySummary: String
+        let refundSettlementOnlyEstimatedAmount: Decimal
+        let refundSettlementOnlyOriginalCurrencySummary: String
         let estimateFootnote: String?
         let transactions: [FinancialTransaction]
+
+        var hasRefundBreakdown: Bool {
+            refundReductionEstimatedAmount != 0 || refundSettlementOnlyEstimatedAmount != 0
+        }
     }
     
     var body: some View {
@@ -316,6 +326,12 @@ struct ChartsView: View {
         let color: Color
         let transactions: [FinancialTransaction]
         let originalCurrencySummary: String
+        let grossEstimatedAmount: Decimal
+        let grossOriginalCurrencySummary: String
+        let refundReductionEstimatedAmount: Decimal
+        let refundReductionOriginalCurrencySummary: String
+        let refundSettlementOnlyEstimatedAmount: Decimal
+        let refundSettlementOnlyOriginalCurrencySummary: String
         let estimateFootnote: String?
     }
     
@@ -334,6 +350,12 @@ struct ChartsView: View {
             estimatedAmount: item.amount,
             mainCurrency: currencyService.mainCurrency,
             originalCurrencySummary: item.originalCurrencySummary,
+            grossEstimatedAmount: item.grossEstimatedAmount,
+            grossOriginalCurrencySummary: item.grossOriginalCurrencySummary,
+            refundReductionEstimatedAmount: item.refundReductionEstimatedAmount,
+            refundReductionOriginalCurrencySummary: item.refundReductionOriginalCurrencySummary,
+            refundSettlementOnlyEstimatedAmount: item.refundSettlementOnlyEstimatedAmount,
+            refundSettlementOnlyOriginalCurrencySummary: item.refundSettlementOnlyOriginalCurrencySummary,
             estimateFootnote: item.estimateFootnote,
             transactions: sortedTransactions
         )
@@ -503,6 +525,12 @@ private struct ChartsRenderState {
                 color: displayColor,
                 transactions: detail.transactionIDs.compactMap { transactionsByID[$0] },
                 originalCurrencySummary: reportCurrencySummary(detail.originalCurrencyTotals),
+                grossEstimatedAmount: detail.grossEstimatedAmount,
+                grossOriginalCurrencySummary: reportCurrencySummary(detail.grossOriginalCurrencyTotals),
+                refundReductionEstimatedAmount: detail.refundReductionEstimatedAmount,
+                refundReductionOriginalCurrencySummary: reportCurrencySummary(detail.refundReductionOriginalCurrencyTotals),
+                refundSettlementOnlyEstimatedAmount: detail.refundSettlementOnlyEstimatedAmount,
+                refundSettlementOnlyOriginalCurrencySummary: reportCurrencySummary(detail.refundSettlementOnlyOriginalCurrencyTotals),
                 estimateFootnote: detail.estimateStatus.label
             )
         }
@@ -680,6 +708,38 @@ private struct ReportDetailSummaryCard: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            if detail.hasRefundBreakdown {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("退款扣減")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+
+                    ReportBreakdownRow(
+                        title: "總支出",
+                        amount: detail.grossEstimatedAmount,
+                        mainCurrency: detail.mainCurrency,
+                        originalSummary: detail.grossOriginalCurrencySummary
+                    )
+                    ReportBreakdownRow(
+                        title: "退款扣減",
+                        amount: detail.refundReductionEstimatedAmount,
+                        mainCurrency: detail.mainCurrency,
+                        originalSummary: detail.refundReductionOriginalCurrencySummary
+                    )
+
+                    if detail.refundSettlementOnlyEstimatedAmount != 0 {
+                        ReportBreakdownRow(
+                            title: "只作結算",
+                            amount: detail.refundSettlementOnlyEstimatedAmount,
+                            mainCurrency: detail.mainCurrency,
+                            originalSummary: detail.refundSettlementOnlyOriginalCurrencySummary
+                        )
+                    }
+                }
+            }
+
             if let estimateFootnote = detail.estimateFootnote {
                 Label(estimateFootnote, systemImage: estimateFootnote == "估算不完整" ? "exclamationmark.triangle.fill" : "arrow.triangle.2.circlepath")
                     .font(.caption)
@@ -689,6 +749,33 @@ private struct ReportDetailSummaryCard: View {
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(uiColor: .secondarySystemBackground), in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+private struct ReportBreakdownRow: View {
+    let title: String
+    let amount: Decimal
+    let mainCurrency: String
+    let originalSummary: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                if !originalSummary.isEmpty {
+                    Text(originalSummary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            Text(amount.formatted(.currency(code: mainCurrency)))
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+        }
     }
 }
 

--- a/AI 記帳Tests/ReportAggregationServiceTests.swift
+++ b/AI 記帳Tests/ReportAggregationServiceTests.swift
@@ -177,6 +177,103 @@ final class ReportAggregationServiceTests: XCTestCase {
         XCTAssertEqual(.cached, cached.slices.first?.estimateStatus)
     }
 
+    func testRefundAggregation_reducesExpenseWithoutCountingIncome() {
+        let travelID = UUID()
+        let expenseID = UUID()
+        let refundID = UUID()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let transactions = [
+            snapshot(
+                id: expenseID,
+                amount: -20_650,
+                currency: "JPY",
+                date: date,
+                categoryId: travelID,
+                tags: ["旅行"]
+            ),
+            snapshot(
+                id: refundID,
+                amount: 2_550,
+                currency: "JPY",
+                date: date.addingTimeInterval(60),
+                type: .transfer,
+                categoryId: travelID,
+                tags: ["旅行"],
+                semantic: .refund(destination: .debtAccount, originalExpenseRemaining: 20_650)
+            )
+        ]
+        let converter = FixedReportCurrencyConverter(mainCurrency: "JPY")
+
+        let expense = aggregate(transactions, converter)
+        XCTAssertEqual(1, expense.slices.count)
+        let slice = expense.slices[0]
+
+        XCTAssertEqual("餐飲", slice.name)
+        XCTAssertEqual(Decimal(18_100), slice.estimatedAmount)
+        XCTAssertEqual(Decimal(20_650), slice.grossEstimatedAmount)
+        XCTAssertEqual(Decimal(2_550), slice.refundReductionEstimatedAmount)
+        XCTAssertEqual(Decimal.zero, slice.refundSettlementOnlyEstimatedAmount)
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "JPY", amount: 18_100)],
+            slice.originalCurrencyTotals
+        )
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "JPY", amount: 20_650)],
+            slice.grossOriginalCurrencyTotals
+        )
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "JPY", amount: 2_550)],
+            slice.refundReductionOriginalCurrencyTotals
+        )
+        XCTAssertEqual([refundID, expenseID], slice.transactionIDs)
+
+        let income = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: transactions,
+                flow: .income,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: converter
+        )
+        XCTAssertTrue(income.slices.isEmpty)
+    }
+
+    func testRefundAggregation_capsExpenseReductionAndKeepsExcessSettlementOnly() {
+        let travelID = UUID()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let transactions = [
+            snapshot(
+                amount: -2_000,
+                currency: "JPY",
+                date: date,
+                categoryId: travelID
+            ),
+            snapshot(
+                amount: 2_550,
+                currency: "JPY",
+                date: date.addingTimeInterval(60),
+                type: .transfer,
+                categoryId: travelID,
+                semantic: .refund(destination: .debtAccount, originalExpenseRemaining: 2_000)
+            )
+        ]
+
+        let result = aggregate(transactions, FixedReportCurrencyConverter(mainCurrency: "JPY"))
+        XCTAssertEqual(1, result.slices.count)
+        let slice = result.slices[0]
+
+        XCTAssertEqual(Decimal.zero, slice.estimatedAmount)
+        XCTAssertEqual(Decimal(2_000), slice.refundReductionEstimatedAmount)
+        XCTAssertEqual(Decimal(550), slice.refundSettlementOnlyEstimatedAmount)
+        XCTAssertTrue(slice.originalCurrencyTotals.isEmpty)
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "JPY", amount: 550)],
+            slice.refundSettlementOnlyOriginalCurrencyTotals
+        )
+    }
+
     func testSharedDateFilter_excludesExclusiveEndBoundary() {
         let calendar = Calendar(identifier: .gregorian)
         let selectedDate = Date(timeIntervalSince1970: 1_700_000_000)
@@ -208,17 +305,43 @@ final class ReportAggregationServiceTests: XCTestCase {
         )
     }
 
-    private func snapshot(amount: Decimal, currency: String, date: Date) -> ReportTransactionSnapshot {
+    private func aggregate(
+        _ transactions: [ReportTransactionSnapshot],
+        _ converter: ReportCurrencyConverting
+    ) -> ReportAggregationResult {
+        ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: transactions,
+                flow: .expense,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: converter
+        )
+    }
+
+    private func snapshot(
+        id: UUID = UUID(),
+        amount: Decimal,
+        currency: String,
+        date: Date,
+        type: TransactionType = .expense,
+        categoryId: UUID? = nil,
+        tags: [String] = [],
+        semantic: ReportTransactionSemantic = .regular
+    ) -> ReportTransactionSnapshot {
         ReportTransactionSnapshot(
-            id: UUID(),
+            id: id,
             amount: amount,
             currencyCode: currency,
             date: date,
-            type: .expense,
-            categoryID: nil,
-            categoryName: nil,
-            categoryColorHex: nil,
-            tagNames: []
+            type: type,
+            categoryID: categoryId,
+            categoryName: categoryId == nil ? nil : "餐飲",
+            categoryColorHex: categoryId == nil ? nil : "#FF0000",
+            tagNames: tags,
+            semantic: semantic
         )
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregation.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregation.kt
@@ -5,6 +5,9 @@ import java.time.Instant
 import java.util.UUID
 import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundDestinationKind
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundSemanticInput
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundSemantics
 import org.duckdns.lhfser.aiaccounting.core.transactions.RateSourceState
 
 enum class ReportFlow(val transactionType: TransactionType) {
@@ -44,8 +47,17 @@ data class ReportTransactionSnapshot(
     val categoryId: UUID?,
     val categoryName: String?,
     val categoryColorHex: String?,
-    val tagNames: List<String>
+    val tagNames: List<String>,
+    val semantic: ReportTransactionSemantic = ReportTransactionSemantic.Regular
 )
+
+sealed interface ReportTransactionSemantic {
+    data object Regular : ReportTransactionSemantic
+    data class Refund(
+        val destination: RefundDestinationKind,
+        val originalExpenseRemaining: BigDecimal? = null
+    ) : ReportTransactionSemantic
+}
 
 data class ReportCurrencyTotal(
     val currencyCode: String,
@@ -58,6 +70,12 @@ data class ReportSlice(
     val categoryColorHex: String?,
     val estimatedAmount: BigDecimal,
     val originalCurrencyTotals: List<ReportCurrencyTotal>,
+    val grossEstimatedAmount: BigDecimal,
+    val grossOriginalCurrencyTotals: List<ReportCurrencyTotal>,
+    val refundReductionEstimatedAmount: BigDecimal,
+    val refundReductionOriginalCurrencyTotals: List<ReportCurrencyTotal>,
+    val refundSettlementOnlyEstimatedAmount: BigDecimal,
+    val refundSettlementOnlyOriginalCurrencyTotals: List<ReportCurrencyTotal>,
     val estimateStatus: ReportEstimateStatus,
     val transactionIds: List<UUID>
 ) {
@@ -65,6 +83,12 @@ data class ReportSlice(
         get() = ReportDetailSummary(
             estimatedAmount = estimatedAmount,
             originalCurrencyTotals = originalCurrencyTotals,
+            grossEstimatedAmount = grossEstimatedAmount,
+            grossOriginalCurrencyTotals = grossOriginalCurrencyTotals,
+            refundReductionEstimatedAmount = refundReductionEstimatedAmount,
+            refundReductionOriginalCurrencyTotals = refundReductionOriginalCurrencyTotals,
+            refundSettlementOnlyEstimatedAmount = refundSettlementOnlyEstimatedAmount,
+            refundSettlementOnlyOriginalCurrencyTotals = refundSettlementOnlyOriginalCurrencyTotals,
             estimateStatus = estimateStatus,
             transactionIds = transactionIds
         )
@@ -73,6 +97,12 @@ data class ReportSlice(
 data class ReportDetailSummary(
     val estimatedAmount: BigDecimal,
     val originalCurrencyTotals: List<ReportCurrencyTotal>,
+    val grossEstimatedAmount: BigDecimal,
+    val grossOriginalCurrencyTotals: List<ReportCurrencyTotal>,
+    val refundReductionEstimatedAmount: BigDecimal,
+    val refundReductionOriginalCurrencyTotals: List<ReportCurrencyTotal>,
+    val refundSettlementOnlyEstimatedAmount: BigDecimal,
+    val refundSettlementOnlyOriginalCurrencyTotals: List<ReportCurrencyTotal>,
     val estimateStatus: ReportEstimateStatus,
     val transactionIds: List<UUID>
 ) {
@@ -101,22 +131,23 @@ object ReportAggregationService {
         request: ReportAggregationRequest,
         currencyConverter: ReportCurrencyConverting
     ): ReportAggregationResult {
-        val filtered = request.transactions.filter { transaction ->
-            transaction.type == request.flow.transactionType &&
-                (request.startDate == null || transaction.date >= request.startDate) &&
-                (request.endDate == null || transaction.date < request.endDate) &&
-                matchesTagFilter(transaction, request.tagFilter)
+        val filtered = request.transactions.mapNotNull { transaction ->
+            val contribution = contributionFor(transaction, request.flow) ?: return@mapNotNull null
+            if (request.startDate != null && transaction.date < request.startDate) return@mapNotNull null
+            if (request.endDate != null && transaction.date >= request.endDate) return@mapNotNull null
+            if (!matchesTagFilter(transaction, request.tagFilter)) return@mapNotNull null
+            ReportAggregationItem(transaction = transaction, contribution = contribution)
         }
 
         val grouped = when (request.grouping) {
             ReportGroupingMode.Category -> filtered.groupBy {
-                it.categoryId?.toString() ?: "uncategorized"
+                it.transaction.categoryId?.toString() ?: "uncategorized"
             }
-            ReportGroupingMode.Tag -> buildMap<String, MutableList<ReportTransactionSnapshot>> {
-                filtered.forEach { transaction ->
-                    val tags = transaction.tagNames.ifEmpty { listOf("無標籤") }
+            ReportGroupingMode.Tag -> buildMap<String, MutableList<ReportAggregationItem>> {
+                filtered.forEach { item ->
+                    val tags = item.transaction.tagNames.ifEmpty { listOf("無標籤") }
                     tags.forEach { tagName ->
-                        getOrPut(tagName) { mutableListOf() }.add(transaction)
+                        getOrPut(tagName) { mutableListOf() }.add(item)
                     }
                 }
             }
@@ -149,39 +180,98 @@ object ReportAggregationService {
         }
     }
 
+    private fun contributionFor(
+        transaction: ReportTransactionSnapshot,
+        flow: ReportFlow
+    ): ReportContribution? {
+        return when (val semantic = transaction.semantic) {
+            ReportTransactionSemantic.Regular -> {
+                if (transaction.type != flow.transactionType) null else {
+                    ReportContribution.Regular(transaction.amount.abs())
+                }
+            }
+            is ReportTransactionSemantic.Refund -> {
+                if (flow != ReportFlow.Expense) return null
+                val effect = runCatching {
+                    RefundSemantics.effect(
+                        RefundSemanticInput(
+                            amount = transaction.amount.abs(),
+                            destination = semantic.destination,
+                            originalExpenseRemaining = semantic.originalExpenseRemaining
+                        )
+                    )
+                }.getOrNull() ?: return null
+                ReportContribution.Refund(
+                    reductionAmount = effect.expenseReduction,
+                    settlementOnlyAmount = effect.settlementOnlyAmount
+                )
+            }
+        }
+    }
+
     private fun makeSlice(
         key: String,
-        transactions: List<ReportTransactionSnapshot>,
+        transactions: List<ReportAggregationItem>,
         grouping: ReportGroupingMode,
         currencyConverter: ReportCurrencyConverting
     ): ReportSlice {
-        var estimatedAmount = BigDecimal.ZERO
-        val originalTotals = mutableMapOf<String, BigDecimal>()
+        val gross = ReportAmountAccumulator()
+        val refundReduction = ReportAmountAccumulator()
+        val refundSettlementOnly = ReportAmountAccumulator()
+        val netOriginalTotals = mutableMapOf<String, BigDecimal>()
         val statuses = mutableListOf<ReportEstimateStatus>()
         var unavailableCount = 0
+        var conversionAttemptCount = 0
 
-        transactions.forEach { transaction ->
-            val amount = transaction.amount.abs()
-            val currencyCode = transaction.currencyCode.uppercase()
-            originalTotals[currencyCode] = (originalTotals[currencyCode] ?: BigDecimal.ZERO) + amount
-
-            val conversion = currencyConverter.estimateInMainCurrency(amount, currencyCode)
-            if (conversion == null) {
-                unavailableCount += 1
-            } else {
-                estimatedAmount += conversion.amount
-                statuses += conversion.status
+        transactions.forEach { item ->
+            val currencyCode = item.transaction.currencyCode.uppercase()
+            when (val contribution = item.contribution) {
+                is ReportContribution.Regular -> {
+                    netOriginalTotals[currencyCode] = (netOriginalTotals[currencyCode] ?: BigDecimal.ZERO) + contribution.amount
+                    add(
+                        amount = contribution.amount,
+                        currencyCode = currencyCode,
+                        accumulator = gross,
+                        currencyConverter = currencyConverter,
+                        statuses = statuses,
+                        unavailableCount = { unavailableCount += 1 },
+                        conversionAttemptCount = { conversionAttemptCount += 1 }
+                    )
+                }
+                is ReportContribution.Refund -> {
+                    netOriginalTotals[currencyCode] = (netOriginalTotals[currencyCode] ?: BigDecimal.ZERO) - contribution.reductionAmount
+                    add(
+                        amount = contribution.reductionAmount,
+                        currencyCode = currencyCode,
+                        accumulator = refundReduction,
+                        currencyConverter = currencyConverter,
+                        statuses = statuses,
+                        unavailableCount = { unavailableCount += 1 },
+                        conversionAttemptCount = { conversionAttemptCount += 1 }
+                    )
+                    add(
+                        amount = contribution.settlementOnlyAmount,
+                        currencyCode = currencyCode,
+                        accumulator = refundSettlementOnly,
+                        currencyConverter = currencyConverter,
+                        statuses = statuses,
+                        unavailableCount = { unavailableCount += 1 },
+                        conversionAttemptCount = { conversionAttemptCount += 1 }
+                    )
+                }
             }
         }
+        val estimatedAmount = gross.estimatedAmount - refundReduction.estimatedAmount
 
         val status = when {
-            unavailableCount == transactions.size -> ReportEstimateStatus.Unavailable
+            conversionAttemptCount == 0 -> ReportEstimateStatus.Exact
+            unavailableCount == conversionAttemptCount -> ReportEstimateStatus.Unavailable
             unavailableCount > 0 -> ReportEstimateStatus.Partial
             ReportEstimateStatus.Cached in statuses -> ReportEstimateStatus.Cached
             ReportEstimateStatus.Live in statuses -> ReportEstimateStatus.Live
             else -> ReportEstimateStatus.Exact
         }
-        val first = transactions.firstOrNull()
+        val first = transactions.firstOrNull()?.transaction
 
         return ReportSlice(
             key = key,
@@ -194,15 +284,68 @@ object ReportAggregationService {
                 ReportGroupingMode.Tag -> null
             },
             estimatedAmount = estimatedAmount,
-            originalCurrencyTotals = originalTotals.entries
-                .sortedBy { it.key }
-                .map { ReportCurrencyTotal(currencyCode = it.key, amount = it.value) },
+            originalCurrencyTotals = netOriginalTotals.toCurrencyTotals(),
+            grossEstimatedAmount = gross.estimatedAmount,
+            grossOriginalCurrencyTotals = gross.originalCurrencyTotals,
+            refundReductionEstimatedAmount = refundReduction.estimatedAmount,
+            refundReductionOriginalCurrencyTotals = refundReduction.originalCurrencyTotals,
+            refundSettlementOnlyEstimatedAmount = refundSettlementOnly.estimatedAmount,
+            refundSettlementOnlyOriginalCurrencyTotals = refundSettlementOnly.originalCurrencyTotals,
             estimateStatus = status,
             transactionIds = transactions
-                .sortedByDescending { it.date }
-                .map { it.id }
+                .sortedByDescending { it.transaction.date }
+                .map { it.transaction.id }
         )
     }
+
+    private fun add(
+        amount: BigDecimal,
+        currencyCode: String,
+        accumulator: ReportAmountAccumulator,
+        currencyConverter: ReportCurrencyConverting,
+        statuses: MutableList<ReportEstimateStatus>,
+        unavailableCount: () -> Unit,
+        conversionAttemptCount: () -> Unit
+    ) {
+        if (amount.compareTo(BigDecimal.ZERO) == 0) return
+        accumulator.originalTotals[currencyCode] = (accumulator.originalTotals[currencyCode] ?: BigDecimal.ZERO) + amount
+        conversionAttemptCount()
+        val conversion = currencyConverter.estimateInMainCurrency(amount, currencyCode)
+        if (conversion == null) {
+            unavailableCount()
+        } else {
+            accumulator.estimatedAmount += conversion.amount
+            statuses += conversion.status
+        }
+    }
+}
+
+private data class ReportAggregationItem(
+    val transaction: ReportTransactionSnapshot,
+    val contribution: ReportContribution
+)
+
+private sealed interface ReportContribution {
+    data class Regular(val amount: BigDecimal) : ReportContribution
+    data class Refund(
+        val reductionAmount: BigDecimal,
+        val settlementOnlyAmount: BigDecimal
+    ) : ReportContribution
+}
+
+private data class ReportAmountAccumulator(
+    var estimatedAmount: BigDecimal = BigDecimal.ZERO,
+    val originalTotals: MutableMap<String, BigDecimal> = mutableMapOf()
+) {
+    val originalCurrencyTotals: List<ReportCurrencyTotal>
+        get() = originalTotals.toCurrencyTotals()
+}
+
+private fun Map<String, BigDecimal>.toCurrencyTotals(): List<ReportCurrencyTotal> {
+    return entries
+        .filter { it.value.compareTo(BigDecimal.ZERO) != 0 }
+        .sortedBy { it.key }
+        .map { ReportCurrencyTotal(currencyCode = it.key, amount = it.value) }
 }
 
 class CurrencyServiceReportConverter(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -112,6 +113,12 @@ private data class ReportChartSlice(
     val color: Color,
     val transactions: List<TransactionWithDetails>,
     val originalCurrencySummary: String,
+    val grossEstimatedAmount: BigDecimal,
+    val grossOriginalCurrencySummary: String,
+    val refundReductionEstimatedAmount: BigDecimal,
+    val refundReductionOriginalCurrencySummary: String,
+    val refundSettlementOnlyEstimatedAmount: BigDecimal,
+    val refundSettlementOnlyOriginalCurrencySummary: String,
     val estimateFootnote: String?
 )
 
@@ -120,9 +127,19 @@ private data class ReportDetail(
     val estimatedAmount: BigDecimal,
     val baseCurrency: String,
     val originalCurrencySummary: String,
+    val grossEstimatedAmount: BigDecimal,
+    val grossOriginalCurrencySummary: String,
+    val refundReductionEstimatedAmount: BigDecimal,
+    val refundReductionOriginalCurrencySummary: String,
+    val refundSettlementOnlyEstimatedAmount: BigDecimal,
+    val refundSettlementOnlyOriginalCurrencySummary: String,
     val estimateFootnote: String?,
     val transactions: List<TransactionWithDetails>
-)
+) {
+    val hasRefundBreakdown: Boolean
+        get() = refundReductionEstimatedAmount.compareTo(BigDecimal.ZERO) != 0 ||
+            refundSettlementOnlyEstimatedAmount.compareTo(BigDecimal.ZERO) != 0
+}
 
 private data class BudgetAlert(
     val budget: CategoryMonthlyBudgetEntity,
@@ -815,6 +832,38 @@ private fun ReportDetailSummaryCard(detail: ReportDetail) {
                 )
             }
 
+            if (detail.hasRefundBreakdown) {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        "退款扣減",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    ReportBreakdownRow(
+                        title = "總支出",
+                        amount = detail.grossEstimatedAmount,
+                        baseCurrency = detail.baseCurrency,
+                        originalCurrencySummary = detail.grossOriginalCurrencySummary
+                    )
+                    ReportBreakdownRow(
+                        title = "退款扣減",
+                        amount = detail.refundReductionEstimatedAmount,
+                        baseCurrency = detail.baseCurrency,
+                        originalCurrencySummary = detail.refundReductionOriginalCurrencySummary
+                    )
+                    if (detail.refundSettlementOnlyEstimatedAmount.compareTo(BigDecimal.ZERO) != 0) {
+                        ReportBreakdownRow(
+                            title = "只作結算",
+                            amount = detail.refundSettlementOnlyEstimatedAmount,
+                            baseCurrency = detail.baseCurrency,
+                            originalCurrencySummary = detail.refundSettlementOnlyOriginalCurrencySummary
+                        )
+                    }
+                }
+            }
+
             detail.estimateFootnote?.let { footnote ->
                 Text(
                     footnote,
@@ -828,6 +877,43 @@ private fun ReportDetailSummaryCard(detail: ReportDetail) {
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ReportBreakdownRow(
+    title: String,
+    amount: BigDecimal,
+    baseCurrency: String,
+    originalCurrencySummary: String
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                title,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (originalCurrencySummary.isNotBlank()) {
+                Text(
+                    originalCurrencySummary,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Text(
+            amount.asCurrencyText(baseCurrency),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
     }
 }
 
@@ -884,6 +970,18 @@ private fun ReportAggregationResult.toChartSlices(
             originalCurrencySummary = detail.originalCurrencyTotals.joinToString(" · ") {
                 it.amount.asCurrencyText(it.currencyCode)
             },
+            grossEstimatedAmount = detail.grossEstimatedAmount,
+            grossOriginalCurrencySummary = detail.grossOriginalCurrencyTotals.joinToString(" · ") {
+                it.amount.asCurrencyText(it.currencyCode)
+            },
+            refundReductionEstimatedAmount = detail.refundReductionEstimatedAmount,
+            refundReductionOriginalCurrencySummary = detail.refundReductionOriginalCurrencyTotals.joinToString(" · ") {
+                it.amount.asCurrencyText(it.currencyCode)
+            },
+            refundSettlementOnlyEstimatedAmount = detail.refundSettlementOnlyEstimatedAmount,
+            refundSettlementOnlyOriginalCurrencySummary = detail.refundSettlementOnlyOriginalCurrencyTotals.joinToString(" · ") {
+                it.amount.asCurrencyText(it.currencyCode)
+            },
             estimateFootnote = detail.estimateStatus.label
         )
     }
@@ -910,6 +1008,12 @@ private fun presentTransactions(
         estimatedAmount = item.amount,
         baseCurrency = baseCurrency,
         originalCurrencySummary = item.originalCurrencySummary,
+        grossEstimatedAmount = item.grossEstimatedAmount,
+        grossOriginalCurrencySummary = item.grossOriginalCurrencySummary,
+        refundReductionEstimatedAmount = item.refundReductionEstimatedAmount,
+        refundReductionOriginalCurrencySummary = item.refundReductionOriginalCurrencySummary,
+        refundSettlementOnlyEstimatedAmount = item.refundSettlementOnlyEstimatedAmount,
+        refundSettlementOnlyOriginalCurrencySummary = item.refundSettlementOnlyOriginalCurrencySummary,
         estimateFootnote = item.estimateFootnote,
         transactions = sorted
     )

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregationTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/core/report/ReportAggregationTest.kt
@@ -4,7 +4,9 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.refund.RefundDestinationKind
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ReportAggregationTest {
@@ -142,6 +144,106 @@ class ReportAggregationTest {
         assertEquals(ReportEstimateStatus.Cached, cached.slices.single().estimateStatus)
     }
 
+    @Test
+    fun refundAggregation_reducesExpenseWithoutCountingIncome() {
+        val travelId = UUID.randomUUID()
+        val expenseId = UUID.randomUUID()
+        val refundId = UUID.randomUUID()
+        val date = Instant.parse("2026-02-01T12:00:00Z")
+        val transactions = listOf(
+            snapshot(
+                id = expenseId,
+                amount = "-20650",
+                currency = "JPY",
+                date = date,
+                categoryId = travelId,
+                tags = listOf("旅行")
+            ),
+            snapshot(
+                id = refundId,
+                amount = "2550",
+                currency = "JPY",
+                date = date.plusSeconds(60),
+                type = TransactionType.Transfer,
+                categoryId = travelId,
+                tags = listOf("旅行"),
+                semantic = ReportTransactionSemantic.Refund(
+                    destination = RefundDestinationKind.DebtAccount,
+                    originalExpenseRemaining = BigDecimal("20650")
+                )
+            )
+        )
+        val converter = FixedReportCurrencyConverter(mainCurrency = "JPY")
+
+        val expense = aggregate(transactions, converter)
+        val slice = expense.slices.single()
+
+        assertEquals("餐飲", slice.name)
+        assertMoneyEquals("18100", slice.estimatedAmount)
+        assertMoneyEquals("20650", slice.grossEstimatedAmount)
+        assertMoneyEquals("2550", slice.refundReductionEstimatedAmount)
+        assertMoneyEquals("0", slice.refundSettlementOnlyEstimatedAmount)
+        assertEquals(
+            listOf(ReportCurrencyTotal(currencyCode = "JPY", amount = BigDecimal("18100"))),
+            slice.originalCurrencyTotals
+        )
+        assertEquals(
+            listOf(ReportCurrencyTotal(currencyCode = "JPY", amount = BigDecimal("20650"))),
+            slice.grossOriginalCurrencyTotals
+        )
+        assertEquals(
+            listOf(ReportCurrencyTotal(currencyCode = "JPY", amount = BigDecimal("2550"))),
+            slice.refundReductionOriginalCurrencyTotals
+        )
+        assertEquals(listOf(refundId, expenseId), slice.transactionIds)
+
+        val income = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = transactions,
+                flow = ReportFlow.Income,
+                grouping = ReportGroupingMode.Category
+            ),
+            currencyConverter = converter
+        )
+        assertTrue(income.slices.isEmpty())
+    }
+
+    @Test
+    fun refundAggregation_capsExpenseReductionAndKeepsExcessSettlementOnly() {
+        val travelId = UUID.randomUUID()
+        val date = Instant.parse("2026-02-01T12:00:00Z")
+        val transactions = listOf(
+            snapshot(
+                amount = "-2000",
+                currency = "JPY",
+                date = date,
+                categoryId = travelId
+            ),
+            snapshot(
+                amount = "2550",
+                currency = "JPY",
+                date = date.plusSeconds(60),
+                type = TransactionType.Transfer,
+                categoryId = travelId,
+                semantic = ReportTransactionSemantic.Refund(
+                    destination = RefundDestinationKind.DebtAccount,
+                    originalExpenseRemaining = BigDecimal("2000")
+                )
+            )
+        )
+
+        val slice = aggregate(transactions, FixedReportCurrencyConverter(mainCurrency = "JPY")).slices.single()
+
+        assertMoneyEquals("0", slice.estimatedAmount)
+        assertMoneyEquals("2000", slice.refundReductionEstimatedAmount)
+        assertMoneyEquals("550", slice.refundSettlementOnlyEstimatedAmount)
+        assertEquals(emptyList<ReportCurrencyTotal>(), slice.originalCurrencyTotals)
+        assertEquals(
+            listOf(ReportCurrencyTotal(currencyCode = "JPY", amount = BigDecimal("550"))),
+            slice.refundSettlementOnlyOriginalCurrencyTotals
+        )
+    }
+
     private fun aggregate(
         transactions: List<ReportTransactionSnapshot>,
         converter: ReportCurrencyConverting
@@ -163,7 +265,8 @@ class ReportAggregationTest {
         date: Instant,
         type: TransactionType = TransactionType.Expense,
         categoryId: UUID? = UUID.randomUUID(),
-        tags: List<String> = emptyList()
+        tags: List<String> = emptyList(),
+        semantic: ReportTransactionSemantic = ReportTransactionSemantic.Regular
     ): ReportTransactionSnapshot {
         return ReportTransactionSnapshot(
             id = id,
@@ -174,7 +277,8 @@ class ReportAggregationTest {
             categoryId = categoryId,
             categoryName = categoryId?.let { "餐飲" },
             categoryColorHex = categoryId?.let { "#FF0000" },
-            tagNames = tags
+            tagNames = tags,
+            semantic = semantic
         )
     }
 

--- a/docs/adr/0004-refund-semantics.md
+++ b/docs/adr/0004-refund-semantics.md
@@ -37,6 +37,7 @@ When a refund is linked to a known original expense, report reduction is capped 
 - Refund forms should prefill as much as possible from the original expense or advance case.
 - Refund records must be auditable and reversible, because they can alter both reports and debt balances.
 - Report drill-down should show gross expense, refund reduction, net expense, original-currency totals, and estimate status.
+- Report aggregation should expose refund-aware summary fields from a single domain interface rather than forcing chart screens to infer refund effects from notes or transaction signs.
 - Cross-platform parity vectors must cover own-account refunds, debt-account refunds, capped reductions, and cross-currency display expectations.
 - v1 does not require a SwiftData or Room schema migration; persistence can be designed in a later PR after this semantic seam is stable.
 

--- a/docs/specs/data-model.md
+++ b/docs/specs/data-model.md
@@ -82,6 +82,7 @@ Invariants:
 - Transfer should not be counted as income/expense.
 - For transfer groups, legs should share `transferGroupID`.
 - Refund semantics are not represented by a dedicated persisted type yet. Until a future schema is defined, refund domain logic must treat refunds as expense reversals, never ordinary income.
+- Report aggregation may receive a non-persisted semantic snapshot that marks a transaction-like record as a refund. That snapshot is a UI/domain adapter only; it must not be exported as a new backup field until a persisted refund schema is explicitly added.
 
 ### `Shortcut`
 - `id: UUID` (unique)
@@ -172,6 +173,7 @@ Compatibility behavior currently implemented on import:
 - Asset-adjustment legacy records are represented as transfers and must not affect income/expense charts.
 - Multi-leg transfer editing must preserve `transferGroupID`.
 - Refunds are expense reversals. If a refund lands in an own account, the own account increases. If a refund lands with a debt account holder, the debt balance moves in the user's favour. Linked report reduction is capped at the remaining original expense amount.
+- Refund-aware report aggregation must expose gross amount, refund reduction, settlement-only excess, and net amount for report drill-down. Income reports must ignore refund records.
 
 ## Change Policy
 

--- a/docs/specs/parity-test-vectors.md
+++ b/docs/specs/parity-test-vectors.md
@@ -221,6 +221,7 @@ Expected:
 - Debt balance delta: `0`.
 - Expense report reduction: `2550 JPY`.
 - Net expense delta: `-2550 JPY`.
+- Report drill-down shows gross expense, refund reduction, and net expense separately.
 - Income report contribution: `0`.
 
 ## Vector 15: Refund To Debt Account Holder
@@ -236,6 +237,7 @@ Expected:
 - If the user still owes Colin, payable decreases by `2550 JPY`.
 - If the case is already settled, Colin now owes the user `2550 JPY`.
 - Expense report reduction: `2550 JPY`.
+- Report drill-down shows gross expense `20650 JPY`, refund reduction `2550 JPY`, and net expense `18100 JPY`.
 - Income report contribution: `0`.
 
 ## Vector 16: Refund Larger Than Remaining Expense
@@ -249,6 +251,7 @@ Expected:
 - Colin debt balance delta: `+2550 JPY` in the user's favour.
 - Expense report reduction is capped at `2000 JPY`.
 - Settlement-only amount: `550 JPY`.
+- Report drill-down shows refund reduction `2000 JPY` separately from settlement-only `550 JPY`.
 - Income report contribution: `0`.
 
 ## Automated Coverage
@@ -262,7 +265,7 @@ Expected:
 | 9 | `testMutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions` | `mutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions` |
 | 10, 12, 13 | `LedgerSemanticVectorsTests.testVector13_settlementRecordsAreExcludedFromReports` | `ParityVectorsTest.vector13_settlementRecordsAreExcludedFromReports` |
 | 11 | `testExportImport_preservesSameAccountCrossCurrencyTransferAndBudgetHistory_excludesUIPreferences` | `backupRoundTrip_preservesSameAccountCrossCurrencyTransferAndBudgetHistory` |
-| 14-16 | `RefundSemanticsServiceTests` | `RefundSemanticsTest` |
+| 14-16 | `RefundSemanticsServiceTests`, `ReportAggregationServiceTests.testRefundAggregation_reducesExpenseWithoutCountingIncome`, `ReportAggregationServiceTests.testRefundAggregation_capsExpenseReductionAndKeepsExcessSettlementOnly` | `RefundSemanticsTest`, `ReportAggregationTest.refundAggregation_reducesExpenseWithoutCountingIncome`, `ReportAggregationTest.refundAggregation_capsExpenseReductionAndKeepsExcessSettlementOnly` |
 
 ## CI Gate Recommendation
 


### PR DESCRIPTION
## Summary
- Add refund-aware report aggregation semantics for iOS and Android.
- Expose gross, refund reduction, settlement-only excess, and net totals through report detail summaries.
- Show refund breakdown in report drill-down sheets when present.
- Update refund ADR, data model notes, and parity vector coverage.

## Validation
- xcrun swiftc -parse AI 記帳/Services/RefundSemanticsService.swift AI 記帳/Services/ReportAggregationService.swift AI 記帳/Views/Charts/ChartsView.swift AI 記帳Tests/ReportAggregationServiceTests.swift
- ./gradlew testDebugUnitTest assembleDebug

## Notes
- Local full iOS xcodebuild is blocked by this machine's unavailable iOS 26.5 simulator platform/destination. GitHub iOS CI should provide the full build/test gate.
