### PR TITLE
Fix iOS transaction currency and account-safe editing

### DIFF
--- a/AI 記帳/Services/TransactionEditService.swift
+++ b/AI 記帳/Services/TransactionEditService.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+struct OrdinaryTransactionEditDraft {
+    let amount: Decimal
+    let currencyCode: String
+    let date: Date
+    let note: String
+    let type: TransactionType
+    let account: Account?
+    let category: Category?
+    let tags: [Tag]
+}
+
+struct TransferLegIdentity: Hashable {
+    let accountID: UUID
+    let currencyCode: String
+
+    init(accountID: UUID, currencyCode: String) {
+        self.accountID = accountID
+        self.currencyCode = currencyCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+    }
+}
+
+enum TransactionEditError: LocalizedError, Equatable {
+    case invalidAmount
+    case invalidCurrency
+    case missingAccount
+    case invalidAccountType
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAmount:
+            return "請輸入有效金額。"
+        case .invalidCurrency:
+            return "請選擇有效幣種。"
+        case .missingAccount:
+            return "請選擇帳戶。"
+        case .invalidAccountType:
+            return "一般收入或支出只能使用自己的帳戶。"
+        }
+    }
+}
+
+@MainActor
+enum TransactionEditService {
+    static func validate(_ draft: OrdinaryTransactionEditDraft) throws {
+        guard draft.amount > 0 else {
+            throw TransactionEditError.invalidAmount
+        }
+
+        guard !draft.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw TransactionEditError.invalidCurrency
+        }
+
+        guard let account = draft.account else {
+            throw TransactionEditError.missingAccount
+        }
+
+        if draft.type != .transfer, account.type == .debt {
+            throw TransactionEditError.invalidAccountType
+        }
+    }
+
+    static func apply(
+        _ draft: OrdinaryTransactionEditDraft,
+        to transaction: FinancialTransaction,
+        updatedAt: Date = Date()
+    ) throws {
+        try validate(draft)
+
+        transaction.type = draft.type
+        transaction.amount = signedAmount(
+            draft.amount,
+            for: draft.type,
+            preservingTransferSignFrom: transaction.amount
+        )
+        transaction.currencyCode = draft.currencyCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        transaction.date = draft.date
+        transaction.note = draft.note
+        transaction.account = draft.account
+        transaction.category = draft.type == .transfer ? nil : draft.category
+        transaction.tags = draft.type == .transfer ? [] : draft.tags
+        transaction.updatedAt = updatedAt
+    }
+
+    static func hasDuplicateTransferLegs(_ identities: [TransferLegIdentity]) -> Bool {
+        Set(identities).count != identities.count
+    }
+
+    private static func signedAmount(
+        _ amount: Decimal,
+        for type: TransactionType,
+        preservingTransferSignFrom originalAmount: Decimal
+    ) -> Decimal {
+        switch type {
+        case .expense:
+            return -abs(amount)
+        case .income:
+            return abs(amount)
+        case .transfer:
+            return originalAmount >= 0 ? abs(amount) : -abs(amount)
+        }
+    }
+}

--- a/AI 記帳/Views/Transactions/EditTransactionView.swift
+++ b/AI 記帳/Views/Transactions/EditTransactionView.swift
@@ -12,6 +12,7 @@ struct EditTransactionView: View {
     @Query(sort: \Tag.name) private var tags: [Tag]
     
     @State private var amountString: String = ""
+    @State private var selectedCurrency = "HKD"
     @State private var selectedType: TransactionType = .expense
     @State private var selectedAccount: Account?
     @State private var selectedCategory: Category?
@@ -24,6 +25,12 @@ struct EditTransactionView: View {
     
     // 🔥 新增：焦點控制
     @FocusState private var isAmountFocused: Bool
+
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+
+    private var availableCurrencies: [String] {
+        currencies.contains(selectedCurrency) ? currencies : [selectedCurrency] + currencies
+    }
 
     private var selectableAccounts: [Account] {
         let allowed = TransactionSemantics.allowedAccounts(for: selectedType, from: accounts)
@@ -68,22 +75,29 @@ struct EditTransactionView: View {
                     }
 
                     HStack {
-                        Text(selectedAccount?.currency ?? transaction.currencyCode)
+                        Picker("幣種", selection: $selectedCurrency) {
+                            ForEach(availableCurrencies, id: \.self) { code in
+                                Text(code).tag(code)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 88)
+
                         TextField("金額", text: amountBinding)
                             .keyboardType(.decimalPad)
-                            .focused($isAmountFocused) // 🔥 綁定焦點
+                            .focused($isAmountFocused)
                             .accessibilityIdentifier("transactionEditor.amountField")
                     }
                     CurrencyRateHintView(
                         currencyService: currencyService,
                         amount: Decimal(string: amountString),
-                        currencyCode: transaction.currencyCode
+                        currencyCode: selectedCurrency
                     )
                 }
 
                 Section("詳細資訊") {
                     Picker("帳戶", selection: $selectedAccount) {
-                        Text("無").tag(nil as Account?)
+                        Text("選擇帳戶").tag(nil as Account?)
                         ForEach(selectableAccounts) { acc in
                             Text(acc.name).tag(acc as Account?)
                         }
@@ -136,6 +150,7 @@ struct EditTransactionView: View {
                     Button("完成") {
                         saveChanges()
                     }
+                    .disabled(!canSubmit)
                     .accessibilityIdentifier("transactionEditor.saveButton")
                 }
                 
@@ -170,14 +185,17 @@ struct EditTransactionView: View {
             }
 
             let previousKey = originalBudgetKey
-            transaction.type = selectedType
-            transaction.account = selectedAccount
-            transaction.category = selectedType == .transfer ? nil : selectedCategory
-            transaction.date = selectedDate
-            transaction.note = note
-            transaction.tags = selectedType == .transfer ? [] : Array(selectedTags)
-            transaction.amount = signedAmount(from: amount)
-            transaction.updatedAt = Date()
+            let draft = OrdinaryTransactionEditDraft(
+                amount: amount,
+                currencyCode: selectedCurrency,
+                date: selectedDate,
+                note: note,
+                type: selectedType,
+                account: selectedAccount,
+                category: selectedCategory,
+                tags: Array(selectedTags)
+            )
+            try TransactionEditService.apply(draft, to: transaction)
             try modelContext.save()
             let currentKey = BudgetHistoryService.affectedKey(for: transaction)
             try BudgetHistoryService.shared.syncAffected(
@@ -187,6 +205,7 @@ struct EditTransactionView: View {
             )
             dismiss()
         } catch {
+            modelContext.rollback()
             errorMessage = error.localizedDescription
         }
     }
@@ -196,6 +215,9 @@ struct EditTransactionView: View {
         didLoadDraft = true
         selectedType = transaction.type
         selectedAccount = transaction.account
+        selectedCurrency = transaction.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? (transaction.account?.currency ?? "HKD")
+            : transaction.currencyCode.uppercased()
         selectedCategory = transaction.category
         selectedDate = transaction.date
         note = transaction.note
@@ -204,13 +226,12 @@ struct EditTransactionView: View {
         originalBudgetKey = BudgetHistoryService.affectedKey(for: transaction)
     }
 
-    private func signedAmount(from amount: Decimal) -> Decimal {
-        if selectedType == .transfer {
-            return transaction.amount >= 0 ? abs(amount) : -abs(amount)
-        }
-        return selectedType == .expense ? -abs(amount) : abs(amount)
+    private var canSubmit: Bool {
+        positiveDecimal(from: amountString) != nil
+            && selectedAccount != nil
+            && !selectedCurrency.isEmpty
     }
-    
+
     private var filteredCategories: [Category] {
         categories.filter { $0.kind.supports(selectedType) }
     }

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -293,15 +293,19 @@ struct EditTransferView: View {
             let parsedOutgoing = try parseLegs(from: outgoingLegs, sideName: "轉出")
             let parsedIncoming = try parseLegs(from: incomingLegs, sideName: "轉入")
 
-            let outgoingIDs = Set(parsedOutgoing.map { $0.account.id })
-            let incomingIDs = Set(parsedIncoming.map { $0.account.id })
+            let outgoingIdentities = parsedOutgoing.map {
+                TransferLegIdentity(accountID: $0.account.id, currencyCode: $0.currency)
+            }
+            let incomingIdentities = parsedIncoming.map {
+                TransferLegIdentity(accountID: $0.account.id, currencyCode: $0.currency)
+            }
 
-            if outgoingIDs.count != parsedOutgoing.count {
-                showValidation("轉出帳戶不可重複，請合併金額。")
+            if TransactionEditService.hasDuplicateTransferLegs(outgoingIdentities) {
+                showValidation("相同帳戶及幣種不可重複，請合併金額。")
                 return
             }
-            if incomingIDs.count != parsedIncoming.count {
-                showValidation("轉入帳戶不可重複，請合併金額。")
+            if TransactionEditService.hasDuplicateTransferLegs(incomingIdentities) {
+                showValidation("相同帳戶及幣種不可重複，請合併金額。")
                 return
             }
 

--- a/AI 記帳Tests/TransactionEditServiceTests.swift
+++ b/AI 記帳Tests/TransactionEditServiceTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import AI_記帳
+
+@MainActor
+final class TransactionEditServiceTests: XCTestCase {
+    func testApplyingDraftUpdatesTransactionCurrencyWithoutChangingAccountCurrency() throws {
+        let account = Account(
+            name: "Multi-currency bank",
+            currency: "JPY",
+            type: .bank,
+            baseBalance: 0
+        )
+        let transaction = FinancialTransaction(
+            amount: -725,
+            currencyCode: "JPY",
+            note: "LUUP",
+            type: .expense,
+            account: account
+        )
+        let draft = OrdinaryTransactionEditDraft(
+            amount: 35.59,
+            currencyCode: "HKD",
+            date: transaction.date,
+            note: transaction.note,
+            type: .expense,
+            account: account,
+            category: nil,
+            tags: []
+        )
+
+        try TransactionEditService.apply(draft, to: transaction, updatedAt: Date(timeIntervalSince1970: 100))
+
+        XCTAssertEqual("HKD", transaction.currencyCode)
+        XCTAssertEqual("JPY", account.currency)
+        XCTAssertEqual(Decimal(string: "-35.59")!, transaction.amount)
+    }
+
+    func testOrdinaryTransactionRequiresAnAccount() {
+        let draft = OrdinaryTransactionEditDraft(
+            amount: 10,
+            currencyCode: "HKD",
+            date: Date(),
+            note: "",
+            type: .expense,
+            account: nil,
+            category: nil,
+            tags: []
+        )
+
+        XCTAssertThrowsError(try TransactionEditService.validate(draft)) { error in
+            XCTAssertEqual(error as? TransactionEditError, .missingAccount)
+        }
+    }
+
+    func testIncomeAndExpenseRejectDebtAccounts() {
+        let debtAccount = Account(
+            name: "Friend",
+            currency: "HKD",
+            type: .debt,
+            baseBalance: 0
+        )
+        let draft = OrdinaryTransactionEditDraft(
+            amount: 10,
+            currencyCode: "HKD",
+            date: Date(),
+            note: "",
+            type: .income,
+            account: debtAccount,
+            category: nil,
+            tags: []
+        )
+
+        XCTAssertThrowsError(try TransactionEditService.validate(draft)) { error in
+            XCTAssertEqual(error as? TransactionEditError, .invalidAccountType)
+        }
+    }
+
+    func testTransferLegIdentityAllowsSameAccountWithDifferentCurrencies() {
+        let accountID = UUID()
+        let identities = [
+            TransferLegIdentity(accountID: accountID, currencyCode: "JPY"),
+            TransferLegIdentity(accountID: accountID, currencyCode: "HKD"),
+        ]
+
+        XCTAssertFalse(TransactionEditService.hasDuplicateTransferLegs(identities))
+    }
+
+    func testTransferLegIdentityRejectsSameAccountAndCurrencyTwice() {
+        let accountID = UUID()
+        let identities = [
+            TransferLegIdentity(accountID: accountID, currencyCode: "hkd"),
+            TransferLegIdentity(accountID: accountID, currencyCode: " HKD "),
+        ]
+
+        XCTAssertTrue(TransactionEditService.hasDuplicateTransferLegs(identities))
+    }
+}


### PR DESCRIPTION
Closes #131

## Summary
- add editable transaction currency and account validation
- apply ordinary transaction drafts through a testable service
- allow same-account transfer legs when currencies differ
- add behavior tests for currency correction and validation

## Validation
- Swift parser check
- GitHub CI
- local iOS tests will be repeated after the matching Xcode 26.5 simulator runtime finishes installing