### PR TITLE
Preserve Android editor invariants

### DIFF
--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
@@ -42,6 +42,9 @@ interface CategoryDao {
     @Query("SELECT * FROM categories")
     suspend fun getAll(): List<CategoryEntity>
 
+    @Query("SELECT * FROM categories WHERE id = :categoryId")
+    suspend fun getCategory(categoryId: UUID): CategoryEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(category: CategoryEntity)
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -13,6 +13,7 @@ import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
 import org.duckdns.lhfser.aiaccounting.core.health.DataHealthChecker
 import org.duckdns.lhfser.aiaccounting.core.health.DataHealthReport
 import org.duckdns.lhfser.aiaccounting.core.health.DataHealthSnapshot
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
 import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
@@ -64,6 +65,22 @@ data class AccountDeletionImpact(
     val isEmptyAccount: Boolean
         get() = !counts.hasBookkeeping
 }
+
+data class AccountEditDraft(
+    val accountId: UUID?,
+    val name: String,
+    val requestedCurrency: String,
+    val type: AccountType,
+    val baseBalance: BigDecimal,
+    val isArchived: Boolean
+)
+
+data class RecurringRuleEditorData(
+    val rule: RecurringRuleEntity,
+    val account: AccountEntity?,
+    val category: CategoryEntity?,
+    val tags: List<TagEntity>
+)
 
 enum class LedgerDeletionResult {
     Deleted,
@@ -536,6 +553,34 @@ class AccountingRepository(
         accountDao.upsert(account)
     }
 
+    suspend fun saveAccountEdit(draft: AccountEditDraft): UUID {
+        require(draft.name.isNotBlank()) { "請輸入帳戶名稱。" }
+
+        return database.withTransaction {
+            val existing = draft.accountId?.let { accountId ->
+                requireNotNull(accountDao.getAccount(accountId)) {
+                    "找不到要編輯的帳戶。"
+                }
+            }
+            if (existing == null) {
+                require(draft.requestedCurrency.isNotBlank()) { "請選擇主幣種。" }
+            }
+            val accountId = existing?.id ?: draft.accountId ?: UUID.randomUUID()
+            val account = AccountEntity(
+                id = accountId,
+                name = draft.name.trim(),
+                currency = existing?.currency ?: draft.requestedCurrency.trim().uppercase(),
+                type = draft.type,
+                baseBalance = draft.baseBalance,
+                sortOrder = existing?.sortOrder
+                    ?: ((accountDao.getAll().maxOfOrNull { it.sortOrder } ?: -1) + 1),
+                isArchived = draft.isArchived
+            )
+            accountDao.upsert(account)
+            accountId
+        }
+    }
+
     suspend fun previewAccountDeletion(accountId: UUID): AccountDeletionImpact? {
         return buildAccountDeletionTargets(accountId)?.impact
     }
@@ -715,6 +760,19 @@ class AccountingRepository(
 
     suspend fun getRecurringRuleTagIds(ruleId: UUID): List<UUID> {
         return recurringDao.getRuleTags(ruleId).map { it.tagId }
+    }
+
+    suspend fun getRecurringRuleEditorData(ruleId: UUID): RecurringRuleEditorData? {
+        return database.withTransaction {
+            val rule = recurringDao.getRule(ruleId) ?: return@withTransaction null
+            val tagIds = recurringDao.getRuleTags(ruleId).mapTo(mutableSetOf()) { it.tagId }
+            RecurringRuleEditorData(
+                rule = rule,
+                account = rule.accountId?.let { accountDao.getAccount(it) },
+                category = rule.categoryId?.let { categoryDao.getCategory(it) },
+                tags = tagDao.getAll().filter { it.id in tagIds }
+            )
+        }
     }
 
     suspend fun upsertRecurringRule(rule: RecurringRuleEntity, tagIds: List<UUID> = emptyList()) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountEditorScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,8 +28,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountDeletionImpact
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountEditDraft
 import org.duckdns.lhfser.aiaccounting.core.model.AccountType
-import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
@@ -43,7 +42,6 @@ import java.util.UUID
 fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
     val repository = LocalRepository.current
     val scope = rememberCoroutineScope()
-    val accounts by repository.accounts.collectAsState(initial = emptyList())
     val scrollState = rememberScrollState()
 
     var name by remember { mutableStateOf("") }
@@ -57,9 +55,9 @@ fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
     var isEditing by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
 
-    LaunchedEffect(accountId, accounts) {
+    LaunchedEffect(accountId) {
         val id = accountId?.let(UUID::fromString)
-        val existing = accounts.firstOrNull { it.id == id }
+        val existing = id?.let { repository.getAccount(it) }
         if (existing != null) {
             isEditing = true
             name = existing.name
@@ -88,16 +86,35 @@ fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
             ,
                 keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
                 keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
-            CurrencyPicker(selected = currency, onSelect = { currency = it })
+            if (isEditing) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text("主幣種", style = MaterialTheme.typography.titleSmall)
+                    Text(currency, style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "主幣種建立後不可修改；其他幣種請透過交易或餘額調整記錄。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                CurrencyPicker(selected = currency, onSelect = { currency = it })
+            }
             AccountTypePicker(type = type, onChange = { type = it })
-            OutlinedTextField(
-                value = baseBalance,
-                onValueChange = { baseBalance = sanitizeAmount(it) },
-                label = { Text("初始餘額") },
-                modifier = Modifier.fillMaxWidth()
-            ,
-                keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done),
-                keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions())
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = baseBalance,
+                    onValueChange = { baseBalance = sanitizeSignedAmount(it) },
+                    label = { Text("初始餘額") },
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                        imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                    ),
+                    keyboardActions = org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+                )
+                TextButton(onClick = { baseBalance = toggleAmountSign(baseBalance) }) {
+                    Text("+/-")
+                }
+            }
         }
 
         Text("其他設定", style = MaterialTheme.typography.titleMedium)
@@ -111,23 +128,25 @@ fun AccountEditorScreen(accountId: String?, onDone: () -> Unit) {
         Button(
             onClick = {
                 scope.launch {
-                    val id = accountId?.let(UUID::fromString) ?: UUID.randomUUID()
-                    val balanceValue = baseBalance.toBigDecimalOrNull() ?: BigDecimal.ZERO
-                    val sortOrder = accounts.size
-                    val account = AccountEntity(
-                        id = id,
-                        name = name.ifBlank { "帳戶" },
-                        currency = currency,
-                        type = type,
-                        baseBalance = balanceValue,
-                        sortOrder = sortOrder,
-                        isArchived = isArchived
-                    )
-                    repository.upsertAccount(account)
-                    onDone()
+                    runCatching {
+                        repository.saveAccountEdit(
+                            AccountEditDraft(
+                                accountId = accountId?.let(UUID::fromString),
+                                name = name,
+                                requestedCurrency = currency,
+                                type = type,
+                                baseBalance = baseBalance.ifBlank { "0" }.toBigDecimal(),
+                                isArchived = isArchived
+                            )
+                        )
+                    }.onSuccess {
+                        onDone()
+                    }.onFailure {
+                        errorMessage = it.localizedMessage ?: "無法儲存帳戶"
+                    }
                 }
             },
-            enabled = name.isNotBlank()
+            enabled = name.isNotBlank() && baseBalance.ifBlank { "0" }.toBigDecimalOrNull() != null
         ) {
             Text("儲存")
         }
@@ -307,7 +326,8 @@ private fun AccountTypePicker(type: AccountType, onChange: (AccountType) -> Unit
     }
 }
 
-private fun sanitizeAmount(input: String): String {
+internal fun sanitizeSignedAmount(input: String): String {
+    val isNegative = input.trimStart().startsWith("-")
     val allowed = input.filter { it.isDigit() || it == '.' }
     var hasDot = false
     val result = StringBuilder()
@@ -318,5 +338,14 @@ private fun sanitizeAmount(input: String): String {
         }
         result.append(char)
     }
-    return result.toString()
+    val normalized = result.toString()
+    return if (isNegative && normalized.isNotEmpty()) "-$normalized" else normalized
+}
+
+private fun toggleAmountSign(input: String): String {
+    return when {
+        input.startsWith("-") -> input.removePrefix("-")
+        input.isBlank() -> "-"
+        else -> "-$input"
+    }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/RecurringTransactionsScreen.kt
@@ -266,14 +266,14 @@ fun RecurringRuleEditorScreen(
     val accounts by repository.accounts.collectAsState(initial = emptyList())
     val categories by repository.categories.collectAsState(initial = emptyList())
     val tags by repository.tags.collectAsState(initial = emptyList())
-    val rules by repository.recurringRules.collectAsState(initial = emptyList())
     val scrollState = rememberScrollState()
 
     val parsedRuleId = remember(ruleId) { ruleId?.let { runCatching { UUID.fromString(it) }.getOrNull() } ?: UUID.randomUUID() }
-    val existingRule = rules.firstOrNull { it.id == parsedRuleId }
     val ownAccounts = accounts.filter { it.type != AccountType.Debt && !it.isArchived }
 
     var loaded by remember(parsedRuleId) { mutableStateOf(false) }
+    var existingRule by remember(parsedRuleId) { mutableStateOf<RecurringRuleEntity?>(null) }
+    var loadError by remember(parsedRuleId) { mutableStateOf<String?>(null) }
     var title by remember { mutableStateOf("") }
     var amount by remember { mutableStateOf("") }
     var currencyCode by remember { mutableStateOf(currencyService.mainCurrency) }
@@ -290,24 +290,34 @@ fun RecurringRuleEditorScreen(
 
     val filteredCategories = categories.filter { it.kind.supports(type) }
 
-    LaunchedEffect(existingRule, ownAccounts, filteredCategories) {
-        if (loaded) return@LaunchedEffect
-        if (existingRule != null) {
-            title = existingRule.title
-            amount = existingRule.amount.toPlainString()
-            currencyCode = existingRule.currencyCode
-            type = existingRule.type
-            note = existingRule.note
-            frequency = RecurringFrequencyOption.fromRaw(existingRule.frequency)
-            intervalCount = existingRule.intervalCount.toString()
-            nextDueDate = existingRule.nextDueDate.atZone(ZoneId.systemDefault()).toLocalDate().toString()
-            isPaused = existingRule.isPaused
-            selectedAccount = ownAccounts.firstOrNull { it.id == existingRule.accountId }
-            selectedCategory = filteredCategories.firstOrNull { it.id == existingRule.categoryId }
-            val existingTagIds = repository.getRecurringRuleTagIds(existingRule.id).toSet()
-            selectedTags = tags.filter { it.id in existingTagIds }
+    LaunchedEffect(ruleId) {
+        if (ruleId == null || loaded) return@LaunchedEffect
+        val editorData = repository.getRecurringRuleEditorData(parsedRuleId)
+        if (editorData == null) {
+            loadError = "找不到要編輯的定期規則。"
             loaded = true
-        } else if (ownAccounts.isNotEmpty()) {
+            return@LaunchedEffect
+        }
+
+        val rule = editorData.rule
+        existingRule = rule
+        title = rule.title
+        amount = rule.amount.toPlainString()
+        currencyCode = rule.currencyCode
+        type = rule.type
+        note = rule.note
+        frequency = RecurringFrequencyOption.fromRaw(rule.frequency)
+        intervalCount = rule.intervalCount.toString()
+        nextDueDate = rule.nextDueDate.atZone(ZoneId.systemDefault()).toLocalDate().toString()
+        isPaused = rule.isPaused
+        selectedAccount = editorData.account
+        selectedCategory = editorData.category
+        selectedTags = editorData.tags
+        loaded = true
+    }
+
+    LaunchedEffect(ruleId, ownAccounts, filteredCategories) {
+        if (ruleId == null && !loaded && ownAccounts.isNotEmpty()) {
             selectedAccount = ownAccounts.first()
             currencyCode = selectedAccount?.currency ?: currencyService.mainCurrency
             selectedCategory = filteredCategories.firstOrNull()
@@ -316,7 +326,11 @@ fun RecurringRuleEditorScreen(
     }
 
     LaunchedEffect(type, filteredCategories) {
-        if (selectedCategory != null && filteredCategories.none { it.id == selectedCategory?.id }) {
+        if (
+            categories.isNotEmpty() &&
+            selectedCategory != null &&
+            filteredCategories.none { it.id == selectedCategory?.id }
+        ) {
             selectedCategory = filteredCategories.firstOrNull()
         }
     }
@@ -335,9 +349,16 @@ fun RecurringRuleEditorScreen(
         verticalArrangement = Arrangement.spacedBy(AppSpacing.section)
     ) {
         ParityTopSection(
-            title = if (existingRule == null) "新增定期記帳" else "編輯定期記帳",
+            title = if (ruleId == null) "新增定期記帳" else "編輯定期記帳",
             subtitle = "到期後先進待確認，不會偷偷寫入帳目。"
         )
+
+        if (loadError != null) {
+            Text(
+                text = loadError.orEmpty(),
+                color = MaterialTheme.colorScheme.error
+            )
+        }
 
         SectionCard {
             Column(modifier = Modifier.padding(AppSpacing.card), verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -462,7 +483,10 @@ fun RecurringRuleEditorScreen(
                     }
                 }
             },
-            enabled = selectedAccount != null && amount.toBigDecimalOrNull()?.let { it > BigDecimal.ZERO } == true && parseDateInput(nextDueDate) != null,
+            enabled = loadError == null &&
+                selectedAccount != null &&
+                amount.toBigDecimalOrNull()?.let { it > BigDecimal.ZERO } == true &&
+                parseDateInput(nextDueDate) != null,
             modifier = Modifier.fillMaxWidth().height(52.dp)
         ) {
             Text("儲存")
@@ -475,7 +499,8 @@ fun RecurringRuleEditorScreen(
         }
     }
 
-    if (showDeleteConfirm && existingRule != null) {
+    val ruleToDelete = existingRule
+    if (showDeleteConfirm && ruleToDelete != null) {
         AlertDialog(
             onDismissRequest = { showDeleteConfirm = false },
             title = { Text("刪除定期規則？") },
@@ -485,7 +510,7 @@ fun RecurringRuleEditorScreen(
                     onClick = {
                         showDeleteConfirm = false
                         scope.launch {
-                            repository.deleteRecurringRule(existingRule)
+                            repository.deleteRecurringRule(ruleToDelete)
                             onDone()
                         }
                     }

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/EditorInvariantsTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/EditorInvariantsTest.kt
@@ -1,0 +1,135 @@
+package org.duckdns.lhfser.aiaccounting.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.CategoryKind
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.ui.screens.sanitizeSignedAmount
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class EditorInvariantsTest {
+    private lateinit var database: AIAccountingDatabase
+    private lateinit var repository: AccountingRepository
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AIAccountingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = AccountingRepository(database, CurrencyService(context))
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun editingAccount_preservesCurrencyAndSortOrderButAllowsSignedBalance() = runBlocking {
+        val account = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "JPY bank",
+            currency = "JPY",
+            type = AccountType.Bank,
+            baseBalance = BigDecimal("1000"),
+            sortOrder = 7,
+            isArchived = false
+        )
+        repository.upsertAccount(account)
+
+        repository.saveAccountEdit(
+            AccountEditDraft(
+                accountId = account.id,
+                name = "Renamed bank",
+                requestedCurrency = "",
+                type = AccountType.Bank,
+                baseBalance = BigDecimal("-250"),
+                isArchived = false
+            )
+        )
+
+        val updated = repository.getAccount(account.id)
+        assertEquals("Renamed bank", updated?.name)
+        assertEquals("JPY", updated?.currency)
+        assertEquals(7, updated?.sortOrder)
+        assertEquals(BigDecimal("-250"), updated?.baseBalance)
+    }
+
+    @Test
+    fun signedAmountInput_keepsOneLeadingSignAndDecimalPoint() {
+        assertEquals("-250.5", sanitizeSignedAmount("--250..5"))
+        assertEquals("250.5", sanitizeSignedAmount("250..5"))
+        assertEquals("", sanitizeSignedAmount("-"))
+    }
+
+    @Test
+    fun recurringRuleEditorData_loadsStableRuleRelationsAndTags() = runBlocking {
+        val account = AccountEntity(
+            id = UUID.randomUUID(),
+            name = "Wallet",
+            currency = "HKD",
+            type = AccountType.Cash,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = 0,
+            isArchived = false
+        )
+        val category = CategoryEntity(
+            id = UUID.randomUUID(),
+            name = "Transport",
+            icon = "tram",
+            colorHex = "#123456",
+            kind = CategoryKind.Expense
+        )
+        val tag = TagEntity(UUID.randomUUID(), "Monthly")
+        val rule = RecurringRuleEntity(
+            id = UUID.randomUUID(),
+            title = "Transit pass",
+            amount = BigDecimal("500"),
+            currencyCode = "HKD",
+            type = TransactionType.Expense,
+            note = "",
+            frequency = "Monthly",
+            intervalCount = 1,
+            nextDueDate = Instant.parse("2026-07-01T00:00:00Z"),
+            isPaused = false,
+            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
+            updatedAt = Instant.parse("2026-06-01T00:00:00Z"),
+            accountId = account.id,
+            categoryId = category.id
+        )
+        repository.upsertAccount(account)
+        repository.upsertCategory(category)
+        repository.upsertTag(tag)
+        repository.upsertRecurringRule(rule, listOf(tag.id))
+
+        val editorData = repository.getRecurringRuleEditorData(rule.id)
+
+        assertNotNull(editorData)
+        assertEquals(rule, editorData?.rule)
+        assertEquals(account, editorData?.account)
+        assertEquals(category, editorData?.category)
+        assertEquals(listOf(tag), editorData?.tags)
+    }
+}


### PR DESCRIPTION
Closes #135

## Summary
- preserve account currency and sort order while supporting signed opening balances
- load recurring rule account, category, and tags from one stable repository snapshot
- prevent asynchronous editor flows from resetting existing rules to blank drafts

## Validation
- `./gradlew testDebugUnitTest --tests org.duckdns.lhfser.aiaccounting.data.EditorInvariantsTest`
- `./gradlew testDebugUnitTest assembleDebug`