### PR TITLE
Make Android transaction editing stable and atomic

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -627,6 +627,64 @@ class AccountingRepository(
         }
     }
 
+    suspend fun replaceOrdinaryTransactions(
+        originalTransactionId: UUID?,
+        replacements: List<TransactionEntity>,
+        tagIds: List<UUID> = emptyList()
+    ): List<UUID> {
+        require(replacements.isNotEmpty()) { "至少需要一筆交易。" }
+        replacements.forEach(::validateOrdinaryReplacement)
+
+        return database.withTransaction {
+            val original = originalTransactionId?.let { transactionId ->
+                requireNotNull(transactionDao.getTransaction(transactionId)?.transaction) {
+                    "找不到要編輯的交易。"
+                }
+            }
+            if (original != null) {
+                validateOrdinaryReplacement(original)
+            }
+
+            val now = Instant.now()
+            val prepared = replacements.mapIndexed { index, replacement ->
+                when {
+                    original == null -> replacement
+                    replacements.size == 1 -> replacement.copy(
+                        id = original.id,
+                        photoPath = replacement.photoPath ?: original.photoPath,
+                        createdAt = original.createdAt,
+                        updatedAt = now
+                    )
+                    index == 0 -> replacement.copy(
+                        photoPath = replacement.photoPath ?: original.photoPath,
+                        createdAt = original.createdAt,
+                        updatedAt = now
+                    )
+                    else -> replacement.copy(updatedAt = now)
+                }
+            }
+
+            original?.let {
+                transactionDao.clearTransactionTags(it.id)
+                if (prepared.none { replacement -> replacement.id == it.id }) {
+                    transactionDao.delete(it)
+                }
+            }
+
+            prepared.forEach { transactionDao.clearTransactionTags(it.id) }
+            transactionDao.upsertAll(prepared)
+            if (tagIds.isNotEmpty()) {
+                transactionDao.insertTransactionTags(
+                    prepared.flatMap { transaction ->
+                        tagIds.map { tagId -> TransactionTagCrossRef(transaction.id, tagId) }
+                    }
+                )
+            }
+            syncAllBudgetHistory()
+            prepared.map { it.id }
+        }
+    }
+
     suspend fun deleteTransaction(transaction: TransactionEntity) {
         database.withTransaction {
             transactionDao.delete(transaction)
@@ -2009,6 +2067,28 @@ class AccountingRepository(
         transactions.forEach { transaction ->
             transactionDao.delete(transaction)
             transactionDao.clearTransactionTags(transaction.id)
+        }
+    }
+
+    private fun validateOrdinaryReplacement(transaction: TransactionEntity) {
+        require(transaction.amount.compareTo(BigDecimal.ZERO) != 0) {
+            "交易金額不可為零。"
+        }
+        require(transaction.currencyCode.isNotBlank()) {
+            "交易幣種不可留空。"
+        }
+        require(transaction.accountId != null) {
+            "請選擇帳戶。"
+        }
+        require(transaction.type != TransactionType.Transfer) {
+            "轉帳必須使用轉帳編輯流程。"
+        }
+        require(
+            transaction.transferGroupId == null &&
+                transaction.linkedTransactionId == null &&
+                transaction.transferSide == null
+        ) {
+            "這筆交易包含轉帳或代墊關聯，必須使用對應的編輯流程。"
         }
     }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionEditorScreen.kt
@@ -127,36 +127,46 @@ fun TransactionEditorScreen(
         (allowed + preserved).distinctBy { it.id }
     }
 
-    LaunchedEffect(transactionId, accounts, categories, tags) {
+    LaunchedEffect(transactionId) {
         if (transactionId == null) return@LaunchedEffect
         val tx = repository.getTransaction(UUID.fromString(transactionId))
-        tx?.let {
+        if (tx == null) {
+            errorMessage = "找不到要編輯的交易。"
+        } else {
             entryMode = EntryMode.Normal
-            transactionType = it.transaction.type
-            amountInput = it.transaction.amount.abs().toPlainString()
-            note = it.transaction.note
-            selectedAccount = accounts.firstOrNull { acc -> acc.id == it.transaction.accountId }
-            selectedCategory = categories.firstOrNull { cat -> cat.id == it.transaction.categoryId }
-            selectedTags = tags.filter { tag -> it.tags.any { t -> t.id == tag.id } }
-            selectedCurrency = it.transaction.currencyCode
-            date = it.transaction.date
+            transactionType = tx.transaction.type
+            amountInput = tx.transaction.amount.abs().toPlainString()
+            note = tx.transaction.note
+            selectedAccount = tx.account
+            selectedCategory = tx.category
+            selectedTags = tx.tags
+            selectedCurrency = tx.transaction.currencyCode
+            date = tx.transaction.date
         }
     }
 
     val filteredCategories = categories.filter { it.kind.supports(transactionType) }
 
     LaunchedEffect(transactionType, filteredCategories, selectableAccounts) {
-        if (selectedCategory != null && filteredCategories.none { it.id == selectedCategory?.id }) {
+        if (
+            categories.isNotEmpty() &&
+            selectedCategory != null &&
+            filteredCategories.none { it.id == selectedCategory?.id }
+        ) {
             selectedCategory = null
         }
         if (!newCategoryKind.supports(transactionType)) {
             newCategoryKind = defaultCategoryKindFor(transactionType)
         }
-        if (selectedAccount != null && selectableAccounts.none { it.id == selectedAccount?.id }) {
+        if (
+            accounts.isNotEmpty() &&
+            selectedAccount != null &&
+            selectableAccounts.none { it.id == selectedAccount?.id }
+        ) {
             selectedAccount = selectableAccounts.firstOrNull()
             selectedAccount?.let { selectedCurrency = it.currency }
         }
-        if (entryMode == EntryMode.Split) {
+        if (accounts.isNotEmpty() && entryMode == EntryMode.Split) {
             splitLegs = splitLegs.map { leg ->
                 if (leg.account != null && selectableAccounts.none { it.id == leg.account?.id }) {
                     leg.copy(account = null)
@@ -334,22 +344,26 @@ fun TransactionEditorScreen(
         Button(
             onClick = {
                 scope.launch {
-                    saveTransaction(
-                        repository = repository,
-                        entryMode = entryMode,
-                        transactionId = transactionId,
-                        type = transactionType,
-                        amountInput = amountInput,
-                        selectedAccount = selectedAccount,
-                        selectedCategory = selectedCategory,
-                        selectedTags = selectedTags,
-                        selectedCurrency = selectedCurrency,
-                        date = date,
-                        note = note,
-                        splitLegs = splitLegs,
-                        mergeLegs = mergeLegs
-                    )
-                    onDone()
+                    try {
+                        saveTransaction(
+                            repository = repository,
+                            entryMode = entryMode,
+                            transactionId = transactionId,
+                            type = transactionType,
+                            amountInput = amountInput,
+                            selectedAccount = selectedAccount,
+                            selectedCategory = selectedCategory,
+                            selectedTags = selectedTags,
+                            selectedCurrency = selectedCurrency,
+                            date = date,
+                            note = note,
+                            splitLegs = splitLegs,
+                            mergeLegs = mergeLegs
+                        )
+                        onDone()
+                    } catch (error: Exception) {
+                        errorMessage = error.message ?: "無法儲存交易。"
+                    }
                 }
             },
             enabled = canSubmit(
@@ -817,12 +831,15 @@ private suspend fun saveTransaction(
     splitLegs: List<SplitLeg>,
     mergeLegs: List<MergeLeg>
 ) {
+    val originalTransactionId = transactionId?.let(UUID::fromString)
+    val now = Instant.now()
+
     when (entryMode) {
         EntryMode.Normal -> {
-            val account = selectedAccount ?: return
-            val amount = parsePositive(amountInput) ?: return
+            val account = requireNotNull(selectedAccount) { "請選擇帳戶。" }
+            val amount = requireNotNull(parsePositive(amountInput)) { "請輸入有效金額。" }
             val finalAmount = if (type == TransactionType.Expense) amount.abs().negate() else amount.abs()
-            val txId = transactionId?.let(UUID::fromString) ?: UUID.randomUUID()
+            val txId = originalTransactionId ?: UUID.randomUUID()
             val transaction = TransactionEntity(
                 id = txId,
                 amount = finalAmount,
@@ -834,20 +851,21 @@ private suspend fun saveTransaction(
                 linkedTransactionId = null,
                 transferGroupId = null,
                 transferSide = null,
-                createdAt = Instant.now(),
-                updatedAt = Instant.now(),
+                createdAt = now,
+                updatedAt = now,
                 accountId = account.id,
                 categoryId = selectedCategory?.id
             )
-            repository.upsertTransaction(transaction, selectedTags.map { it.id })
+            repository.replaceOrdinaryTransactions(
+                originalTransactionId = originalTransactionId,
+                replacements = listOf(transaction),
+                tagIds = selectedTags.map { it.id }
+            )
         }
         EntryMode.Split -> {
-            if (transactionId != null) {
-                repository.deleteTransactionById(UUID.fromString(transactionId))
-            }
-            val legs = splitLegs.mapNotNull { leg ->
-                val account = leg.account ?: return@mapNotNull null
-                val amount = parsePositive(leg.amount) ?: return@mapNotNull null
+            val legs = splitLegs.map { leg ->
+                val account = requireNotNull(leg.account) { "請為每個分拆項目選擇帳戶。" }
+                val amount = requireNotNull(parsePositive(leg.amount)) { "請輸入有效的分拆金額。" }
                 Triple(account, amount, leg.currency)
             }
             val transactions = legs.mapIndexed { index, (account, amount, currency) ->
@@ -863,21 +881,22 @@ private suspend fun saveTransaction(
                     linkedTransactionId = null,
                     transferGroupId = null,
                     transferSide = null,
-                    createdAt = Instant.now(),
-                    updatedAt = Instant.now(),
+                    createdAt = now,
+                    updatedAt = now,
                     accountId = account.id,
                     categoryId = selectedCategory?.id
                 )
             }
-            repository.upsertTransactions(transactions, selectedTags.map { it.id })
+            repository.replaceOrdinaryTransactions(
+                originalTransactionId = originalTransactionId,
+                replacements = transactions,
+                tagIds = selectedTags.map { it.id }
+            )
         }
         EntryMode.Merge -> {
-            if (transactionId != null) {
-                repository.deleteTransactionById(UUID.fromString(transactionId))
-            }
-            val account = selectedAccount ?: return
-            val legs = mergeLegs.mapNotNull { leg ->
-                val amount = parsePositive(leg.amount) ?: return@mapNotNull null
+            val account = requireNotNull(selectedAccount) { "請選擇合併入帳戶。" }
+            val legs = mergeLegs.map { leg ->
+                val amount = requireNotNull(parsePositive(leg.amount)) { "請輸入有效的合併金額。" }
                 Pair(amount, leg.currency)
             }
             val transactions = legs.mapIndexed { index, (amount, currency) ->
@@ -893,13 +912,17 @@ private suspend fun saveTransaction(
                     linkedTransactionId = null,
                     transferGroupId = null,
                     transferSide = null,
-                    createdAt = Instant.now(),
-                    updatedAt = Instant.now(),
+                    createdAt = now,
+                    updatedAt = now,
                     accountId = account.id,
                     categoryId = selectedCategory?.id
                 )
             }
-            repository.upsertTransactions(transactions, selectedTags.map { it.id })
+            repository.replaceOrdinaryTransactions(
+                originalTransactionId = originalTransactionId,
+                replacements = transactions,
+                tagIds = selectedTags.map { it.id }
+            )
         }
     }
 }

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/TransactionReplacementTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/TransactionReplacementTest.kt
@@ -1,0 +1,170 @@
+package org.duckdns.lhfser.aiaccounting.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class TransactionReplacementTest {
+    private lateinit var database: AIAccountingDatabase
+    private lateinit var repository: AccountingRepository
+    private lateinit var account: AccountEntity
+
+    @Before
+    fun setUp() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AIAccountingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = AccountingRepository(database, CurrencyService(context))
+        account = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        repository.upsertAccount(account)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun replacingOrdinaryTransaction_preservesReceiptAndCreatedAt() = runBlocking {
+        val transactionId = UUID.randomUUID()
+        val createdAt = Instant.parse("2026-05-01T10:00:00Z")
+        repository.upsertTransaction(
+            transaction = ordinaryTransaction(
+                id = transactionId,
+                amount = BigDecimal("-725"),
+                currencyCode = "JPY",
+                photoPath = "/receipts/luup.jpg",
+                createdAt = createdAt
+            ),
+            tagIds = emptyList()
+        )
+
+        repository.replaceOrdinaryTransactions(
+            originalTransactionId = transactionId,
+            replacements = listOf(
+                ordinaryTransaction(
+                    id = transactionId,
+                    amount = BigDecimal("-35.59"),
+                    currencyCode = "HKD",
+                    photoPath = null,
+                    createdAt = Instant.now()
+                )
+            ),
+            tagIds = emptyList()
+        )
+
+        val updated = repository.getTransaction(transactionId)?.transaction
+        assertNotNull(updated)
+        assertEquals("/receipts/luup.jpg", updated?.photoPath)
+        assertEquals(createdAt, updated?.createdAt)
+        assertEquals(BigDecimal("-35.59"), updated?.amount)
+        assertEquals("HKD", updated?.currencyCode)
+    }
+
+    @Test
+    fun invalidReplacement_leavesOriginalTransactionUntouched() = runBlocking {
+        val transactionId = UUID.randomUUID()
+        val original = ordinaryTransaction(
+            id = transactionId,
+            amount = BigDecimal("-100"),
+            currencyCode = "HKD",
+            photoPath = "/receipts/original.jpg",
+            createdAt = Instant.parse("2026-05-02T10:00:00Z")
+        )
+        repository.upsertTransaction(original, emptyList())
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                repository.replaceOrdinaryTransactions(
+                    originalTransactionId = transactionId,
+                    replacements = listOf(original.copy(amount = BigDecimal.ZERO)),
+                    tagIds = emptyList()
+                )
+            }
+        }
+
+        assertEquals(original, repository.getTransaction(transactionId)?.transaction)
+    }
+
+    @Test
+    fun splitReplacement_removesOriginalAndCreatesEveryValidatedLeg() = runBlocking {
+        val transactionId = UUID.randomUUID()
+        val original = ordinaryTransaction(
+            id = transactionId,
+            amount = BigDecimal("-100"),
+            currencyCode = "HKD",
+            photoPath = "/receipts/split.jpg",
+            createdAt = Instant.parse("2026-05-03T10:00:00Z")
+        )
+        repository.upsertTransaction(original, emptyList())
+        val firstID = UUID.randomUUID()
+        val secondID = UUID.randomUUID()
+
+        repository.replaceOrdinaryTransactions(
+            originalTransactionId = transactionId,
+            replacements = listOf(
+                ordinaryTransaction(firstID, BigDecimal("-40"), "HKD"),
+                ordinaryTransaction(secondID, BigDecimal("-60"), "HKD")
+            ),
+            tagIds = emptyList()
+        )
+
+        assertEquals(null, repository.getTransaction(transactionId))
+        assertEquals("/receipts/split.jpg", repository.getTransaction(firstID)?.transaction?.photoPath)
+        assertNotNull(repository.getTransaction(secondID))
+    }
+
+    private fun ordinaryTransaction(
+        id: UUID,
+        amount: BigDecimal,
+        currencyCode: String,
+        photoPath: String? = null,
+        createdAt: Instant = Instant.now()
+    ): TransactionEntity {
+        return TransactionEntity(
+            id = id,
+            amount = amount,
+            currencyCode = currencyCode,
+            date = Instant.parse("2026-06-10T10:00:00Z"),
+            note = "LUUP",
+            photoPath = photoPath,
+            type = TransactionType.Expense,
+            linkedTransactionId = null,
+            transferGroupId = null,
+            transferSide = null,
+            createdAt = createdAt,
+            updatedAt = createdAt,
+            accountId = account.id,
+            categoryId = null
+        )
+    }
+}


### PR DESCRIPTION
Closes #132

## Summary
- load editor drafts once from transaction relations instead of list emissions
- replace normal, split, and merged transactions atomically
- preserve receipt paths and creation timestamps
- surface persistence failures without dismissing the editor
- add Room behavior tests for preservation and rollback-safe validation

## Validation
- `./gradlew testDebugUnitTest assembleDebug`