### PR TITLE
Add semantic transfer replacement and routing

### DIFF
--- a/AI 記帳/Services/DebtTransferEditService.swift
+++ b/AI 記帳/Services/DebtTransferEditService.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+enum DebtTransferDirection {
+    case borrow
+    case repay
+}
+
+struct DebtTransferEditDraft {
+    let debtAccount: Account
+    let ownAccount: Account
+    let amount: Decimal
+    let currencyCode: String
+    let date: Date
+    let note: String
+    let direction: DebtTransferDirection
+}
+
+enum DebtTransferEditError: LocalizedError, Equatable {
+    case invalidAmount
+    case missingGroup
+    case invalidStructure
+    case directionChanged
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAmount:
+            return "債務金額必須大於 0。"
+        case .missingGroup:
+            return "找不到原本的債務轉帳群組。"
+        case .invalidStructure:
+            return "債務轉帳必須包含一個借貸對象與一個自己的帳戶。"
+        case .directionChanged:
+            return "不可在編輯時翻轉借入／還款方向。"
+        }
+    }
+}
+
+enum DebtTransferEditService {
+    static func apply(
+        _ draft: DebtTransferEditDraft,
+        debtTransaction: FinancialTransaction,
+        ownTransaction: FinancialTransaction,
+        updatedAt: Date
+    ) throws {
+        guard draft.amount > 0 else {
+            throw DebtTransferEditError.invalidAmount
+        }
+        guard let groupID = debtTransaction.transferGroupID,
+              ownTransaction.transferGroupID == groupID
+        else {
+            throw DebtTransferEditError.missingGroup
+        }
+        guard debtTransaction.account?.type == .debt,
+              ownTransaction.account?.type != .debt
+        else {
+            throw DebtTransferEditError.invalidStructure
+        }
+
+        let existingDebtSide = debtTransaction.transferSide
+            ?? (debtTransaction.amount < 0 ? .outgoing : .incoming)
+        let expectedDebtSide: TransferSide = draft.direction == .borrow ? .outgoing : .incoming
+        guard existingDebtSide == expectedDebtSide else {
+            throw DebtTransferEditError.directionChanged
+        }
+
+        let amount = abs(draft.amount)
+        let currencyCode = draft.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        let memo = draft.note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? (draft.direction == .borrow ? "借入 / 收款" : "借出 / 還款")
+            : draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        debtTransaction.account = draft.debtAccount
+        ownTransaction.account = draft.ownAccount
+        debtTransaction.currencyCode = currencyCode
+        ownTransaction.currencyCode = currencyCode
+        debtTransaction.date = draft.date
+        ownTransaction.date = draft.date
+        debtTransaction.transferGroupID = groupID
+        ownTransaction.transferGroupID = groupID
+        debtTransaction.linkedTransactionID = ownTransaction.id
+        ownTransaction.linkedTransactionID = debtTransaction.id
+        debtTransaction.updatedAt = updatedAt
+        ownTransaction.updatedAt = updatedAt
+
+        switch draft.direction {
+        case .borrow:
+            debtTransaction.amount = -amount
+            debtTransaction.transferSide = .outgoing
+            debtTransaction.note = "\(memo) (借入至 \(draft.ownAccount.name))"
+            ownTransaction.amount = amount
+            ownTransaction.transferSide = .incoming
+            ownTransaction.note = "\(memo) (來自 \(draft.debtAccount.name))"
+        case .repay:
+            ownTransaction.amount = -amount
+            ownTransaction.transferSide = .outgoing
+            ownTransaction.note = "\(memo) (還款給 \(draft.debtAccount.name))"
+            debtTransaction.amount = amount
+            debtTransaction.transferSide = .incoming
+            debtTransaction.note = "\(memo) (來自 \(draft.ownAccount.name))"
+        }
+    }
+}

--- a/AI 記帳/Services/TransferEditRoutingService.swift
+++ b/AI 記帳/Services/TransferEditRoutingService.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum TransferEditSemantic: Equatable {
+    case ordinary
+    case debt
+    case debtForgiveness
+    case advanceInitial
+    case advanceRepayment
+}
+
+enum TransferEditRoutingService {
+    static func classify(
+        transaction: FinancialTransaction,
+        groupTransactions: [FinancialTransaction],
+        advanceInitialGroupIDs: Set<UUID>,
+        advanceRepaymentGroupIDs: Set<UUID>
+    ) -> TransferEditSemantic {
+        if let groupID = transaction.transferGroupID {
+            if advanceInitialGroupIDs.contains(groupID) {
+                return .advanceInitial
+            }
+            if advanceRepaymentGroupIDs.contains(groupID) {
+                return .advanceRepayment
+            }
+        }
+        if TransactionSemantics.isDebtForgiveness(note: transaction.note) {
+            return .debtForgiveness
+        }
+        let compactedNote = transaction.note.replacingOccurrences(of: " ", with: "")
+        if compactedNote.contains("(還款至") || compactedNote.contains("(還款給") {
+            return .advanceRepayment
+        }
+        if compactedNote.contains("(代墊給") || compactedNote.contains("(代墊給我") {
+            return .advanceInitial
+        }
+        if groupTransactions.contains(where: { $0.account?.type == .debt }) {
+            return .debt
+        }
+        return .ordinary
+    }
+
+    static func groupTransactions(
+        for transaction: FinancialTransaction,
+        in allTransactions: [FinancialTransaction]
+    ) -> [FinancialTransaction] {
+        if let groupID = transaction.transferGroupID {
+            let group = allTransactions.filter { $0.transferGroupID == groupID }
+            if !group.isEmpty {
+                return group
+            }
+        }
+        if let linkedID = transaction.linkedTransactionID,
+           let linked = allTransactions.first(where: { $0.id == linkedID }) {
+            return [transaction, linked]
+        }
+        return [transaction]
+    }
+}

--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -126,28 +126,25 @@ struct AccountDetailView: View {
     @ViewBuilder
     private func transactionEditor(for tx: FinancialTransaction, renderState: AccountDetailRenderState) -> some View {
         if tx.type == .transfer {
-            if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
+            let group = TransferEditRoutingService.groupTransactions(for: tx, in: renderState.allTransactions)
+            switch TransferEditRoutingService.classify(
+                transaction: tx,
+                groupTransactions: group,
+                advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
+                advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
+            ) {
+            case .advanceInitial, .advanceRepayment:
                 EditAdvanceTransferView(originalTransaction: tx)
-            } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+            case .debtForgiveness:
                 AddDebtView(existingForgivenessTransaction: tx)
-            } else {
+            case .debt:
+                AddDebtView(existingDebtTransaction: tx)
+            case .ordinary:
                 EditTransferView(originalTransaction: tx)
             }
         } else {
             EditTransactionView(transaction: tx)
         }
-    }
-
-    private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {
-        guard tx.type == .transfer else { return false }
-        if let groupID = tx.transferGroupID, advanceGroupIDs.contains(groupID) {
-            return true
-        }
-        let compacted = tx.note.replacingOccurrences(of: " ", with: "")
-        return compacted.contains("(代墊給")
-            || compacted.contains("(代墊給我")
-            || compacted.contains("(還款至")
-            || compacted.contains("(還款給")
     }
 
     private func deleteTransaction(_ transaction: FinancialTransaction) {
@@ -160,10 +157,12 @@ struct AccountDetailView: View {
 }
 
 private struct AccountDetailRenderState {
+    let allTransactions: [FinancialTransaction]
     let accountTransactions: [FinancialTransaction]
     let transferCounterpartByID: [UUID: TransferCounterpartInfo]
     let currencyBalances: [AccountDetailView.CurrencyBalance]
-    let advanceGroupIDs: Set<UUID>
+    let initialAdvanceGroupIDs: Set<UUID>
+    let repaymentAdvanceGroupIDs: Set<UUID>
 
     init(
         account: Account,
@@ -174,11 +173,13 @@ private struct AccountDetailRenderState {
         modelContext: ModelContext
     ) {
         let accountTransactions = allTransactions.filter { $0.account?.id == account.id }
-        var advanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
-        advanceGroupIDs.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
+        let initialAdvanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
+        let repaymentAdvanceGroupIDs = Set(advanceRepayments.compactMap(\.linkedTransferGroupID))
 
+        self.allTransactions = allTransactions
         self.accountTransactions = accountTransactions
-        self.advanceGroupIDs = advanceGroupIDs
+        self.initialAdvanceGroupIDs = initialAdvanceGroupIDs
+        self.repaymentAdvanceGroupIDs = repaymentAdvanceGroupIDs
         self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: allTransactions)
         self.currencyBalances = Self.currencyBalances(
             account: account,

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -563,6 +563,7 @@ private func reportCurrencySummary(_ totals: [ReportCurrencyTotal]) -> String {
 
 private struct ReportTransactionListView: View {
     @Environment(\.modelContext) private var modelContext
+    @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
     @Query private var advanceParticipants: [AdvanceParticipant]
     @Query private var advanceRepayments: [AdvanceRepayment]
 
@@ -574,6 +575,7 @@ private struct ReportTransactionListView: View {
     var body: some View {
         let renderState = ReportTransactionListRenderState(
             transactions: detail.transactions,
+            allTransactions: allTransactions,
             advanceParticipants: advanceParticipants,
             advanceRepayments: advanceRepayments
         )
@@ -641,11 +643,20 @@ private struct ReportTransactionListView: View {
     @ViewBuilder
     private func transactionEditor(for tx: FinancialTransaction, renderState: ReportTransactionListRenderState) -> some View {
         if tx.type == .transfer {
-            if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
+            let group = TransferEditRoutingService.groupTransactions(for: tx, in: renderState.allTransactions)
+            switch TransferEditRoutingService.classify(
+                transaction: tx,
+                groupTransactions: group,
+                advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
+                advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
+            ) {
+            case .advanceInitial, .advanceRepayment:
                 EditAdvanceTransferView(originalTransaction: tx)
-            } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+            case .debtForgiveness:
                 AddDebtView(existingForgivenessTransaction: tx)
-            } else {
+            case .debt:
+                AddDebtView(existingDebtTransaction: tx)
+            case .ordinary:
                 EditTransferView(originalTransaction: tx)
             }
         } else {
@@ -661,17 +672,6 @@ private struct ReportTransactionListView: View {
         }
     }
 
-    private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {
-        guard tx.type == .transfer else { return false }
-        if let groupID = tx.transferGroupID, advanceGroupIDs.contains(groupID) {
-            return true
-        }
-        let compacted = tx.note.replacingOccurrences(of: " ", with: "")
-        return compacted.contains("(代墊給")
-            || compacted.contains("(代墊給我")
-            || compacted.contains("(還款至")
-            || compacted.contains("(還款給")
-    }
 }
 
 private struct ReportDetailSummaryCard: View {
@@ -780,19 +780,22 @@ private struct ReportBreakdownRow: View {
 }
 
 private struct ReportTransactionListRenderState {
+    let allTransactions: [FinancialTransaction]
     let transferCounterpartByID: [UUID: TransferCounterpartInfo]
     let groupedTransactions: [(title: String, items: [FinancialTransaction])]
-    let advanceGroupIDs: Set<UUID>
+    let initialAdvanceGroupIDs: Set<UUID>
+    let repaymentAdvanceGroupIDs: Set<UUID>
 
     init(
         transactions: [FinancialTransaction],
+        allTransactions: [FinancialTransaction],
         advanceParticipants: [AdvanceParticipant],
         advanceRepayments: [AdvanceRepayment]
     ) {
-        var advanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
-        advanceGroupIDs.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
-        self.advanceGroupIDs = advanceGroupIDs
-        self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: transactions)
+        self.allTransactions = allTransactions
+        self.initialAdvanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
+        self.repaymentAdvanceGroupIDs = Set(advanceRepayments.compactMap(\.linkedTransferGroupID))
+        self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: allTransactions)
         self.groupedTransactions = Self.groupedTransactions(from: transactions)
     }
 

--- a/AI 記帳/Views/Transactions/AddDebtView.swift
+++ b/AI 記帳/Views/Transactions/AddDebtView.swift
@@ -8,6 +8,7 @@ struct AddDebtView: View {
 
     @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
     private let existingForgivenessTransactionID: UUID?
+    private let existingDebtTransactionID: UUID?
     private let presetDebtAccountID: UUID?
     private let presetMode: DebtMode?
     private let presetForgivenessDirection: DebtForgivenessDirection?
@@ -73,17 +74,20 @@ struct AddDebtView: View {
 
     @State private var splitLegs: [SplitLeg] = [SplitLeg()]
     @State private var mergeLegs: [MergeLeg] = [MergeLeg()]
+    @State private var existingDebtGroupID: UUID?
 
     @FocusState private var isAmountFocused: Bool
 
     init(
         existingForgivenessTransaction: FinancialTransaction? = nil,
+        existingDebtTransaction: FinancialTransaction? = nil,
         presetDebtAccount: Account? = nil,
         presetMode: DebtMode? = nil,
         presetForgivenessDirection: DebtForgivenessDirection? = nil,
         presetNote: String? = nil
     ) {
         self.existingForgivenessTransactionID = existingForgivenessTransaction?.id
+        self.existingDebtTransactionID = existingDebtTransaction?.id
         self.presetDebtAccountID = presetDebtAccount?.id
         self.presetMode = presetMode
         self.presetForgivenessDirection = presetForgivenessDirection
@@ -100,6 +104,7 @@ struct AddDebtView: View {
                         }
                     }
                     .pickerStyle(.segmented)
+                    .disabled(existingDebtGroupID != nil)
 
                     if mode == .forgive {
                         Picker("免除方向", selection: $forgivenessDirection) {
@@ -108,6 +113,7 @@ struct AddDebtView: View {
                             }
                         }
                         .pickerStyle(.segmented)
+                        .disabled(existingDebtGroupID != nil)
                     } else {
                         Picker("模式", selection: $entryMode) {
                             ForEach(EntryMode.allCases) { option in
@@ -115,6 +121,12 @@ struct AddDebtView: View {
                             }
                         }
                         .pickerStyle(.segmented)
+                        .disabled(existingDebtGroupID != nil)
+                        if existingDebtGroupID != nil {
+                            Text("編輯既有債務時會保留借入／還款方向與原本的轉帳關聯。")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
 
@@ -145,7 +157,7 @@ struct AddDebtView: View {
                             }
                         }
                         .onChange(of: selectedMyAccount) { _, _ in
-                            if let acc = selectedMyAccount {
+                            if existingDebtGroupID == nil, let acc = selectedMyAccount {
                                 selectedCurrency = acc.currency
                             }
                         }
@@ -182,7 +194,13 @@ struct AddDebtView: View {
                     Button("取消") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(existingForgivenessTransactionID == nil ? "確認" : "儲存") { saveTransaction() }
+                    Button(
+                        existingForgivenessTransactionID == nil && existingDebtTransactionID == nil
+                            ? "確認"
+                            : "儲存"
+                    ) {
+                        saveTransaction()
+                    }
                         .disabled(!canSubmit)
                 }
                 ToolbarItemGroup(placement: .keyboard) {
@@ -204,6 +222,7 @@ struct AddDebtView: View {
                     date = transaction.date
                     note = extractForgivenessNote(transaction.note)
                 }
+                loadExistingDebtTransaction()
                 if selectedMyAccount == nil {
                     selectedMyAccount = myAccounts.first
                 }
@@ -211,7 +230,7 @@ struct AddDebtView: View {
                     selectedDebtAccount = debtAccounts.first
                 }
                 applyPresetIfNeeded()
-                if let acc = selectedMyAccount {
+                if existingDebtGroupID == nil, let acc = selectedMyAccount {
                     selectedCurrency = acc.currency
                 }
                 if splitLegs.first?.account == nil, let first = myAccounts.first {
@@ -424,6 +443,17 @@ struct AddDebtView: View {
             return
         }
 
+        if existingDebtGroupID != nil {
+            do {
+                try updateExistingDebtPair(debtAccount: debtAcc)
+                dismiss()
+            } catch {
+                modelContext.rollback()
+                showValidation(error.localizedDescription)
+            }
+            return
+        }
+
         switch effectiveEntryMode {
         case .normal:
             guard let amount = positiveDecimal(from: amountString) else {
@@ -607,6 +637,87 @@ struct AddDebtView: View {
         }
     }
 
+    private func loadExistingDebtTransaction() {
+        guard existingDebtGroupID == nil,
+              let existingDebtTransactionID,
+              let original = allAccounts
+                .flatMap(\.transactions)
+                .first(where: { $0.id == existingDebtTransactionID }),
+              let groupID = original.transferGroupID
+        else {
+            return
+        }
+
+        let group = allAccounts
+            .flatMap(\.transactions)
+            .filter { $0.transferGroupID == groupID }
+        guard group.count == 2,
+              let debtTransaction = group.first(where: { $0.account?.type == .debt }),
+              let ownTransaction = group.first(where: { $0.account?.type != .debt }),
+              let debtAccount = debtTransaction.account,
+              let ownAccount = ownTransaction.account
+        else {
+            showValidation("這筆債務轉帳的分錄結構不完整。")
+            return
+        }
+
+        existingDebtGroupID = groupID
+        let debtSide = debtTransaction.transferSide
+            ?? (debtTransaction.amount < 0 ? .outgoing : .incoming)
+        mode = debtSide == .outgoing ? .borrow : .repay
+        entryMode = .normal
+        selectedDebtAccount = debtAccount
+        selectedMyAccount = ownAccount
+        selectedCurrency = ownTransaction.currencyCode
+        amountString = NSDecimalNumber(decimal: abs(ownTransaction.amount)).stringValue
+        date = ownTransaction.date
+        note = extractDebtNote(group.first(where: { !$0.note.isEmpty })?.note ?? "")
+    }
+
+    private func updateExistingDebtPair(debtAccount: Account) throws {
+        guard let groupID = existingDebtGroupID,
+              let myAccount = selectedMyAccount,
+              let amount = positiveDecimal(from: amountString)
+        else {
+            throw NSError(
+                domain: "AddDebtView",
+                code: 20,
+                userInfo: [NSLocalizedDescriptionKey: "請輸入完整金額並選擇自己的帳戶。"]
+            )
+        }
+
+        let group = allAccounts
+            .flatMap(\.transactions)
+            .filter { $0.transferGroupID == groupID }
+        guard group.count == 2,
+              let debtTransaction = group.first(where: { $0.account?.type == .debt }),
+              let ownTransaction = group.first(where: { $0.account?.type != .debt })
+        else {
+            throw NSError(
+                domain: "AddDebtView",
+                code: 21,
+                userInfo: [NSLocalizedDescriptionKey: "找不到完整的債務轉帳分錄。"]
+            )
+        }
+
+        try DebtTransferEditService.apply(
+            DebtTransferEditDraft(
+                debtAccount: debtAccount,
+                ownAccount: myAccount,
+                amount: amount,
+                currencyCode: selectedCurrency,
+                date: date,
+                note: note,
+                direction: mode == .borrow ? .borrow : .repay
+            ),
+            debtTransaction: debtTransaction,
+            ownTransaction: ownTransaction,
+            updatedAt: Date()
+        )
+
+        try modelContext.save()
+    }
+
     private func indexedMemo(base: String, mode: EntryMode, index: Int, count: Int) -> String {
         let suffix: String
         switch mode {
@@ -623,6 +734,15 @@ struct AddDebtView: View {
             return suffix
         }
         return "\(trimmed) \(suffix)"
+    }
+
+    private func extractDebtNote(_ value: String) -> String {
+        let separators = [" (借入至", " (來自", " (還款給", " (轉至"]
+        let indexes = separators.compactMap { value.range(of: $0)?.lowerBound }
+        guard let first = indexes.min() else {
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return String(value[..<first]).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func positiveDecimal(from value: String) -> Decimal? {

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -9,6 +9,8 @@ struct EditTransferView: View {
     let originalTransaction: FinancialTransaction
 
     @Query(sort: \Account.name) private var accounts: [Account]
+    @Query private var advanceParticipants: [AdvanceParticipant]
+    @Query private var advanceRepayments: [AdvanceRepayment]
 
     private struct TransferLegInput: Identifiable {
         let id: UUID
@@ -250,6 +252,26 @@ struct EditTransferView: View {
                 isLoading = false
                 return
             }
+            let semantic = TransferEditRoutingService.classify(
+                transaction: originalTransaction,
+                groupTransactions: groupTransactions,
+                advanceInitialGroupIDs: Set(advanceParticipants.compactMap(\.initialTransferGroupID)),
+                advanceRepaymentGroupIDs: Set(advanceRepayments.compactMap(\.linkedTransferGroupID))
+            )
+            guard semantic == .ordinary else {
+                switch semantic {
+                case .debt:
+                    errorMessage = "這是債務管理分錄，請從債務管理編輯。"
+                case .debtForgiveness:
+                    errorMessage = "這是免除債務紀錄，請從債務管理編輯。"
+                case .advanceInitial, .advanceRepayment:
+                    errorMessage = "這是代墊關聯分錄，請從代墊詳情編輯。"
+                case .ordinary:
+                    break
+                }
+                isLoading = false
+                return
+            }
 
             let outgoing = groupTransactions.filter { isOutgoing($0) }
             let incoming = groupTransactions.filter { !isOutgoing($0) }
@@ -364,6 +386,7 @@ struct EditTransferView: View {
             try modelContext.save()
             dismiss()
         } catch {
+            modelContext.rollback()
             showValidation(error.localizedDescription)
         }
     }

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -130,11 +130,23 @@ struct TransactionsListView: View {
     @ViewBuilder
     private func transactionEditor(for tx: FinancialTransaction, renderState: TransactionsRenderState) -> some View {
         if tx.type == .transfer {
-            if isAdvanceTransfer(tx, advanceGroupIDs: renderState.advanceGroupIDs) {
+            let group = TransferEditRoutingService.groupTransactions(
+                for: tx,
+                in: renderState.allTransactions
+            )
+            switch TransferEditRoutingService.classify(
+                transaction: tx,
+                groupTransactions: group,
+                advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
+                advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
+            ) {
+            case .advanceInitial, .advanceRepayment:
                 EditAdvanceTransferView(originalTransaction: tx)
-            } else if TransactionSemantics.isDebtForgiveness(note: tx.note) {
+            case .debtForgiveness:
                 AddDebtView(existingForgivenessTransaction: tx)
-            } else {
+            case .debt:
+                AddDebtView(existingDebtTransaction: tx)
+            case .ordinary:
                 EditTransferView(originalTransaction: tx)
             }
         } else {
@@ -429,27 +441,17 @@ struct TransactionsListView: View {
         }
     }
     
-    private func isAdvanceTransfer(_ tx: FinancialTransaction, advanceGroupIDs: Set<UUID>) -> Bool {
-        guard tx.type == .transfer else { return false }
-        if let groupID = tx.transferGroupID, advanceGroupIDs.contains(groupID) {
-            return true
-        }
-        let compacted = tx.note.replacingOccurrences(of: " ", with: "")
-        return compacted.contains("(代墊給")
-            || compacted.contains("(代墊給我")
-            || compacted.contains("(還款至")
-            || compacted.contains("(還款給")
-    }
 }
 
 private struct TransactionsRenderState {
+    let allTransactions: [FinancialTransaction]
     let filteredTransactions: [FinancialTransaction]
     let filteredAdvanceCases: [AdvanceCase]
     let ledgerItems: [TransactionsListView.LedgerItem]
     let groupedTransactions: [TransactionsListView.TransactionGroup]
     let transferCounterpartByID: [UUID: TransferCounterpartInfo]
-    let advanceGroupIDs: Set<UUID>
     let initialAdvanceGroupIDs: Set<UUID>
+    let repaymentAdvanceGroupIDs: Set<UUID>
 
     init(
         transactions: [FinancialTransaction],
@@ -463,8 +465,7 @@ private struct TransactionsRenderState {
         searchText: String
     ) {
         let initialAdvanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
-        var advanceGroupIDs = initialAdvanceGroupIDs
-        advanceGroupIDs.formUnion(advanceRepayments.compactMap(\.linkedTransferGroupID))
+        let repaymentAdvanceGroupIDs = Set(advanceRepayments.compactMap(\.linkedTransferGroupID))
 
         let filteredTransactions = Self.filteredTransactions(
             from: transactions,
@@ -488,13 +489,14 @@ private struct TransactionsRenderState {
             advanceCases: filteredAdvanceCases
         )
 
+        self.allTransactions = transactions
         self.filteredTransactions = filteredTransactions
         self.filteredAdvanceCases = filteredAdvanceCases
         self.ledgerItems = ledgerItems
         self.groupedTransactions = Self.groupedTransactions(from: ledgerItems, filterType: filterType)
         self.transferCounterpartByID = TransferPresentationService.counterpartMap(transactions: transactions)
-        self.advanceGroupIDs = advanceGroupIDs
         self.initialAdvanceGroupIDs = initialAdvanceGroupIDs
+        self.repaymentAdvanceGroupIDs = repaymentAdvanceGroupIDs
     }
 
     private static func filteredTransactions(

--- a/AI 記帳Tests/DebtTransferEditServiceTests.swift
+++ b/AI 記帳Tests/DebtTransferEditServiceTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import AI_記帳
+
+@MainActor
+final class DebtTransferEditServiceTests: XCTestCase {
+    func testBorrowEditPreservesGroupAndTransactionCurrency() throws {
+        let debtAccount = Account(name: "Friend", currency: "JPY", type: .debt, baseBalance: 0)
+        let wallet = Account(name: "Wallet", currency: "JPY", type: .cash, baseBalance: 0)
+        let groupID = UUID()
+        let debtTransaction = FinancialTransaction(
+            amount: -725,
+            currencyCode: "JPY",
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .outgoing,
+            account: debtAccount
+        )
+        let ownTransaction = FinancialTransaction(
+            amount: 725,
+            currencyCode: "JPY",
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .incoming,
+            account: wallet
+        )
+
+        try DebtTransferEditService.apply(
+            DebtTransferEditDraft(
+                debtAccount: debtAccount,
+                ownAccount: wallet,
+                amount: 35.59,
+                currencyCode: "HKD",
+                date: Date(timeIntervalSince1970: 10),
+                note: "LUUP",
+                direction: .borrow
+            ),
+            debtTransaction: debtTransaction,
+            ownTransaction: ownTransaction,
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        XCTAssertEqual(groupID, debtTransaction.transferGroupID)
+        XCTAssertEqual(groupID, ownTransaction.transferGroupID)
+        XCTAssertEqual("HKD", debtTransaction.currencyCode)
+        XCTAssertEqual("HKD", ownTransaction.currencyCode)
+        XCTAssertEqual(Decimal(string: "-35.59"), debtTransaction.amount)
+        XCTAssertEqual(Decimal(string: "35.59"), ownTransaction.amount)
+        XCTAssertEqual("JPY", wallet.currency)
+    }
+
+    func testEditRejectsDirectionFlip() {
+        let debtAccount = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let groupID = UUID()
+        let debtTransaction = FinancialTransaction(
+            amount: -100,
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .outgoing,
+            account: debtAccount
+        )
+        let ownTransaction = FinancialTransaction(
+            amount: 100,
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .incoming,
+            account: wallet
+        )
+
+        XCTAssertThrowsError(
+            try DebtTransferEditService.apply(
+                DebtTransferEditDraft(
+                    debtAccount: debtAccount,
+                    ownAccount: wallet,
+                    amount: 100,
+                    currencyCode: "HKD",
+                    date: Date(),
+                    note: "",
+                    direction: .repay
+                ),
+                debtTransaction: debtTransaction,
+                ownTransaction: ownTransaction,
+                updatedAt: Date()
+            )
+        ) { error in
+            XCTAssertEqual(error as? DebtTransferEditError, .directionChanged)
+        }
+    }
+
+    func testLegacyEditInfersMissingSidesFromAmounts() throws {
+        let debtAccount = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let groupID = UUID()
+        let debtTransaction = FinancialTransaction(
+            amount: -100,
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: nil,
+            account: debtAccount
+        )
+        let ownTransaction = FinancialTransaction(
+            amount: 100,
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: nil,
+            account: wallet
+        )
+
+        try DebtTransferEditService.apply(
+            DebtTransferEditDraft(
+                debtAccount: debtAccount,
+                ownAccount: wallet,
+                amount: 80,
+                currencyCode: "HKD",
+                date: Date(timeIntervalSince1970: 10),
+                note: "",
+                direction: .borrow
+            ),
+            debtTransaction: debtTransaction,
+            ownTransaction: ownTransaction,
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        XCTAssertEqual(.outgoing, debtTransaction.transferSide)
+        XCTAssertEqual(.incoming, ownTransaction.transferSide)
+        XCTAssertEqual(Decimal(-80), debtTransaction.amount)
+        XCTAssertEqual(Decimal(80), ownTransaction.amount)
+    }
+}

--- a/AI 記帳Tests/TransferEditRoutingServiceTests.swift
+++ b/AI 記帳Tests/TransferEditRoutingServiceTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import AI_記帳
+
+@MainActor
+final class TransferEditRoutingServiceTests: XCTestCase {
+    func testDebtGroupRoutesToDebtEditor() {
+        let debt = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let groupID = UUID()
+        let outgoing = FinancialTransaction(
+            amount: -100,
+            currencyCode: "HKD",
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .outgoing,
+            account: debt
+        )
+        let incoming = FinancialTransaction(
+            amount: 100,
+            currencyCode: "HKD",
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .incoming,
+            account: wallet
+        )
+
+        XCTAssertEqual(
+            .debt,
+            TransferEditRoutingService.classify(
+                transaction: incoming,
+                groupTransactions: [outgoing, incoming],
+                advanceInitialGroupIDs: [],
+                advanceRepaymentGroupIDs: []
+            )
+        )
+    }
+
+    func testAdvanceGroupWinsOverDebtAccountShape() {
+        let debt = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let groupID = UUID()
+        let transaction = FinancialTransaction(
+            amount: 100,
+            currencyCode: "HKD",
+            type: .transfer,
+            transferGroupID: groupID,
+            transferSide: .incoming,
+            account: debt
+        )
+
+        XCTAssertEqual(
+            .advanceInitial,
+            TransferEditRoutingService.classify(
+                transaction: transaction,
+                groupTransactions: [transaction],
+                advanceInitialGroupIDs: [groupID],
+                advanceRepaymentGroupIDs: []
+            )
+        )
+    }
+
+    func testOrdinaryTransferRemainsOrdinary() {
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let transaction = FinancialTransaction(
+            amount: -10,
+            currencyCode: "HKD",
+            type: .transfer,
+            account: wallet
+        )
+
+        XCTAssertEqual(
+            .ordinary,
+            TransferEditRoutingService.classify(
+                transaction: transaction,
+                groupTransactions: [transaction],
+                advanceInitialGroupIDs: [],
+                advanceRepaymentGroupIDs: []
+            )
+        )
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -87,6 +87,34 @@ enum class LedgerDeletionResult {
     AdvanceInitialRequiresCase
 }
 
+enum class TransferGroupSemantic {
+    Ordinary,
+    Debt,
+    AdvanceInitial,
+    AdvanceRepayment
+}
+
+data class TransferGroupClassification(
+    val semantic: TransferGroupSemantic,
+    val advanceCaseId: UUID? = null,
+    val advanceParticipantId: UUID? = null,
+    val advanceRepaymentId: UUID? = null
+)
+
+data class TransferReplacementLeg(
+    val accountId: UUID,
+    val currencyCode: String,
+    val amount: BigDecimal,
+    val side: TransferSide
+)
+
+data class TransferGroupReplacementDraft(
+    val groupId: UUID,
+    val date: Instant,
+    val note: String,
+    val legs: List<TransferReplacementLeg>
+)
+
 data class LegacyBorrowedAdvanceRepairResult(
     val repairedParticipantCount: Int,
     val removedInflatedAccountTransactionCount: Int
@@ -167,12 +195,127 @@ class AccountingRepository(
         val remaining: BigDecimal
     )
 
+    private data class ResolvedTransferReplacementLeg(
+        val account: AccountEntity,
+        val currencyCode: String,
+        val amount: BigDecimal,
+        val side: TransferSide
+    )
+
     suspend fun getTransaction(transactionId: UUID): TransactionWithDetails? {
         return transactionDao.getTransaction(transactionId)
     }
 
     suspend fun getTransferGroup(groupId: UUID): List<TransactionWithDetails> {
         return transactionDao.getTransferGroup(groupId)
+    }
+
+    suspend fun classifyTransferGroup(groupId: UUID): TransferGroupClassification? {
+        return database.withTransaction {
+            classifyTransferGroupLocked(groupId)
+        }
+    }
+
+    suspend fun replaceTransferGroup(draft: TransferGroupReplacementDraft): TransferGroupClassification {
+        validateTransferReplacementDraft(draft)
+
+        return database.withTransaction {
+            val existing = transactionDao.getTransferGroup(draft.groupId)
+            require(existing.isNotEmpty()) { "找不到要編輯的轉帳。" }
+
+            val classification = requireNotNull(classifyTransferGroupLocked(draft.groupId)) {
+                "無法判斷轉帳類型。"
+            }
+            require(
+                classification.semantic == TransferGroupSemantic.Ordinary ||
+                    classification.semantic == TransferGroupSemantic.Debt
+            ) {
+                "代墊建立或還款分錄必須從代墊詳情編輯。"
+            }
+
+            val accountById = accountDao.getAll().associateBy { it.id }
+            val resolvedLegs = draft.legs.map { leg ->
+                val account = requireNotNull(accountById[leg.accountId]) { "找不到所選帳戶。" }
+                ResolvedTransferReplacementLeg(
+                    account = account,
+                    currencyCode = leg.currencyCode.trim().uppercase(),
+                    amount = leg.amount.abs(),
+                    side = leg.side
+                )
+            }
+
+            validateTransferSemantic(classification.semantic, existing, resolvedLegs)
+
+            val existingBySide = existing.groupBy { effectiveTransferSide(it.transaction) }
+            val outgoingCounterpart = counterpartSummary(
+                resolvedLegs.filter { it.side == TransferSide.Incoming }.map { it.account }
+            )
+            val incomingCounterpart = counterpartSummary(
+                resolvedLegs.filter { it.side == TransferSide.Outgoing }.map { it.account }
+            )
+            val memo = draft.note.trim().ifBlank {
+                if (classification.semantic == TransferGroupSemantic.Debt) "借貸" else "轉帳"
+            }
+            val now = Instant.now()
+            val prepared = mutableListOf<TransactionEntity>()
+            val removed = mutableListOf<TransactionEntity>()
+
+            TransferSide.values().forEach { side ->
+                val desiredForSide = resolvedLegs.filter { it.side == side }
+                val existingForSide = existingBySide[side]
+                    .orEmpty()
+                    .sortedWith(compareBy({ it.transaction.createdAt }, { it.transaction.id.toString() }))
+
+                desiredForSide.forEachIndexed { index, leg ->
+                    val current = existingForSide.getOrNull(index)?.transaction
+                    prepared += TransactionEntity(
+                        id = current?.id ?: UUID.randomUUID(),
+                        amount = if (side == TransferSide.Outgoing) leg.amount.negate() else leg.amount,
+                        currencyCode = leg.currencyCode,
+                        date = draft.date,
+                        note = transferReplacementNote(
+                            semantic = classification.semantic,
+                            side = side,
+                            legAccount = leg.account,
+                            allLegs = resolvedLegs,
+                            memo = memo,
+                            ordinaryCounterpart = if (side == TransferSide.Outgoing) {
+                                outgoingCounterpart
+                            } else {
+                                incomingCounterpart
+                            }
+                        ),
+                        photoPath = current?.photoPath,
+                        type = TransactionType.Transfer,
+                        linkedTransactionId = null,
+                        transferGroupId = draft.groupId,
+                        transferSide = side,
+                        createdAt = current?.createdAt ?: now,
+                        updatedAt = now,
+                        accountId = leg.account.id,
+                        categoryId = null
+                    )
+                }
+                removed += existingForSide.drop(desiredForSide.size).map { it.transaction }
+            }
+
+            if (prepared.size == 2) {
+                val outgoing = prepared.single { it.transferSide == TransferSide.Outgoing }
+                val incoming = prepared.single { it.transferSide == TransferSide.Incoming }
+                val outgoingIndex = prepared.indexOfFirst { it.id == outgoing.id }
+                val incomingIndex = prepared.indexOfFirst { it.id == incoming.id }
+                prepared[outgoingIndex] = outgoing.copy(linkedTransactionId = incoming.id)
+                prepared[incomingIndex] = incoming.copy(linkedTransactionId = outgoing.id)
+            }
+
+            removed.forEach { transaction ->
+                transactionDao.clearTransactionTags(transaction.id)
+                transactionDao.delete(transaction)
+            }
+            transactionDao.upsertAll(prepared)
+            syncAllBudgetHistory()
+            classification
+        }
     }
 
     suspend fun getAccount(accountId: UUID): AccountEntity? {
@@ -2046,6 +2189,133 @@ class AccountingRepository(
         }
         syncAllBudgetHistory()
         return LedgerDeletionResult.Deleted
+    }
+
+    private suspend fun classifyTransferGroupLocked(groupId: UUID): TransferGroupClassification? {
+        advanceDao.getAllRepayments()
+            .firstOrNull { it.linkedTransferGroupId == groupId }
+            ?.let { repayment ->
+                return TransferGroupClassification(
+                    semantic = TransferGroupSemantic.AdvanceRepayment,
+                    advanceCaseId = repayment.advanceCaseId,
+                    advanceParticipantId = repayment.participantId,
+                    advanceRepaymentId = repayment.id
+                )
+            }
+
+        advanceDao.getAllParticipants()
+            .firstOrNull { it.initialTransferGroupId == groupId }
+            ?.let { participant ->
+                return TransferGroupClassification(
+                    semantic = TransferGroupSemantic.AdvanceInitial,
+                    advanceCaseId = participant.advanceCaseId,
+                    advanceParticipantId = participant.id
+                )
+            }
+
+        val group = transactionDao.getTransferGroup(groupId)
+        if (group.isEmpty()) return null
+        if (group.any { TransactionSemantics.isDebtForgiveness(it.transaction.note) }) {
+            return TransferGroupClassification(TransferGroupSemantic.Debt)
+        }
+        return if (group.any { it.account?.type == AccountType.Debt }) {
+            TransferGroupClassification(TransferGroupSemantic.Debt)
+        } else {
+            TransferGroupClassification(TransferGroupSemantic.Ordinary)
+        }
+    }
+
+    private fun validateTransferReplacementDraft(draft: TransferGroupReplacementDraft) {
+        require(draft.legs.any { it.side == TransferSide.Outgoing }) { "至少需要一筆轉出分錄。" }
+        require(draft.legs.any { it.side == TransferSide.Incoming }) { "至少需要一筆轉入分錄。" }
+        require(draft.legs.all { it.amount > BigDecimal.ZERO }) { "所有轉帳金額都必須大於 0。" }
+        require(draft.legs.all { it.currencyCode.isNotBlank() }) { "所有轉帳分錄都必須有幣種。" }
+
+        TransferSide.values().forEach { side ->
+            val sideLegs = draft.legs.filter { it.side == side }
+            val uniqueIdentities = sideLegs
+                .map { it.accountId to it.currencyCode.trim().uppercase() }
+                .toSet()
+            require(uniqueIdentities.size == sideLegs.size) {
+                "同一方向不可重複使用相同帳戶及幣種。"
+            }
+        }
+    }
+
+    private fun validateTransferSemantic(
+        semantic: TransferGroupSemantic,
+        existing: List<TransactionWithDetails>,
+        desired: List<ResolvedTransferReplacementLeg>
+    ) {
+        when (semantic) {
+            TransferGroupSemantic.Ordinary -> {
+                require(desired.none { it.account.type == AccountType.Debt }) {
+                    "一般轉帳不可直接改成債務紀錄，請使用債務管理。"
+                }
+            }
+            TransferGroupSemantic.Debt -> {
+                require(desired.size == 2) { "債務轉帳必須保持一進一出。" }
+                require(desired.count { it.account.type == AccountType.Debt } == 1) {
+                    "債務轉帳必須包含一個借貸對象與一個自己的帳戶。"
+                }
+                val existingDebtSide = existing
+                    .singleOrNull { it.account?.type == AccountType.Debt }
+                    ?.transaction
+                    ?.let(::effectiveTransferSide)
+                val desiredDebtSide = desired.single { it.account.type == AccountType.Debt }.side
+                require(existingDebtSide != null && desiredDebtSide == existingDebtSide) {
+                    "不可在編輯時翻轉借入／還款方向；請建立新的債務紀錄。"
+                }
+            }
+            TransferGroupSemantic.AdvanceInitial,
+            TransferGroupSemantic.AdvanceRepayment -> {
+                error("代墊關聯轉帳不可使用一般替換。")
+            }
+        }
+    }
+
+    private fun counterpartSummary(accounts: List<AccountEntity>): String {
+        val distinct = accounts.distinctBy { it.id }
+        return when (distinct.size) {
+            0 -> "帳戶"
+            1 -> distinct.single().name
+            else -> "${distinct.size} 個帳戶"
+        }
+    }
+
+    private fun effectiveTransferSide(transaction: TransactionEntity): TransferSide {
+        return transaction.transferSide
+            ?: if (transaction.amount < BigDecimal.ZERO) TransferSide.Outgoing else TransferSide.Incoming
+    }
+
+    private fun transferReplacementNote(
+        semantic: TransferGroupSemantic,
+        side: TransferSide,
+        legAccount: AccountEntity,
+        allLegs: List<ResolvedTransferReplacementLeg>,
+        memo: String,
+        ordinaryCounterpart: String
+    ): String {
+        if (semantic == TransferGroupSemantic.Ordinary) {
+            return if (side == TransferSide.Outgoing) {
+                "$memo (轉至 $ordinaryCounterpart)"
+            } else {
+                "$memo (來自 $ordinaryCounterpart)"
+            }
+        }
+
+        val debtLeg = allLegs.single { it.account.type == AccountType.Debt }
+        val ownLeg = allLegs.single { it.account.type != AccountType.Debt }
+        return when {
+            debtLeg.side == TransferSide.Outgoing && legAccount.type == AccountType.Debt ->
+                "$memo (借入至 ${ownLeg.account.name})"
+            debtLeg.side == TransferSide.Outgoing ->
+                "$memo (來自 ${debtLeg.account.name})"
+            side == TransferSide.Outgoing ->
+                "$memo (還款給 ${debtLeg.account.name})"
+            else ->
+                "$memo (來自 ${ownLeg.account.name})"
+        }
     }
 
     private suspend fun rollbackRepayments(repayments: List<AdvanceRepaymentEntity>) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/AIAccountingRoot.kt
@@ -260,7 +260,8 @@ fun AIAccountingRoot(
                 ReportsScreen(
                     onEdit = { id -> navController.navigate("transaction/edit/$id") },
                     onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") },
-                    onEditDebt = { id -> navController.navigate("debt/edit/$id") }
+                    onEditDebt = { id -> navController.navigate("debt/edit/$id") },
+                    onOpenAdvanceCase = { caseId -> navController.navigate("advance/$caseId") }
                 )
             }
             composable(AppDestination.Accounts.route) {
@@ -432,7 +433,8 @@ fun AIAccountingRoot(
                     onEditAccount = { id -> navController.navigate("accounts/edit/$id") },
                     onEditTransaction = { id -> navController.navigate("transaction/edit/$id") },
                     onEditTransfer = { groupId -> navController.navigate("transfer/edit/$groupId") },
-                    onEditDebt = { id -> navController.navigate("debt/edit/$id") }
+                    onEditDebt = { id -> navController.navigate("debt/edit/$id") },
+                    onOpenAdvanceCase = { caseId -> navController.navigate("advance/$caseId") }
                 )
             }
             composable(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/routing/TransactionEditRouting.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/routing/TransactionEditRouting.kt
@@ -1,0 +1,44 @@
+package org.duckdns.lhfser.aiaccounting.ui.routing
+
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupSemantic
+
+sealed interface TransactionEditDestination {
+    data class Ordinary(val transactionId: String) : TransactionEditDestination
+    data class Transfer(val groupId: String) : TransactionEditDestination
+    data class Debt(val transactionId: String) : TransactionEditDestination
+    data class Advance(val caseId: String) : TransactionEditDestination
+}
+
+suspend fun resolveTransactionEditDestination(
+    repository: AccountingRepository,
+    item: TransactionWithDetails
+): TransactionEditDestination {
+    val transaction = item.transaction
+    if (transaction.type != TransactionType.Transfer) {
+        return TransactionEditDestination.Ordinary(transaction.id.toString())
+    }
+    if (TransactionSemantics.isDebtForgiveness(transaction.note)) {
+        return TransactionEditDestination.Debt(transaction.id.toString())
+    }
+
+    val groupId = transaction.transferGroupId
+        ?: return TransactionEditDestination.Ordinary(transaction.id.toString())
+    val classification = repository.classifyTransferGroup(groupId)
+    return when (classification?.semantic) {
+        TransferGroupSemantic.Debt ->
+            TransactionEditDestination.Debt(transaction.id.toString())
+        TransferGroupSemantic.AdvanceInitial,
+        TransferGroupSemantic.AdvanceRepayment -> {
+            val caseId = requireNotNull(classification.advanceCaseId) {
+                "代墊分錄缺少案件關聯。"
+            }
+            TransactionEditDestination.Advance(caseId.toString())
+        }
+        TransferGroupSemantic.Ordinary,
+        null -> TransactionEditDestination.Transfer(groupId.toString())
+    }
+}

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AccountDetailScreen.kt
@@ -34,6 +34,8 @@ import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.routing.TransactionEditDestination
+import org.duckdns.lhfser.aiaccounting.ui.routing.resolveTransactionEditDestination
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParitySectionHeader
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityStatusPill
@@ -53,7 +55,8 @@ fun AccountDetailScreen(
     onEditAccount: (String) -> Unit,
     onEditTransaction: (String) -> Unit,
     onEditTransfer: (String) -> Unit,
-    onEditDebt: (String) -> Unit
+    onEditDebt: (String) -> Unit,
+    onOpenAdvanceCase: (String) -> Unit
 ) {
     val repository = LocalRepository.current
     val scope = rememberCoroutineScope()
@@ -162,11 +165,19 @@ fun AccountDetailScreen(
                 AccountTransactionRow(
                     item = item,
                     onClick = {
-                        val groupId = item.transaction.transferGroupId?.toString()
-                        when {
-                            item.transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(item.transaction.note) -> onEditDebt(item.transaction.id.toString())
-                            item.transaction.type == TransactionType.Transfer && groupId != null -> onEditTransfer(groupId)
-                            else -> onEditTransaction(item.transaction.id.toString())
+                        scope.launch {
+                            runCatching {
+                                resolveTransactionEditDestination(repository, item)
+                            }.onSuccess { destination ->
+                                when (destination) {
+                                    is TransactionEditDestination.Ordinary -> onEditTransaction(destination.transactionId)
+                                    is TransactionEditDestination.Transfer -> onEditTransfer(destination.groupId)
+                                    is TransactionEditDestination.Debt -> onEditDebt(destination.transactionId)
+                                    is TransactionEditDestination.Advance -> onOpenAdvanceCase(destination.caseId)
+                                }
+                            }.onFailure {
+                                errorMessage = it.localizedMessage ?: "無法開啟編輯頁。"
+                            }
                         }
                     },
                     onLongClick = { transactionToDelete = item }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/DebtEntryScreen.kt
@@ -35,6 +35,9 @@ import org.duckdns.lhfser.aiaccounting.core.transactions.DebtForgivenessDirectio
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupReplacementDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupSemantic
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferReplacementLeg
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
@@ -114,6 +117,7 @@ fun DebtEntryScreen(
     var mergeLegs by remember { mutableStateOf(listOf(DebtMergeLeg())) }
     var validationMessage by remember { mutableStateOf<String?>(null) }
     var didApplyPreset by remember { mutableStateOf(false) }
+    var editingDebtGroupId by remember { mutableStateOf<UUID?>(null) }
 
     val selectedDebtBalance = remember(selectedDebtAccount, transactions) {
         val account = selectedDebtAccount ?: return@remember BigDecimal.ZERO
@@ -163,9 +167,10 @@ fun DebtEntryScreen(
         }
     }
 
-    LaunchedEffect(transactionId, accounts) {
+    LaunchedEffect(transactionId) {
         val id = transactionId?.let(UUID::fromString) ?: return@LaunchedEffect
-        val existing = repository.getTransaction(id)?.transaction ?: return@LaunchedEffect
+        val existingWithDetails = repository.getTransaction(id) ?: return@LaunchedEffect
+        val existing = existingWithDetails.transaction
         if (existing.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(existing.note)) {
             mode = DebtMode.Forgive
             entryMode = DebtEntryMode.Normal
@@ -176,7 +181,41 @@ fun DebtEntryScreen(
             amountInput = existing.amount.abs().toPlainString()
             note = extractForgivenessBaseNote(existing.note)
             date = existing.date
+            return@LaunchedEffect
         }
+
+        val groupId = existing.transferGroupId ?: return@LaunchedEffect
+        val classification = repository.classifyTransferGroup(groupId)
+        if (classification?.semantic != TransferGroupSemantic.Debt) {
+            validationMessage = "這筆紀錄不是可編輯的債務轉帳。"
+            return@LaunchedEffect
+        }
+        val group = repository.getTransferGroup(groupId)
+        val debtLeg = group.singleOrNull { it.account?.type == org.duckdns.lhfser.aiaccounting.core.model.AccountType.Debt }
+        val ownLeg = group.singleOrNull { it.account?.type != org.duckdns.lhfser.aiaccounting.core.model.AccountType.Debt }
+        if (debtLeg == null || ownLeg == null || group.size != 2) {
+            validationMessage = "這筆債務轉帳的分錄結構不完整。"
+            return@LaunchedEffect
+        }
+
+        editingDebtGroupId = groupId
+        mode = if (
+            debtLeg.transaction.transferSide == TransferSide.Outgoing ||
+            (debtLeg.transaction.transferSide == null && debtLeg.transaction.amount < BigDecimal.ZERO)
+        ) {
+            DebtMode.Borrow
+        } else {
+            DebtMode.Repay
+        }
+        entryMode = DebtEntryMode.Normal
+        selectedDebtAccount = debtLeg.account
+        selectedMyAccount = ownLeg.account
+        selectedCurrency = ownLeg.transaction.currencyCode
+        amountInput = ownLeg.transaction.amount.abs().toPlainString()
+        note = extractDebtBaseNote(
+            group.firstOrNull { it.transaction.note.isNotBlank() }?.transaction?.note.orEmpty()
+        )
+        date = ownLeg.transaction.date
     }
 
     Column(
@@ -206,7 +245,9 @@ fun DebtEntryScreen(
                 options = DebtMode.values().toList(),
                 selected = mode,
                 label = { debtModeTitle(it, selectedDebtBalance) },
-                onSelect = { mode = it }
+                onSelect = { selected ->
+                    if (editingDebtGroupId == null) mode = selected
+                }
             )
             if (mode == DebtMode.Forgive) {
                 ParitySegmentedControl(
@@ -225,8 +266,17 @@ fun DebtEntryScreen(
                     options = DebtEntryMode.values().toList(),
                     selected = entryMode,
                     label = { it.label },
-                    onSelect = { entryMode = it }
+                    onSelect = { selected ->
+                        if (editingDebtGroupId == null) entryMode = selected
+                    }
                 )
+                if (editingDebtGroupId != null) {
+                    Text(
+                        "編輯既有債務時會保留借入／還款方向與原本的關聯。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
 
@@ -391,6 +441,10 @@ fun DebtEntryScreen(
                             return@launch
                         }
                         val id = transactionId?.let(UUID::fromString) ?: UUID.randomUUID()
+                        val createdAt = transactionId
+                            ?.let(UUID::fromString)
+                            ?.let { repository.getTransaction(it)?.transaction?.createdAt }
+                            ?: Instant.now()
                         val transaction = TransactionEntity(
                             id = id,
                             amount = amount.multiply(forgivenessDirection.amountSign),
@@ -402,7 +456,7 @@ fun DebtEntryScreen(
                             linkedTransactionId = null,
                             transferGroupId = null,
                             transferSide = null,
-                            createdAt = Instant.now(),
+                            createdAt = createdAt,
                             updatedAt = Instant.now(),
                             accountId = debtAccount.id,
                             categoryId = null
@@ -410,6 +464,62 @@ fun DebtEntryScreen(
                         repository.upsertTransaction(transaction, emptyList())
                         onDone()
                     } else {
+                        val existingGroupId = editingDebtGroupId
+                        if (existingGroupId != null) {
+                            val ownAccount = selectedMyAccount
+                            val amount = amountInput.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO }
+                            if (ownAccount == null || amount == null) {
+                                validationMessage = "請輸入完整金額並選擇自己的帳戶。"
+                                return@launch
+                            }
+                            val legs = if (mode == DebtMode.Borrow) {
+                                listOf(
+                                    TransferReplacementLeg(
+                                        accountId = debtAccount.id,
+                                        currencyCode = selectedCurrency,
+                                        amount = amount,
+                                        side = TransferSide.Outgoing
+                                    ),
+                                    TransferReplacementLeg(
+                                        accountId = ownAccount.id,
+                                        currencyCode = selectedCurrency,
+                                        amount = amount,
+                                        side = TransferSide.Incoming
+                                    )
+                                )
+                            } else {
+                                listOf(
+                                    TransferReplacementLeg(
+                                        accountId = ownAccount.id,
+                                        currencyCode = selectedCurrency,
+                                        amount = amount,
+                                        side = TransferSide.Outgoing
+                                    ),
+                                    TransferReplacementLeg(
+                                        accountId = debtAccount.id,
+                                        currencyCode = selectedCurrency,
+                                        amount = amount,
+                                        side = TransferSide.Incoming
+                                    )
+                                )
+                            }
+                            runCatching {
+                                repository.replaceTransferGroup(
+                                    TransferGroupReplacementDraft(
+                                        groupId = existingGroupId,
+                                        date = date,
+                                        note = note,
+                                        legs = legs
+                                    )
+                                )
+                            }.onSuccess {
+                                onDone()
+                            }.onFailure {
+                                validationMessage = it.localizedMessage ?: "無法儲存債務紀錄。"
+                            }
+                            return@launch
+                        }
+
                         val debtTransactions = buildDebtTransactions(
                             mode = mode,
                             entryMode = entryMode,
@@ -745,4 +855,13 @@ private fun extractForgivenessBaseNote(note: String): String {
         .replace(Regex("\\(對方免除：.*\\)$"), "")
         .replace(Regex("\\(我方免除：.*\\)$"), "")
         .trim()
+}
+
+private fun extractDebtBaseNote(note: String): String {
+    val separators = listOf(" (借入至", " (來自", " (還款給", " (轉至")
+    val separatorIndex = separators
+        .map { note.indexOf(it) }
+        .filter { it >= 0 }
+        .minOrNull()
+    return if (separatorIndex == null) note.trim() else note.substring(0, separatorIndex).trim()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/ReportsScreen.kt
@@ -75,6 +75,8 @@ import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.routing.TransactionEditDestination
+import org.duckdns.lhfser.aiaccounting.ui.routing.resolveTransactionEditDestination
 import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
@@ -152,7 +154,8 @@ private data class BudgetAlert(
 fun ReportsScreen(
     onEdit: (String) -> Unit,
     onEditTransfer: (String) -> Unit,
-    onEditDebt: (String) -> Unit
+    onEditDebt: (String) -> Unit,
+    onOpenAdvanceCase: (String) -> Unit
 ) {
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
@@ -466,7 +469,20 @@ fun ReportsScreen(
                 detail = reportDetail ?: return@ModalBottomSheet,
                 onEdit = { tx ->
                     reportDetail = null
-                    routeTransactionEdit(tx, onEdit, onEditTransfer, onEditDebt)
+                    scope.launch {
+                        runCatching {
+                            resolveTransactionEditDestination(repository, tx)
+                        }.onSuccess { destination ->
+                            when (destination) {
+                                is TransactionEditDestination.Ordinary -> onEdit(destination.transactionId)
+                                is TransactionEditDestination.Transfer -> onEditTransfer(destination.groupId)
+                                is TransactionEditDestination.Debt -> onEditDebt(destination.transactionId)
+                                is TransactionEditDestination.Advance -> onOpenAdvanceCase(destination.caseId)
+                            }
+                        }.onFailure {
+                            errorMessage = it.localizedMessage ?: "無法開啟編輯頁。"
+                        }
+                    }
                 },
                 onDelete = { tx ->
                     transactionToDelete = tx
@@ -914,26 +930,6 @@ private fun ReportBreakdownRow(
             fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.onSurface
         )
-    }
-}
-
-private fun routeTransactionEdit(
-    item: TransactionWithDetails,
-    onEdit: (String) -> Unit,
-    onEditTransfer: (String) -> Unit,
-    onEditDebt: (String) -> Unit
-) {
-    val groupId = item.transaction.transferGroupId?.toString()
-    when {
-        item.transaction.type == TransactionType.Transfer && TransactionSemantics.isDebtForgiveness(item.transaction.note) -> {
-            onEditDebt(item.transaction.id.toString())
-        }
-        item.transaction.type == TransactionType.Transfer && groupId != null -> {
-            onEditTransfer(groupId)
-        }
-        else -> {
-            onEdit(item.transaction.id.toString())
-        }
     }
 }
 

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -58,6 +58,8 @@ import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.repository.LedgerDeletionResult
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.routing.TransactionEditDestination
+import org.duckdns.lhfser.aiaccounting.ui.routing.resolveTransactionEditDestination
 import org.duckdns.lhfser.aiaccounting.ui.LocalUiPreferences
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityEmptyState
 import org.duckdns.lhfser.aiaccounting.ui.components.ParityFilterCapsule
@@ -248,16 +250,22 @@ fun TransactionsScreen(
                     items(section.items, key = { it.stableId }) { item ->
                         when (item) {
                             is LedgerItem.TransactionEntry -> {
-                                val groupId = item.item.transaction.transferGroupId?.toString()
-                                val isDebtForgiveness = TransactionSemantics.isDebtForgiveness(item.item.transaction.note)
-                                val isTransfer = item.item.transaction.type == TransactionType.Transfer && groupId != null
                                 TransactionRow(
                                     item = item.item,
                                     onClick = {
-                                        when {
-                                            isDebtForgiveness -> onEditDebt(item.item.transaction.id.toString())
-                                            isTransfer -> onEditTransfer(groupId!!)
-                                            else -> onEdit(item.item.transaction.id.toString())
+                                        scope.launch {
+                                            runCatching {
+                                                resolveTransactionEditDestination(repository, item.item)
+                                            }.onSuccess { destination ->
+                                                when (destination) {
+                                                    is TransactionEditDestination.Ordinary -> onEdit(destination.transactionId)
+                                                    is TransactionEditDestination.Transfer -> onEditTransfer(destination.groupId)
+                                                    is TransactionEditDestination.Debt -> onEditDebt(destination.transactionId)
+                                                    is TransactionEditDestination.Advance -> onOpenAdvanceCase(destination.caseId)
+                                                }
+                                            }.onFailure {
+                                                errorMessage = it.localizedMessage ?: "無法開啟編輯頁。"
+                                            }
                                         }
                                     },
                                     onLongClick = {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransferEditorScreen.kt
@@ -31,8 +31,9 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
-import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
-import org.duckdns.lhfser.aiaccounting.data.repository.TransferLeg
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupReplacementDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupSemantic
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferReplacementLeg
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
@@ -96,6 +97,9 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
     var note by remember { mutableStateOf("") }
     var date by remember { mutableStateOf(Instant.now()) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isLoaded by remember { mutableStateOf(false) }
+    var isEditable by remember { mutableStateOf(false) }
     val selectableAccountIds = buildSet {
         fromAccount?.id?.let(::add)
         toAccount?.id?.let(::add)
@@ -110,13 +114,36 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
         currencyService.fetchRates()
     }
 
-    LaunchedEffect(groupId, accounts) {
+    LaunchedEffect(groupId) {
         val id = groupId?.let(UUID::fromString) ?: return@LaunchedEffect
+        val classification = repository.classifyTransferGroup(id)
+        if (classification?.semantic != TransferGroupSemantic.Ordinary) {
+            errorMessage = when (classification?.semantic) {
+                TransferGroupSemantic.Debt -> "這是債務管理分錄，請從債務管理編輯。"
+                TransferGroupSemantic.AdvanceInitial,
+                TransferGroupSemantic.AdvanceRepayment -> "這是代墊關聯分錄，請從代墊詳情編輯。"
+                else -> "找不到可編輯的轉帳。"
+            }
+            isLoaded = true
+            return@LaunchedEffect
+        }
         val group = repository.getTransferGroup(id)
-        if (group.isEmpty()) return@LaunchedEffect
+        if (group.isEmpty()) {
+            errorMessage = "找不到可編輯的轉帳。"
+            isLoaded = true
+            return@LaunchedEffect
+        }
 
-        val outgoing = group.filter { it.transaction.transferSide == TransferSide.Outgoing }
-        val incoming = group.filter { it.transaction.transferSide == TransferSide.Incoming }
+        val outgoing = group.filter {
+            it.transaction.transferSide == TransferSide.Outgoing || (
+                it.transaction.transferSide == null && it.transaction.amount < BigDecimal.ZERO
+            )
+        }
+        val incoming = group.filter {
+            it.transaction.transferSide == TransferSide.Incoming || (
+                it.transaction.transferSide == null && it.transaction.amount >= BigDecimal.ZERO
+            )
+        }
         val firstNote = group.firstOrNull { it.transaction.note.isNotBlank() }?.transaction?.note ?: ""
         note = firstNote
         date = (outgoing.firstOrNull() ?: incoming.first()).transaction.date
@@ -125,8 +152,8 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
                 mode = TransferEditMode.OneToOne
                 val outTx = outgoing.first()
                 val inTx = incoming.first()
-                fromAccount = accounts.firstOrNull { it.id == outTx.transaction.accountId }
-                toAccount = accounts.firstOrNull { it.id == inTx.transaction.accountId }
+                fromAccount = outTx.account
+                toAccount = inTx.account
                 currencyOut = outTx.transaction.currencyCode
                 currencyIn = inTx.transaction.currencyCode
                 amountOut = outTx.transaction.amount.abs().toPlainString()
@@ -135,12 +162,12 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
             outgoing.size == 1 && incoming.size > 1 -> {
                 mode = TransferEditMode.OneToMany
                 val outTx = outgoing.first()
-                sourceAccount = accounts.firstOrNull { it.id == outTx.transaction.accountId }
+                sourceAccount = outTx.account
                 sourceCurrency = outTx.transaction.currencyCode
                 sourceAmount = outTx.transaction.amount.abs().toPlainString()
                 destinationLegs = incoming.map { tx ->
                     TransferEditLegInput(
-                        account = accounts.firstOrNull { it.id == tx.transaction.accountId },
+                        account = tx.account,
                         currency = tx.transaction.currencyCode,
                         amount = tx.transaction.amount.abs().toPlainString()
                     )
@@ -149,18 +176,21 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
             outgoing.size > 1 && incoming.size == 1 -> {
                 mode = TransferEditMode.ManyToOne
                 val inTx = incoming.first()
-                destinationAccount = accounts.firstOrNull { it.id == inTx.transaction.accountId }
+                destinationAccount = inTx.account
                 destinationCurrency = inTx.transaction.currencyCode
                 destinationAmount = inTx.transaction.amount.abs().toPlainString()
                 sourceLegs = outgoing.map { tx ->
                     TransferEditLegInput(
-                        account = accounts.firstOrNull { it.id == tx.transaction.accountId },
+                        account = tx.account,
                         currency = tx.transaction.currencyCode,
                         amount = tx.transaction.amount.abs().toPlainString()
                     )
                 }
             }
+            else -> errorMessage = "這組轉帳的分錄結構不完整，無法安全編輯。"
         }
+        isEditable = errorMessage == null
+        isLoaded = true
     }
 
     Column(
@@ -328,72 +358,84 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
         Button(
             onClick = {
                 scope.launch {
-                    val id = groupId?.let(UUID::fromString) ?: return@launch
-                    repository.deleteTransferGroup(id)
-                    when (mode) {
-                        TransferEditMode.OneToOne -> {
-                            val from = fromAccount ?: return@launch
-                            val to = toAccount ?: return@launch
-                            val amountOutValue = parsePositive(amountOut) ?: return@launch
-                            val amountInValue = if (currencyOut == currencyIn) amountOutValue else parsePositive(amountIn)
-                                ?: return@launch
-                            repository.createTransferOneToOne(
-                                from = from,
-                                to = to,
-                                amountOut = amountOutValue,
-                                currencyOut = currencyOut,
-                                amountIn = amountInValue,
-                                currencyIn = currencyIn,
-                                date = date,
-                                note = note
+                    runCatching {
+                        val id = requireNotNull(groupId?.let(UUID::fromString)) { "缺少轉帳識別資料。" }
+                        val legs = when (mode) {
+                            TransferEditMode.OneToOne -> listOf(
+                                TransferReplacementLeg(
+                                    accountId = requireNotNull(fromAccount?.id) { "請選擇轉出帳戶。" },
+                                    currencyCode = currencyOut,
+                                    amount = requireNotNull(parsePositive(amountOut)) { "請輸入有效轉出金額。" },
+                                    side = TransferSide.Outgoing
+                                ),
+                                TransferReplacementLeg(
+                                    accountId = requireNotNull(toAccount?.id) { "請選擇轉入帳戶。" },
+                                    currencyCode = currencyIn,
+                                    amount = requireNotNull(parsePositive(amountIn)) { "請輸入有效轉入金額。" },
+                                    side = TransferSide.Incoming
+                                )
                             )
-                        }
-                        TransferEditMode.OneToMany -> {
-                            val source = sourceAccount ?: return@launch
-                            val sourceValue = parsePositive(sourceAmount) ?: return@launch
-                            val legs = destinationLegs.mapNotNull { leg ->
-                                val account = leg.account ?: return@mapNotNull null
-                                val amount = parsePositive(leg.amount) ?: return@mapNotNull null
-                                TransferLeg(account, leg.currency, amount)
+                            TransferEditMode.OneToMany -> {
+                                val source = requireNotNull(sourceAccount) { "請選擇轉出帳戶。" }
+                                val sourceValue = requireNotNull(parsePositive(sourceAmount)) { "請輸入有效轉出總額。" }
+                                listOf(
+                                    TransferReplacementLeg(
+                                        accountId = source.id,
+                                        currencyCode = sourceCurrency,
+                                        amount = sourceValue,
+                                        side = TransferSide.Outgoing
+                                    )
+                                ) + destinationLegs.mapIndexed { index, leg ->
+                                    TransferReplacementLeg(
+                                        accountId = requireNotNull(leg.account?.id) { "請選擇轉入帳戶 ${index + 1}。" },
+                                        currencyCode = leg.currency,
+                                        amount = requireNotNull(parsePositive(leg.amount)) { "請輸入轉入帳戶 ${index + 1} 的有效金額。" },
+                                        side = TransferSide.Incoming
+                                    )
+                                }
                             }
-                            if (legs.isEmpty()) return@launch
-                            repository.createTransferOneToMany(
-                                source = source,
-                                sourceAmount = sourceValue,
-                                sourceCurrency = sourceCurrency,
-                                destinations = legs,
-                                date = date,
-                                note = note
-                            )
-                        }
-                        TransferEditMode.ManyToOne -> {
-                            val destination = destinationAccount ?: return@launch
-                            val destinationValue = parsePositive(destinationAmount) ?: return@launch
-                            val legs = sourceLegs.mapNotNull { leg ->
-                                val account = leg.account ?: return@mapNotNull null
-                                val amount = parsePositive(leg.amount) ?: return@mapNotNull null
-                                TransferLeg(account, leg.currency, amount)
+                            TransferEditMode.ManyToOne -> {
+                                val destination = requireNotNull(destinationAccount) { "請選擇轉入帳戶。" }
+                                val destinationValue = requireNotNull(parsePositive(destinationAmount)) { "請輸入有效轉入總額。" }
+                                sourceLegs.mapIndexed { index, leg ->
+                                    TransferReplacementLeg(
+                                        accountId = requireNotNull(leg.account?.id) { "請選擇轉出帳戶 ${index + 1}。" },
+                                        currencyCode = leg.currency,
+                                        amount = requireNotNull(parsePositive(leg.amount)) { "請輸入轉出帳戶 ${index + 1} 的有效金額。" },
+                                        side = TransferSide.Outgoing
+                                    )
+                                } + TransferReplacementLeg(
+                                    accountId = destination.id,
+                                    currencyCode = destinationCurrency,
+                                    amount = destinationValue,
+                                    side = TransferSide.Incoming
+                                )
                             }
-                            if (legs.isEmpty()) return@launch
-                            repository.createTransferManyToOne(
-                                destination = destination,
-                                destinationAmount = destinationValue,
-                                destinationCurrency = destinationCurrency,
-                                sources = legs,
-                                date = date,
-                                note = note
-                            )
                         }
+                        repository.replaceTransferGroup(
+                            TransferGroupReplacementDraft(
+                                groupId = id,
+                                date = date,
+                                note = note,
+                                legs = legs
+                            )
+                        )
+                    }.onSuccess {
+                        onDone()
+                    }.onFailure {
+                        errorMessage = it.localizedMessage ?: "無法儲存轉帳。"
                     }
-                    onDone()
                 }
-            }
+            },
+            enabled = isLoaded && isEditable
         ) {
             Text("儲存")
         }
 
-        TextButton(onClick = { showDeleteConfirm = true }) {
-            Text("刪除轉帳", color = MaterialTheme.colorScheme.error)
+        if (isEditable) {
+            TextButton(onClick = { showDeleteConfirm = true }) {
+                Text("刪除轉帳", color = MaterialTheme.colorScheme.error)
+            }
         }
     }
 
@@ -413,6 +455,17 @@ fun TransferEditorScreen(groupId: String?, onDone: () -> Unit) {
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirm = false }) { Text("取消") }
+            }
+        )
+    }
+
+    if (errorMessage != null) {
+        AlertDialog(
+            onDismissRequest = { errorMessage = null },
+            title = { Text("無法編輯轉帳") },
+            text = { Text(errorMessage.orEmpty()) },
+            confirmButton = {
+                TextButton(onClick = { errorMessage = null }) { Text("了解") }
             }
         )
     }

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/TransferGroupReplacementTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/TransferGroupReplacementTest.kt
@@ -1,0 +1,319 @@
+package org.duckdns.lhfser.aiaccounting.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
+import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupReplacementDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferGroupSemantic
+import org.duckdns.lhfser.aiaccounting.data.repository.TransferReplacementLeg
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.ui.routing.TransactionEditDestination
+import org.duckdns.lhfser.aiaccounting.ui.routing.resolveTransactionEditDestination
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class TransferGroupReplacementTest {
+    private lateinit var database: AIAccountingDatabase
+    private lateinit var repository: AccountingRepository
+    private lateinit var wallet: AccountEntity
+    private lateinit var bank: AccountEntity
+    private lateinit var friend: AccountEntity
+
+    @Before
+    fun setUp() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AIAccountingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = AccountingRepository(database, CurrencyService(context))
+        wallet = account("Wallet", AccountType.Cash, 0)
+        bank = account("Bank", AccountType.Bank, 1)
+        friend = account("Friend", AccountType.Debt, 2)
+        repository.upsertAccount(wallet)
+        repository.upsertAccount(bank)
+        repository.upsertAccount(friend)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun ordinaryReplacement_isAtomicAndPreservesGroupIdentity() = runBlocking {
+        repository.createTransferOneToOne(
+            from = wallet,
+            to = bank,
+            amountOut = BigDecimal("100"),
+            currencyOut = "HKD",
+            amountIn = BigDecimal("100"),
+            currencyIn = "HKD",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            note = "Move"
+        )
+        val original = database.transactionDao().getAll()
+        val groupId = requireNotNull(original.first().transferGroupId)
+
+        repository.replaceTransferGroup(
+            TransferGroupReplacementDraft(
+                groupId = groupId,
+                date = Instant.parse("2026-06-02T10:00:00Z"),
+                note = "Updated",
+                legs = listOf(
+                    TransferReplacementLeg(wallet.id, "HKD", BigDecimal("80"), TransferSide.Outgoing),
+                    TransferReplacementLeg(bank.id, "HKD", BigDecimal("80"), TransferSide.Incoming)
+                )
+            )
+        )
+
+        val updated = repository.getTransferGroup(groupId)
+        assertEquals(2, updated.size)
+        assertEquals(setOf(groupId), updated.map { it.transaction.transferGroupId }.toSet())
+        assertEquals(setOf(BigDecimal("-80"), BigDecimal("80")), updated.map { it.transaction.amount }.toSet())
+    }
+
+    @Test
+    fun invalidReplacement_leavesOriginalGroupUntouched() = runBlocking {
+        repository.createTransferOneToOne(
+            from = wallet,
+            to = bank,
+            amountOut = BigDecimal("100"),
+            currencyOut = "HKD",
+            amountIn = BigDecimal("100"),
+            currencyIn = "HKD",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            note = "Move"
+        )
+        val original = database.transactionDao().getAll()
+        val groupId = requireNotNull(original.first().transferGroupId)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                repository.replaceTransferGroup(
+                    TransferGroupReplacementDraft(
+                        groupId = groupId,
+                        date = Instant.now(),
+                        note = "Invalid",
+                        legs = listOf(
+                            TransferReplacementLeg(wallet.id, "HKD", BigDecimal.ZERO, TransferSide.Outgoing),
+                            TransferReplacementLeg(bank.id, "HKD", BigDecimal("10"), TransferSide.Incoming)
+                        )
+                    )
+                )
+            }
+        }
+
+        assertEquals(original.toSet(), database.transactionDao().getAll().toSet())
+    }
+
+    @Test
+    fun debtReplacement_preservesDebtDirection() = runBlocking {
+        repository.createTransferOneToOne(
+            from = friend,
+            to = wallet,
+            amountOut = BigDecimal("100"),
+            currencyOut = "HKD",
+            amountIn = BigDecimal("100"),
+            currencyIn = "HKD",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            note = "借入"
+        )
+        val groupId = requireNotNull(database.transactionDao().getAll().first().transferGroupId)
+        assertEquals(TransferGroupSemantic.Debt, repository.classifyTransferGroup(groupId)?.semantic)
+        val destination = resolveTransactionEditDestination(
+            repository,
+            repository.getTransferGroup(groupId).first()
+        )
+        assertEquals(
+            TransactionEditDestination.Debt::class,
+            destination::class
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                repository.replaceTransferGroup(
+                    TransferGroupReplacementDraft(
+                        groupId = groupId,
+                        date = Instant.now(),
+                        note = "Wrong direction",
+                        legs = listOf(
+                            TransferReplacementLeg(wallet.id, "HKD", BigDecimal("100"), TransferSide.Outgoing),
+                            TransferReplacementLeg(friend.id, "HKD", BigDecimal("100"), TransferSide.Incoming)
+                        )
+                    )
+                )
+            }
+        }
+
+        val unchanged = repository.getTransferGroup(groupId)
+        assertEquals(friend.id, unchanged.first { it.transaction.transferSide == TransferSide.Outgoing }.transaction.accountId)
+    }
+
+    @Test
+    fun legacyReplacement_infersMissingSidesWithoutDuplicatingLegs() = runBlocking {
+        val groupId = UUID.randomUUID()
+        val outgoingId = UUID.randomUUID()
+        val incomingId = UUID.randomUUID()
+        val createdAt = Instant.parse("2026-06-01T10:00:00Z")
+        repository.upsertTransactions(
+            listOf(
+                transaction(
+                    id = outgoingId,
+                    amount = BigDecimal("-100"),
+                    accountId = wallet.id,
+                    groupId = groupId,
+                    linkedTransactionId = incomingId,
+                    createdAt = createdAt
+                ),
+                transaction(
+                    id = incomingId,
+                    amount = BigDecimal("100"),
+                    accountId = bank.id,
+                    groupId = groupId,
+                    linkedTransactionId = outgoingId,
+                    createdAt = createdAt
+                )
+            )
+        )
+
+        repository.replaceTransferGroup(
+            TransferGroupReplacementDraft(
+                groupId = groupId,
+                date = Instant.parse("2026-06-02T10:00:00Z"),
+                note = "Legacy updated",
+                legs = listOf(
+                    TransferReplacementLeg(wallet.id, "HKD", BigDecimal("80"), TransferSide.Outgoing),
+                    TransferReplacementLeg(bank.id, "HKD", BigDecimal("80"), TransferSide.Incoming)
+                )
+            )
+        )
+
+        val updated = repository.getTransferGroup(groupId)
+        assertEquals(2, updated.size)
+        assertEquals(setOf(outgoingId, incomingId), updated.map { it.transaction.id }.toSet())
+        assertEquals(
+            setOf(TransferSide.Outgoing, TransferSide.Incoming),
+            updated.mapNotNull { it.transaction.transferSide }.toSet()
+        )
+    }
+
+    @Test
+    fun advanceInitialAndRepaymentGroups_areProtectedFromGenericReplacement() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Dinner",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val advanceCase = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = advanceCase.participants.single()
+        val initialGroupId = requireNotNull(participant.initialTransferGroupId)
+
+        assertEquals(TransferGroupSemantic.AdvanceInitial, repository.classifyTransferGroup(initialGroupId)?.semantic)
+        assertEquals(
+            TransactionEditDestination.Advance(caseId.toString()),
+            resolveTransactionEditDestination(
+                repository,
+                repository.getTransferGroup(initialGroupId).first()
+            )
+        )
+        assertProtected(initialGroupId)
+
+        repository.recordAdvanceRepayment(
+            advanceCase = advanceCase.advanceCase,
+            participant = participant,
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-03T10:00:00Z"),
+            note = "",
+            receiveAccount = wallet,
+            category = null,
+            tagIds = emptyList()
+        )
+        val repaymentGroupId = requireNotNull(
+            repository.getAdvanceCase(caseId)?.repayments?.single()?.linkedTransferGroupId
+        )
+        assertEquals(TransferGroupSemantic.AdvanceRepayment, repository.classifyTransferGroup(repaymentGroupId)?.semantic)
+        assertProtected(repaymentGroupId)
+    }
+
+    private fun assertProtected(groupId: UUID) {
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                repository.replaceTransferGroup(
+                    TransferGroupReplacementDraft(
+                        groupId = groupId,
+                        date = Instant.now(),
+                        note = "Must fail",
+                        legs = listOf(
+                            TransferReplacementLeg(wallet.id, "HKD", BigDecimal("10"), TransferSide.Outgoing),
+                            TransferReplacementLeg(friend.id, "HKD", BigDecimal("10"), TransferSide.Incoming)
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    private fun account(name: String, type: AccountType, order: Int): AccountEntity {
+        return AccountEntity(
+            id = UUID.randomUUID(),
+            name = name,
+            currency = "HKD",
+            type = type,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = order,
+            isArchived = false
+        )
+    }
+
+    private fun transaction(
+        id: UUID,
+        amount: BigDecimal,
+        accountId: UUID,
+        groupId: UUID,
+        linkedTransactionId: UUID,
+        createdAt: Instant
+    ): TransactionEntity {
+        return TransactionEntity(
+            id = id,
+            amount = amount,
+            currencyCode = "HKD",
+            date = createdAt,
+            note = "Legacy transfer",
+            photoPath = null,
+            type = TransactionType.Transfer,
+            linkedTransactionId = linkedTransactionId,
+            transferGroupId = groupId,
+            transferSide = null,
+            createdAt = createdAt,
+            updatedAt = createdAt,
+            accountId = accountId,
+            categoryId = null
+        )
+    }
+}


### PR DESCRIPTION
Closes #133

## Summary
- replace Android transfer groups atomically after complete validation
- route ordinary, debt, and advance-linked records to semantic editors on both platforms
- preserve debt direction, transfer group identity, transaction currency, and legacy nil-side compatibility
- block generic editing of advance initial/repayment groups

## Validation
- `./gradlew testDebugUnitTest assembleDebug`
- targeted legacy/ordinary/debt/advance transfer replacement tests
- Swift syntax parse for all changed Swift files
- `git diff --check`

Local iOS simulator build will be repeated after the Xcode 26.5 runtime download completes; GitHub iOS CI provides an independent compile/test pass.