### PR TITLE
Complete semantic advance editing

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -14,6 +14,12 @@ enum AdvanceServiceError: LocalizedError {
     case invalidAdjustedOwedAmount
     case adjustedOwedLowerThanRepaid
     case missingRepaymentParticipant
+    case missingRepaymentLink
+    case invalidRepaymentStructure
+    case invalidSettlementAccount
+    case invalidSettlementCategory
+    case specialRepaymentRequiresGroupRollback
+    case missingSelfExpense
     case cannotDeleteAdvanceCaseWithoutModelContext
     
     var errorDescription: String? {
@@ -42,6 +48,18 @@ enum AdvanceServiceError: LocalizedError {
             return "更正後欠款不可低於已還金額。"
         case .missingRepaymentParticipant:
             return "找不到還款對應的對象資料。"
+        case .missingRepaymentLink:
+            return "找不到還款對應的轉帳分錄。"
+        case .invalidRepaymentStructure:
+            return "還款轉帳分錄不完整，無法安全編輯。"
+        case .invalidSettlementAccount:
+            return "請選擇未歸檔的非借貸帳戶作為付款或入帳帳戶。"
+        case .invalidSettlementCategory:
+            return "所選分類與這筆還款方向不相符。"
+        case .specialRepaymentRequiresGroupRollback:
+            return "債務抵銷或跨幣種平賬必須整組撤銷，不能當作普通還款單筆沖銷。"
+        case .missingSelfExpense:
+            return "找不到代墊案件對應的自己份額支出。"
         case .cannotDeleteAdvanceCaseWithoutModelContext:
             return "刪除代墊失敗：缺少可用資料上下文。"
         }
@@ -49,6 +67,13 @@ enum AdvanceServiceError: LocalizedError {
 }
 
 enum AdvanceService {
+    enum RepaymentRecordKind: Equatable {
+        case ordinary
+        case mutualDebtOffset(UUID)
+        case manualDebtSettlement(UUID)
+        case invalidSpecial
+    }
+
     enum SettlementDirection {
         case iAdvancedOthers
         case othersAdvancedMe
@@ -57,6 +82,37 @@ enum AdvanceService {
     struct ParticipantInput {
         let debtAccount: Account
         let owedAmount: Decimal
+    }
+
+    struct RepaymentEditDraft {
+        let receiveAccount: Account
+        let amount: Decimal
+        let currencyCode: String
+        let normalizedAmount: Decimal
+        let date: Date
+        let note: String
+        let category: Category?
+        let tags: [Tag]
+    }
+
+    struct SelfExpenseEditDraft {
+        let account: Account
+        let amount: Decimal
+        let currencyCode: String
+        let normalizedAmount: Decimal
+        let date: Date
+        let note: String
+        let category: Category?
+        let tags: [Tag]
+    }
+
+    struct InitialEntryEditDraft {
+        let payerAccount: Account?
+        let owedAmount: Decimal
+        let date: Date
+        let note: String
+        let category: Category?
+        let tags: [Tag]
     }
     
     struct DeleteAdvanceResult {
@@ -205,6 +261,22 @@ enum AdvanceService {
         return UUID(uuidString: String(trimmed[startIndex..<closeIndex]))
     }
 
+    static func repaymentRecordKind(note: String) -> RepaymentRecordKind {
+        if let offsetID = mutualDebtOffsetID(from: note) {
+            return .mutualDebtOffset(offsetID)
+        }
+        if isMutualDebtOffset(note: note) {
+            return .invalidSpecial
+        }
+        if let settlementID = manualDebtSettlementID(from: note) {
+            return .manualDebtSettlement(settlementID)
+        }
+        if isManualDebtSettlement(note: note) {
+            return .invalidSpecial
+        }
+        return .ordinary
+    }
+
     @MainActor
     static func mutualDebtOffsetCandidate(
         debtAccount: Account,
@@ -290,21 +362,10 @@ enum AdvanceService {
         offsetGroupID: UUID,
         modelContext: ModelContext
     ) throws -> Int {
-        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
-            .filter { mutualDebtOffsetID(from: $0.note) == offsetGroupID }
-        guard !repayments.isEmpty else { return 0 }
-
-        for repayment in repayments {
-            if let participant = repayment.participant {
-                let updated = participant.repaidAmount - repayment.normalizedAmount
-                participant.repaidAmount = updated > 0 ? updated : 0
-                participant.updatedAt = Date()
-            }
-            repayment.advanceCase?.updatedAt = Date()
-            modelContext.delete(repayment)
-        }
-        try modelContext.save()
-        return repayments.count
+        try rollbackSpecialRepaymentGroup(
+            matching: { mutualDebtOffsetID(from: $0.note) == offsetGroupID },
+            modelContext: modelContext
+        )
     }
 
     @MainActor
@@ -356,6 +417,17 @@ enum AdvanceService {
             amount: amount,
             currencyCode: currencyCode,
             repaymentCount: repaymentCount
+        )
+    }
+
+    @MainActor
+    static func rollbackManualDebtSettlement(
+        settlementID: UUID,
+        modelContext: ModelContext
+    ) throws -> Int {
+        try rollbackSpecialRepaymentGroup(
+            matching: { manualDebtSettlementID(from: $0.note) == settlementID },
+            modelContext: modelContext
         )
     }
     
@@ -607,6 +679,15 @@ enum AdvanceService {
         guard amount > 0 else {
             throw AdvanceServiceError.invalidRepaymentAmount
         }
+        let currencyCode = currencyCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        guard !currencyCode.isEmpty else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        guard receiveAccount.type != .debt, !receiveAccount.isArchived else {
+            throw AdvanceServiceError.invalidSettlementAccount
+        }
         
         let normalizedAmount = normalizedAmountOverride ?? currencyService.convert(
             amount: abs(amount),
@@ -629,6 +710,7 @@ enum AdvanceService {
         let transferGroupID = UUID()
 
         let settlementDirection = direction ?? inferSettlementDirection(for: participant, modelContext: modelContext)
+        try validateSettlementCategory(category, direction: settlementDirection)
         let outTx: FinancialTransaction
         let inTx: FinancialTransaction
 
@@ -725,6 +807,338 @@ enum AdvanceService {
     }
 
     @MainActor
+    static func updateSelfExpense(
+        advanceCase: AdvanceCase,
+        transaction: FinancialTransaction,
+        draft: SelfExpenseEditDraft,
+        modelContext: ModelContext
+    ) throws {
+        guard advanceCase.selfExpenseTransactionID == transaction.id,
+              transaction.type == .expense,
+              transaction.transferGroupID == nil,
+              transaction.linkedTransactionID == nil
+        else {
+            throw AdvanceServiceError.missingSelfExpense
+        }
+        guard draft.amount > 0, draft.normalizedAmount > 0 else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        guard draft.account.type != .debt, !draft.account.isArchived else {
+            throw AdvanceServiceError.invalidSettlementAccount
+        }
+        if let category = draft.category, !category.kind.supports(.expense) {
+            throw AdvanceServiceError.invalidRepaymentStructure
+        }
+
+        let originalBudgetKey = BudgetHistoryService.affectedKey(for: transaction)
+        let currencyCode = draft.currencyCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        guard !currencyCode.isEmpty else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+
+        let now = Date()
+        transaction.amount = -abs(draft.amount)
+        transaction.currencyCode = currencyCode
+        transaction.date = draft.date
+        transaction.note = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        transaction.account = draft.account
+        transaction.category = draft.category
+        transaction.tags = draft.tags
+        transaction.updatedAt = now
+
+        advanceCase.myShareAmount = abs(draft.normalizedAmount)
+        advanceCase.expenseCategory = draft.category
+        advanceCase.updatedAt = now
+
+        let affectedKeys = [originalBudgetKey, BudgetHistoryService.affectedKey(for: transaction)]
+            .compactMap { $0 }
+        if affectedKeys.isEmpty {
+            try modelContext.save()
+        } else {
+            try BudgetHistoryService.shared.syncAffected(
+                keys: affectedKeys,
+                modelContext: modelContext,
+                currencyService: CurrencyService.shared
+            )
+        }
+    }
+
+    @MainActor
+    static func updateRepayment(
+        advanceCase: AdvanceCase,
+        repayment: AdvanceRepayment,
+        draft: RepaymentEditDraft,
+        modelContext: ModelContext
+    ) throws {
+        guard repayment.advanceCase?.id == advanceCase.id else {
+            throw AdvanceServiceError.participantNotInCase
+        }
+        guard let participant = repayment.participant else {
+            throw AdvanceServiceError.missingRepaymentParticipant
+        }
+        guard let debtAccount = participant.debtAccount else {
+            throw AdvanceServiceError.missingDebtAccount
+        }
+        guard draft.amount > 0, draft.normalizedAmount > 0 else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        guard draft.receiveAccount.type != .debt, !draft.receiveAccount.isArchived else {
+            throw AdvanceServiceError.invalidSettlementAccount
+        }
+        guard !isMutualDebtOffset(note: repayment.note),
+              !isManualDebtSettlement(note: repayment.note) else {
+            throw AdvanceServiceError.specialRepaymentRequiresGroupRollback
+        }
+        guard let groupID = repayment.linkedTransferGroupID else {
+            throw AdvanceServiceError.missingRepaymentLink
+        }
+
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        let transfers = try modelContext.fetch(descriptor).filter { $0.type == .transfer }
+        guard transfers.count == 2,
+              let outgoing = transfers.first(where: { $0.transferSide == .outgoing || $0.amount < 0 }),
+              let incoming = transfers.first(where: { $0.transferSide == .incoming || $0.amount > 0 }),
+              outgoing.id != incoming.id
+        else {
+            throw AdvanceServiceError.invalidRepaymentStructure
+        }
+
+        let allRepayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+        let otherNormalized = allRepayments
+            .filter { $0.id != repayment.id && $0.participant?.id == participant.id }
+            .reduce(Decimal.zero) { $0 + $1.normalizedAmount }
+        let updatedRepaid = otherNormalized + abs(draft.normalizedAmount)
+        if updatedRepaid - participant.owedAmount > roundingTolerance {
+            throw AdvanceServiceError.repaymentExceedsRemaining
+        }
+
+        let direction = inferSettlementDirection(for: participant, modelContext: modelContext)
+        try validateSettlementCategory(draft.category, direction: direction)
+        let amount = abs(draft.amount)
+        let currencyCode = draft.currencyCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        guard !currencyCode.isEmpty else {
+            throw AdvanceServiceError.invalidRepaymentAmount
+        }
+        let finalNote = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let memo = finalNote.isEmpty ? advanceCase.title : finalNote
+        let now = Date()
+
+        outgoing.type = .transfer
+        outgoing.amount = -amount
+        outgoing.currencyCode = currencyCode
+        outgoing.date = draft.date
+        outgoing.transferGroupID = groupID
+        outgoing.transferSide = .outgoing
+        outgoing.linkedTransactionID = incoming.id
+        outgoing.updatedAt = now
+
+        incoming.type = .transfer
+        incoming.amount = amount
+        incoming.currencyCode = currencyCode
+        incoming.date = draft.date
+        incoming.transferGroupID = groupID
+        incoming.transferSide = .incoming
+        incoming.linkedTransactionID = outgoing.id
+        incoming.updatedAt = now
+
+        switch direction {
+        case .iAdvancedOthers:
+            outgoing.account = debtAccount
+            outgoing.note = "\(memo) (還款至 \(draft.receiveAccount.name))"
+            outgoing.category = nil
+            outgoing.tags = []
+
+            incoming.account = draft.receiveAccount
+            incoming.note = "\(memo) (來自 \(participant.name))"
+            incoming.category = draft.category
+            incoming.tags = draft.tags
+        case .othersAdvancedMe:
+            outgoing.account = draft.receiveAccount
+            outgoing.note = "\(memo) (還款給 \(participant.name))"
+            outgoing.category = draft.category
+            outgoing.tags = draft.tags
+
+            incoming.account = debtAccount
+            incoming.note = "\(memo) (來自 \(draft.receiveAccount.name))"
+            incoming.category = nil
+            incoming.tags = []
+        }
+
+        repayment.amount = amount
+        repayment.currencyCode = currencyCode
+        repayment.normalizedAmount = abs(draft.normalizedAmount)
+        repayment.date = draft.date
+        repayment.note = finalNote
+        repayment.receivedAccount = draft.receiveAccount
+
+        participant.repaidAmount = min(updatedRepaid, participant.owedAmount)
+        participant.updatedAt = now
+        advanceCase.updatedAt = now
+        try modelContext.save()
+    }
+
+    @MainActor
+    static func updateInitialEntry(
+        advanceCase: AdvanceCase,
+        participant: AdvanceParticipant,
+        draft: InitialEntryEditDraft,
+        modelContext: ModelContext
+    ) throws {
+        guard participant.advanceCase?.id == advanceCase.id else {
+            throw AdvanceServiceError.participantNotInCase
+        }
+        guard draft.owedAmount > 0 else {
+            throw AdvanceServiceError.invalidAdjustedOwedAmount
+        }
+        guard draft.owedAmount + roundingTolerance >= participant.repaidAmount else {
+            throw AdvanceServiceError.adjustedOwedLowerThanRepaid
+        }
+
+        let direction = inferSettlementDirection(for: participant, modelContext: modelContext)
+        if direction == .iAdvancedOthers {
+            guard let payerAccount = draft.payerAccount,
+                  payerAccount.type != .debt,
+                  !payerAccount.isArchived
+            else {
+                throw AdvanceServiceError.invalidPayerAccount
+            }
+        } else if let category = draft.category, !category.kind.supports(.expense) {
+            throw AdvanceServiceError.invalidSettlementCategory
+        }
+
+        let entries = try advanceCase.participants.map { caseParticipant -> (AdvanceParticipant, [FinancialTransaction]) in
+            guard let groupID = caseParticipant.initialTransferGroupID else {
+                throw AdvanceServiceError.missingRepaymentLink
+            }
+            let descriptor = FetchDescriptor<FinancialTransaction>(
+                predicate: #Predicate { $0.transferGroupID == groupID }
+            )
+            let transactions = try modelContext.fetch(descriptor)
+            guard !transactions.isEmpty,
+                  inferSettlementDirection(for: caseParticipant, modelContext: modelContext) == direction
+            else {
+                throw AdvanceServiceError.invalidRepaymentStructure
+            }
+            switch direction {
+            case .iAdvancedOthers:
+                guard transactions.count == 2,
+                      let outgoing = transactions.first(where: {
+                          $0.transferSide == .outgoing || $0.amount < 0
+                      }),
+                      let incoming = transactions.first(where: {
+                          $0.transferSide == .incoming || $0.amount > 0
+                      }),
+                      outgoing.id != incoming.id
+                else {
+                    throw AdvanceServiceError.invalidRepaymentStructure
+                }
+            case .othersAdvancedMe:
+                guard transactions.count == 1, caseParticipant.debtAccount != nil else {
+                    throw AdvanceServiceError.invalidRepaymentStructure
+                }
+            }
+            return (caseParticipant, transactions)
+        }
+
+        let originalBudgetKeys = entries
+            .flatMap(\.1)
+            .compactMap(BudgetHistoryService.affectedKey(for:))
+        let memo = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseMemo = memo.isEmpty ? advanceCase.title : memo
+        let now = Date()
+
+        for (caseParticipant, transactions) in entries {
+            let amount = caseParticipant.id == participant.id
+                ? abs(draft.owedAmount)
+                : abs(caseParticipant.owedAmount)
+            switch direction {
+            case .iAdvancedOthers:
+                guard let payerAccount = draft.payerAccount,
+                      let debtAccount = caseParticipant.debtAccount,
+                      let outgoing = transactions.first(where: {
+                          $0.transferSide == .outgoing || $0.amount < 0
+                      }),
+                      let incoming = transactions.first(where: {
+                          $0.transferSide == .incoming || $0.amount > 0
+                      })
+                else {
+                    throw AdvanceServiceError.invalidRepaymentStructure
+                }
+                outgoing.type = .transfer
+                outgoing.amount = -amount
+                outgoing.currencyCode = advanceCase.currencyCode
+                outgoing.date = draft.date
+                outgoing.note = "\(baseMemo) (代墊給 \(caseParticipant.name))"
+                outgoing.account = payerAccount
+                outgoing.category = nil
+                outgoing.tags = []
+                outgoing.transferSide = .outgoing
+                outgoing.linkedTransactionID = incoming.id
+                outgoing.updatedAt = now
+
+                incoming.type = .transfer
+                incoming.amount = amount
+                incoming.currencyCode = advanceCase.currencyCode
+                incoming.date = draft.date
+                incoming.note = "\(baseMemo) (來自 \(payerAccount.name))"
+                incoming.account = debtAccount
+                incoming.category = nil
+                incoming.tags = []
+                incoming.transferSide = .incoming
+                incoming.linkedTransactionID = outgoing.id
+                incoming.updatedAt = now
+            case .othersAdvancedMe:
+                guard let expense = transactions.first,
+                      let debtAccount = caseParticipant.debtAccount
+                else {
+                    throw AdvanceServiceError.invalidRepaymentStructure
+                }
+                expense.type = .expense
+                expense.amount = -amount
+                expense.currencyCode = advanceCase.currencyCode
+                expense.date = draft.date
+                expense.note = "\(baseMemo) (他人代墊我：\(caseParticipant.name))"
+                expense.account = debtAccount
+                expense.category = draft.category
+                expense.tags = draft.tags
+                expense.linkedTransactionID = nil
+                expense.transferSide = .outgoing
+                expense.updatedAt = now
+            }
+        }
+
+        participant.owedAmount = abs(draft.owedAmount)
+        participant.repaidAmount = min(participant.repaidAmount, participant.owedAmount)
+        participant.updatedAt = now
+        advanceCase.payerAccount = direction == .iAdvancedOthers ? draft.payerAccount : nil
+        if direction == .othersAdvancedMe {
+            advanceCase.expenseCategory = draft.category
+        }
+        advanceCase.date = draft.date
+        advanceCase.note = memo
+        advanceCase.updatedAt = now
+
+        let affectedKeys = originalBudgetKeys + entries
+            .flatMap(\.1)
+            .compactMap(BudgetHistoryService.affectedKey(for:))
+        if affectedKeys.isEmpty {
+            try modelContext.save()
+        } else {
+            try BudgetHistoryService.shared.syncAffected(
+                keys: affectedKeys,
+                modelContext: modelContext,
+                currencyService: CurrencyService.shared
+            )
+        }
+    }
+
+    @MainActor
     static func inferSettlementDirection(
         for participant: AdvanceParticipant,
         modelContext: ModelContext
@@ -746,7 +1160,8 @@ enum AdvanceService {
             return .othersAdvancedMe
         }
 
-        if outgoing.note.replacingOccurrences(of: " ", with: "").contains("(代墊給我") {
+        let compactedNote = outgoing.note.replacingOccurrences(of: " ", with: "")
+        if compactedNote.contains("(代墊給我") || compactedNote.contains("(他人代墊我") {
             return .othersAdvancedMe
         }
 
@@ -770,14 +1185,83 @@ enum AdvanceService {
             throw AdvanceServiceError.adjustedOwedLowerThanRepaid
         }
         
-        participant.owedAmount = newOwedAmount
-        if participant.repaidAmount > newOwedAmount {
-            participant.repaidAmount = newOwedAmount
+        guard let groupID = participant.initialTransferGroupID else {
+            throw AdvanceServiceError.missingRepaymentLink
         }
-        participant.updatedAt = Date()
-        advanceCase.updatedAt = Date()
-        
-        try modelContext.save()
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        let linkedTransactions = try modelContext.fetch(descriptor)
+        guard !linkedTransactions.isEmpty else {
+            throw AdvanceServiceError.missingRepaymentLink
+        }
+        let originalBudgetKeys = linkedTransactions.compactMap(
+            BudgetHistoryService.affectedKey(for:)
+        )
+
+        let direction = inferSettlementDirection(for: participant, modelContext: modelContext)
+        let amount = abs(newOwedAmount)
+        let now = Date()
+        switch direction {
+        case .iAdvancedOthers:
+            guard linkedTransactions.count == 2 else {
+                throw AdvanceServiceError.invalidRepaymentStructure
+            }
+            for transaction in linkedTransactions {
+                let side = transaction.transferSide
+                    ?? (transaction.amount < 0 ? .outgoing : .incoming)
+                transaction.amount = side == .outgoing ? -amount : amount
+                transaction.currencyCode = advanceCase.currencyCode
+                transaction.date = advanceCase.date
+                transaction.transferSide = side
+                transaction.updatedAt = now
+            }
+        case .othersAdvancedMe:
+            guard linkedTransactions.count == 1,
+                  let expense = linkedTransactions.first,
+                  let debtAccount = participant.debtAccount
+            else {
+                throw AdvanceServiceError.invalidRepaymentStructure
+            }
+            expense.type = .expense
+            expense.amount = -amount
+            expense.currencyCode = advanceCase.currencyCode
+            expense.date = advanceCase.date
+            expense.linkedTransactionID = nil
+            expense.transferGroupID = groupID
+            expense.transferSide = .outgoing
+            expense.account = debtAccount
+            expense.category = advanceCase.expenseCategory
+            expense.updatedAt = now
+        }
+
+        participant.owedAmount = amount
+        participant.repaidAmount = min(participant.repaidAmount, amount)
+        participant.updatedAt = now
+        advanceCase.updatedAt = now
+        let affectedKeys = originalBudgetKeys + linkedTransactions.compactMap(
+            BudgetHistoryService.affectedKey(for:)
+        )
+        if affectedKeys.isEmpty {
+            try modelContext.save()
+        } else {
+            try BudgetHistoryService.shared.syncAffected(
+                keys: affectedKeys,
+                modelContext: modelContext,
+                currencyService: CurrencyService.shared
+            )
+        }
+    }
+
+    private static func validateSettlementCategory(
+        _ category: Category?,
+        direction: SettlementDirection
+    ) throws {
+        guard let category else { return }
+        let expectedType: TransactionType = direction == .iAdvancedOthers ? .income : .expense
+        guard category.kind.supports(expectedType) else {
+            throw AdvanceServiceError.invalidSettlementCategory
+        }
     }
 
     private struct OffsetParticipantEntry {
@@ -892,6 +1376,10 @@ enum AdvanceService {
         guard let participant = repayment.participant else {
             throw AdvanceServiceError.missingRepaymentParticipant
         }
+        guard !isMutualDebtOffset(note: repayment.note),
+              !isManualDebtSettlement(note: repayment.note) else {
+            throw AdvanceServiceError.specialRepaymentRequiresGroupRollback
+        }
         
         if let groupID = repayment.linkedTransferGroupID {
             let descriptor = FetchDescriptor<FinancialTransaction>(
@@ -912,6 +1400,29 @@ enum AdvanceService {
         if autosave {
             try modelContext.save()
         }
+    }
+
+    @MainActor
+    private static func rollbackSpecialRepaymentGroup(
+        matching predicate: (AdvanceRepayment) -> Bool,
+        modelContext: ModelContext
+    ) throws -> Int {
+        let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
+            .filter(predicate)
+        guard !repayments.isEmpty else { return 0 }
+
+        let now = Date()
+        for repayment in repayments {
+            if let participant = repayment.participant {
+                let updated = participant.repaidAmount - repayment.normalizedAmount
+                participant.repaidAmount = updated > 0 ? updated : 0
+                participant.updatedAt = now
+            }
+            repayment.advanceCase?.updatedAt = now
+            modelContext.delete(repayment)
+        }
+        try modelContext.save()
+        return repayments.count
     }
     
     @MainActor
@@ -987,85 +1498,6 @@ enum AdvanceService {
         )
     }
 
-    @MainActor
-    static func syncLinkedTransferGroup(
-        groupID: UUID,
-        modelContext: ModelContext
-    ) throws {
-        let txDescriptor = FetchDescriptor<FinancialTransaction>(
-            predicate: #Predicate { $0.transferGroupID == groupID }
-        )
-        let transfers = try modelContext.fetch(txDescriptor).filter { $0.type == .transfer }
-        guard !transfers.isEmpty else { return }
-
-        let outgoing = transfers.first(where: { $0.transferSide == .outgoing || $0.amount < 0 })
-        let incoming = transfers.first(where: { $0.transferSide == .incoming || $0.amount > 0 })
-        let now = Date()
-
-        let participantDescriptor = FetchDescriptor<AdvanceParticipant>(
-            predicate: #Predicate { $0.initialTransferGroupID == groupID }
-        )
-        if let participant = try modelContext.fetch(participantDescriptor).first {
-            if incoming == nil, outgoing?.type == .expense, let debtAccount = outgoing?.account {
-                participant.debtAccount = debtAccount
-                participant.name = debtAccount.name
-            } else if let incoming, let debtAccount = incoming.account {
-                participant.debtAccount = debtAccount
-                participant.name = debtAccount.name
-            }
-
-            if let advanceCase = participant.advanceCase {
-                if let outgoing, incoming != nil {
-                    advanceCase.payerAccount = outgoing.account
-                }
-                if let amountSource = incoming ?? outgoing {
-                    let normalized = CurrencyService.shared.convert(
-                        amount: abs(amountSource.amount),
-                        from: amountSource.currencyCode,
-                        to: advanceCase.currencyCode
-                    )
-                    participant.owedAmount = normalized >= participant.repaidAmount
-                        ? normalized
-                        : participant.repaidAmount
-                }
-                advanceCase.updatedAt = now
-            }
-            participant.updatedAt = now
-        }
-
-        let repaymentDescriptor = FetchDescriptor<AdvanceRepayment>(
-            predicate: #Predicate { $0.linkedTransferGroupID == groupID }
-        )
-        if let repayment = try modelContext.fetch(repaymentDescriptor).first {
-            if let incoming {
-                repayment.amount = abs(incoming.amount)
-                repayment.currencyCode = incoming.currencyCode
-                repayment.date = incoming.date
-                repayment.note = extractTransferMemo(incoming.note)
-                repayment.receivedAccount = incoming.account
-
-                if let advanceCase = repayment.advanceCase {
-                    repayment.normalizedAmount = CurrencyService.shared.convert(
-                        amount: abs(incoming.amount),
-                        from: incoming.currencyCode,
-                        to: advanceCase.currencyCode
-                    )
-                    advanceCase.updatedAt = now
-                }
-            }
-
-            if let participant = repayment.participant, let advanceCase = repayment.advanceCase {
-                let normalizedTotal = advanceCase.repayments
-                    .filter { $0.participant?.id == participant.id }
-                    .reduce(Decimal.zero) { $0 + $1.normalizedAmount }
-                participant.repaidAmount = normalizedTotal > participant.owedAmount
-                    ? participant.owedAmount
-                    : normalizedTotal
-                participant.updatedAt = now
-            }
-        }
-    }
-    
     @MainActor
     static func repairLegacyLinks(modelContext: ModelContext) throws -> LegacyLinkRepairResult {
         let advanceCases = try modelContext.fetch(FetchDescriptor<AdvanceCase>())

--- a/AI 記帳/Services/TransferEditRoutingService.swift
+++ b/AI 記帳/Services/TransferEditRoutingService.swift
@@ -4,6 +4,7 @@ enum TransferEditSemantic: Equatable {
     case ordinary
     case debt
     case debtForgiveness
+    case advanceSelfExpense
     case advanceInitial
     case advanceRepayment
 }
@@ -12,9 +13,13 @@ enum TransferEditRoutingService {
     static func classify(
         transaction: FinancialTransaction,
         groupTransactions: [FinancialTransaction],
+        advanceSelfExpenseTransactionIDs: Set<UUID> = [],
         advanceInitialGroupIDs: Set<UUID>,
         advanceRepaymentGroupIDs: Set<UUID>
     ) -> TransferEditSemantic {
+        if advanceSelfExpenseTransactionIDs.contains(transaction.id) {
+            return .advanceSelfExpense
+        }
         if let groupID = transaction.transferGroupID {
             if advanceInitialGroupIDs.contains(groupID) {
                 return .advanceInitial
@@ -30,7 +35,9 @@ enum TransferEditRoutingService {
         if compactedNote.contains("(還款至") || compactedNote.contains("(還款給") {
             return .advanceRepayment
         }
-        if compactedNote.contains("(代墊給") || compactedNote.contains("(代墊給我") {
+        if compactedNote.contains("(代墊給") ||
+            compactedNote.contains("(代墊給我") ||
+            compactedNote.contains("(他人代墊我") {
             return .advanceInitial
         }
         if groupTransactions.contains(where: { $0.account?.type == .debt }) {

--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -125,25 +125,26 @@ struct AccountDetailView: View {
     
     @ViewBuilder
     private func transactionEditor(for tx: FinancialTransaction, renderState: AccountDetailRenderState) -> some View {
-        if tx.type == .transfer {
-            let group = TransferEditRoutingService.groupTransactions(for: tx, in: renderState.allTransactions)
-            switch TransferEditRoutingService.classify(
-                transaction: tx,
-                groupTransactions: group,
-                advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
-                advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
-            ) {
-            case .advanceInitial, .advanceRepayment:
-                EditAdvanceTransferView(originalTransaction: tx)
-            case .debtForgiveness:
-                AddDebtView(existingForgivenessTransaction: tx)
-            case .debt:
-                AddDebtView(existingDebtTransaction: tx)
-            case .ordinary:
+        let group = TransferEditRoutingService.groupTransactions(for: tx, in: renderState.allTransactions)
+        switch TransferEditRoutingService.classify(
+            transaction: tx,
+            groupTransactions: group,
+            advanceSelfExpenseTransactionIDs: Set(advanceCases.compactMap(\.selfExpenseTransactionID)),
+            advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
+            advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
+        ) {
+        case .advanceSelfExpense, .advanceInitial, .advanceRepayment:
+            EditAdvanceTransferView(originalTransaction: tx)
+        case .debtForgiveness:
+            AddDebtView(existingForgivenessTransaction: tx)
+        case .debt:
+            AddDebtView(existingDebtTransaction: tx)
+        case .ordinary:
+            if tx.type == .transfer {
                 EditTransferView(originalTransaction: tx)
+            } else {
+                EditTransactionView(transaction: tx)
             }
-        } else {
-            EditTransactionView(transaction: tx)
         }
     }
 

--- a/AI 記帳/Views/Accounts/EditAccountView.swift
+++ b/AI 記帳/Views/Accounts/EditAccountView.swift
@@ -15,6 +15,14 @@ struct EditAccountView: View {
     @FocusState private var isAmountFocused: Bool
     
     let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+
+    private var accountCurrencies: [String] {
+        currencies.contains(account.currency) ? currencies : [account.currency] + currencies
+    }
+
+    private var adjustmentCurrencies: [String] {
+        currencies.contains(adjustmentCurrency) ? currencies : [adjustmentCurrency] + currencies
+    }
     
     var currentHoldings: [(String, Decimal)] {
         let accountTxs = allTransactions.filter { $0.account?.id == account.id }
@@ -40,7 +48,7 @@ struct EditAccountView: View {
                     TextField("帳戶名稱", text: $account.name)
                     
                     Picker("主幣種", selection: $account.currency) {
-                        ForEach(currencies, id: \.self) { code in Text(code).tag(code) }
+                        ForEach(accountCurrencies, id: \.self) { code in Text(code).tag(code) }
                     }
                     .disabled(true)
                     
@@ -83,7 +91,7 @@ struct EditAccountView: View {
                 ) {
                     HStack {
                         Picker("", selection: $adjustmentCurrency) {
-                            ForEach(currencies, id: \.self) { code in Text(code).tag(code) }
+                            ForEach(adjustmentCurrencies, id: \.self) { code in Text(code).tag(code) }
                         }
                         .labelsHidden().frame(width: 80)
                         

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -228,6 +228,7 @@ struct AdvanceCaseDetailView: View {
     let advanceCase: AdvanceCase
     @State private var selectedParticipantForRepayment: AdvanceParticipant?
     @State private var selectedParticipantForEdit: AdvanceParticipant?
+    @State private var selectedRepaymentForEdit: AdvanceRepayment?
     @State private var repaymentToRollback: AdvanceRepayment?
     @State private var selectedDeleteMode: DeleteMode?
     @State private var showingDeleteModeDialog = false
@@ -306,12 +307,28 @@ struct AdvanceCaseDetailView: View {
                 Section("還款紀錄") {
                     ForEach(sortedRepayments) { repayment in
                         repaymentRow(repayment)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                if AdvanceService.repaymentRecordKind(note: repayment.note) == .ordinary,
+                                   repayment.linkedTransferGroupID != nil {
+                                    selectedRepaymentForEdit = repayment
+                                }
+                            }
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                if AdvanceService.repaymentRecordKind(note: repayment.note) == .ordinary,
+                                   repayment.linkedTransferGroupID != nil {
+                                    Button {
+                                        selectedRepaymentForEdit = repayment
+                                    } label: {
+                                        Label("編輯", systemImage: "pencil")
+                                    }
+                                    .tint(.blue)
+                                }
                                 Button(role: .destructive) {
                                     repaymentToRollback = repayment
                                     showingRollbackAlert = true
                                 } label: {
-                                    Label("沖銷", systemImage: "arrow.uturn.backward.circle")
+                                    Label("撤銷", systemImage: "arrow.uturn.backward.circle")
                                 }
                             }
                     }
@@ -324,6 +341,9 @@ struct AdvanceCaseDetailView: View {
         }
         .sheet(item: $selectedParticipantForEdit) { participant in
             EditAdvanceParticipantView(advanceCase: advanceCase, participant: participant)
+        }
+        .sheet(item: $selectedRepaymentForEdit) { repayment in
+            EditAdvanceTransferView(repayment: repayment)
         }
         .confirmationDialog("刪除代墊單", isPresented: $showingDeleteModeDialog, titleVisibility: .visible) {
             Button("只刪追蹤記錄", role: .destructive) {
@@ -352,13 +372,13 @@ struct AdvanceCaseDetailView: View {
                 Text("將只刪除代墊追蹤資料，原本的實際交易紀錄會保留。此操作無法復原。")
             }
         }
-        .alert("確認沖銷還款？", isPresented: $showingRollbackAlert, presenting: repaymentToRollback) { repayment in
+        .alert("確認撤銷紀錄？", isPresented: $showingRollbackAlert, presenting: repaymentToRollback) { repayment in
             Button("取消", role: .cancel) {}
-            Button("沖銷", role: .destructive) {
+            Button("撤銷", role: .destructive) {
                 rollbackRepayment(repayment)
             }
         } message: { repayment in
-            Text("將刪除 \(repayment.amount.formatted(.currency(code: repayment.currencyCode))) 的還款紀錄，並同步刪除對應借貸轉帳。")
+            Text(rollbackMessage(for: repayment))
         }
         .alert("操作失敗", isPresented: $showingError) {
             Button("好", role: .cancel) {}
@@ -446,21 +466,32 @@ struct AdvanceCaseDetailView: View {
     }
     
     private func repaymentRow(_ repayment: AdvanceRepayment) -> some View {
+        let recordKind = AdvanceService.repaymentRecordKind(note: repayment.note)
         VStack(alignment: .leading, spacing: 6) {
             HStack {
-                Text(repayment.participant?.name ?? "未指定對象")
-                    .font(.body)
-                    .fontWeight(.semibold)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(repayment.participant?.name ?? "未指定對象")
+                        .font(.body)
+                        .fontWeight(.semibold)
+                    if recordKind != .ordinary {
+                        Text(repaymentKindLabel(recordKind))
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.orange)
+                    }
+                }
                 Spacer()
                 Text(repayment.amount.formatted(.currency(code: repayment.currencyCode)))
                     .font(.subheadline)
-                    .foregroundStyle(.green)
+                    .foregroundStyle(recordKind == .ordinary ? .green : .orange)
             }
             
             HStack(spacing: 6) {
                 Text(repayment.date.formatted(date: .abbreviated, time: .shortened))
-                Text("•")
-                Text("入帳：\(repayment.receivedAccount?.name ?? "未指定")")
+                if recordKind == .ordinary {
+                    Text("•")
+                    Text("入帳：\(repayment.receivedAccount?.name ?? "未指定")")
+                }
             }
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -482,14 +513,55 @@ struct AdvanceCaseDetailView: View {
     
     private func rollbackRepayment(_ repayment: AdvanceRepayment) {
         do {
-            try AdvanceService.rollbackRepayment(
-                advanceCase: advanceCase,
-                repayment: repayment,
-                modelContext: modelContext
-            )
+            switch AdvanceService.repaymentRecordKind(note: repayment.note) {
+            case .ordinary:
+                try AdvanceService.rollbackRepayment(
+                    advanceCase: advanceCase,
+                    repayment: repayment,
+                    modelContext: modelContext
+                )
+            case .mutualDebtOffset(let offsetID):
+                _ = try AdvanceService.rollbackMutualDebtOffset(
+                    offsetGroupID: offsetID,
+                    modelContext: modelContext
+                )
+            case .manualDebtSettlement(let settlementID):
+                _ = try AdvanceService.rollbackManualDebtSettlement(
+                    settlementID: settlementID,
+                    modelContext: modelContext
+                )
+            case .invalidSpecial:
+                throw AdvanceServiceError.specialRepaymentRequiresGroupRollback
+            }
         } catch {
             errorMessage = error.localizedDescription
             showingError = true
+        }
+    }
+
+    private func repaymentKindLabel(_ kind: AdvanceService.RepaymentRecordKind) -> String {
+        switch kind {
+        case .ordinary:
+            return "還款"
+        case .mutualDebtOffset:
+            return "債務抵銷"
+        case .manualDebtSettlement:
+            return "跨幣種平賬"
+        case .invalidSpecial:
+            return "特殊結算（資料異常）"
+        }
+    }
+
+    private func rollbackMessage(for repayment: AdvanceRepayment) -> String {
+        switch AdvanceService.repaymentRecordKind(note: repayment.note) {
+        case .ordinary:
+            return "將刪除 \(repayment.amount.formatted(.currency(code: repayment.currencyCode))) 的還款紀錄，並同步刪除對應借貸轉帳。"
+        case .mutualDebtOffset:
+            return "將整組撤銷這次債務抵銷，所有受影響案件的未清金額都會回復。"
+        case .manualDebtSettlement:
+            return "將整組撤銷這次跨幣種平賬，所有受影響案件的未清金額都會回復。"
+        case .invalidSpecial:
+            return "這筆特殊結算的識別資料不完整，請先使用資料健康檢查修復。"
         }
     }
     
@@ -832,6 +904,7 @@ struct AddAdvanceCaseView: View {
             )
             dismiss()
         } catch {
+            modelContext.rollback()
             showError(error.localizedDescription)
         }
     }

--- a/AI 記帳/Views/Budgets/BudgetsView.swift
+++ b/AI 記帳/Views/Budgets/BudgetsView.swift
@@ -376,6 +376,10 @@ struct BudgetEditorView: View {
     @State private var errorMessage = ""
     
     private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+
+    private var availableCurrencies: [String] {
+        currencies.contains(currencyCode) ? currencies : [currencyCode] + currencies
+    }
     
     var body: some View {
         NavigationStack {
@@ -395,7 +399,7 @@ struct BudgetEditorView: View {
                 Section("預算") {
                     HStack {
                         Picker("幣種", selection: $currencyCode) {
-                            ForEach(currencies, id: \.self) { code in
+                            ForEach(availableCurrencies, id: \.self) { code in
                                 Text(code).tag(code)
                             }
                         }

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -564,6 +564,7 @@ private func reportCurrencySummary(_ totals: [ReportCurrencyTotal]) -> String {
 private struct ReportTransactionListView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \FinancialTransaction.date, order: .reverse) private var allTransactions: [FinancialTransaction]
+    @Query private var advanceCases: [AdvanceCase]
     @Query private var advanceParticipants: [AdvanceParticipant]
     @Query private var advanceRepayments: [AdvanceRepayment]
 
@@ -642,25 +643,26 @@ private struct ReportTransactionListView: View {
 
     @ViewBuilder
     private func transactionEditor(for tx: FinancialTransaction, renderState: ReportTransactionListRenderState) -> some View {
-        if tx.type == .transfer {
-            let group = TransferEditRoutingService.groupTransactions(for: tx, in: renderState.allTransactions)
-            switch TransferEditRoutingService.classify(
-                transaction: tx,
-                groupTransactions: group,
-                advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
-                advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
-            ) {
-            case .advanceInitial, .advanceRepayment:
-                EditAdvanceTransferView(originalTransaction: tx)
-            case .debtForgiveness:
-                AddDebtView(existingForgivenessTransaction: tx)
-            case .debt:
-                AddDebtView(existingDebtTransaction: tx)
-            case .ordinary:
+        let group = TransferEditRoutingService.groupTransactions(for: tx, in: renderState.allTransactions)
+        switch TransferEditRoutingService.classify(
+            transaction: tx,
+            groupTransactions: group,
+            advanceSelfExpenseTransactionIDs: Set(advanceCases.compactMap(\.selfExpenseTransactionID)),
+            advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
+            advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
+        ) {
+        case .advanceSelfExpense, .advanceInitial, .advanceRepayment:
+            EditAdvanceTransferView(originalTransaction: tx)
+        case .debtForgiveness:
+            AddDebtView(existingForgivenessTransaction: tx)
+        case .debt:
+            AddDebtView(existingDebtTransaction: tx)
+        case .ordinary:
+            if tx.type == .transfer {
                 EditTransferView(originalTransaction: tx)
+            } else {
+                EditTransactionView(transaction: tx)
             }
-        } else {
-            EditTransactionView(transaction: tx)
         }
     }
 

--- a/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
+++ b/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
@@ -188,6 +188,10 @@ struct AddRecurringRuleView: View {
 
     private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
 
+    private var availableCurrencies: [String] {
+        currencies.contains(currencyCode) ? currencies : [currencyCode] + currencies
+    }
+
     init(rule: RecurringRule? = nil) {
         self.rule = rule
     }
@@ -222,7 +226,7 @@ struct AddRecurringRuleView: View {
                     TextField("金額", text: $amountString)
                         .keyboardType(.decimalPad)
                     Picker("幣種", selection: $currencyCode) {
-                        ForEach(currencies, id: \.self) { code in
+                        ForEach(availableCurrencies, id: \.self) { code in
                             Text(code).tag(code)
                         }
                     }

--- a/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
@@ -5,77 +5,121 @@ struct EditAdvanceTransferView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
 
-    let originalTransaction: FinancialTransaction
+    private let originalTransaction: FinancialTransaction?
+    private let directRepayment: AdvanceRepayment?
 
     @Query(sort: \Account.sortOrder) private var allAccounts: [Account]
     @Query(sort: \Category.name) private var categories: [Category]
     @Query(sort: \Tag.name) private var tags: [Tag]
+    @Query private var advanceCases: [AdvanceCase]
     @Query private var participants: [AdvanceParticipant]
     @Query private var repayments: [AdvanceRepayment]
 
-    @State private var outgoingTransaction: FinancialTransaction?
-    @State private var incomingTransaction: FinancialTransaction?
-    @State private var transferGroupID: UUID?
-
-    @State private var fromAccount: Account?
-    @State private var toAccount: Account?
-    @State private var currencyOut: String = "HKD"
-    @State private var currencyIn: String = "HKD"
-    @State private var amountOutString: String = ""
-    @State private var amountInString: String = ""
-    @State private var date: Date = Date()
-    @State private var note: String = ""
-
+    @State private var linkKind: LinkKind = .unknown
+    @State private var settlementDirection: AdvanceService.SettlementDirection = .iAdvancedOthers
+    @State private var selectedAccount: Account?
+    @State private var amountString = ""
+    @State private var currencyCode = "HKD"
+    @State private var normalizedAmountString = ""
+    @State private var date = Date()
+    @State private var note = ""
     @State private var selectedCategory: Category?
     @State private var selectedTags: Set<Tag> = []
-
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var showingValidationAlert = false
     @State private var validationMessage = ""
     @State private var showingAddTag = false
     @State private var newTagName = ""
+    @State private var didLoadDraft = false
 
     @FocusState private var focusedField: Field?
+    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+
+    private var availableCurrencies: [String] {
+        currencies.contains(currencyCode) ? currencies : [currencyCode] + currencies
+    }
+
+    init(originalTransaction: FinancialTransaction) {
+        self.originalTransaction = originalTransaction
+        self.directRepayment = nil
+    }
+
+    init(repayment: AdvanceRepayment) {
+        self.originalTransaction = nil
+        self.directRepayment = repayment
+    }
 
     private enum Field {
-        case amountOut
-        case amountIn
+        case amount
+        case normalizedAmount
         case note
     }
 
-    private enum AdvanceLinkKind {
+    private enum LinkKind {
+        case selfExpense(AdvanceCase, FinancialTransaction)
         case initial(AdvanceParticipant)
         case repayment(AdvanceRepayment)
         case unknown
     }
 
-    @State private var linkKind: AdvanceLinkKind = .unknown
-
-    private let currencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
-
-    private var activeAccounts: [Account] {
-        allAccounts.filter { !$0.isArchived }
+    private var activeOwnAccounts: [Account] {
+        allAccounts.filter { !$0.isArchived && $0.type != .debt }
     }
 
-    private var incomeCategories: [Category] {
-        categories.filter { $0.kind.supports(.income) }
+    private var directionalCategories: [Category] {
+        switch linkKind {
+        case .selfExpense:
+            return categories.filter { $0.kind.supports(.expense) }
+        case .initial:
+            return settlementDirection == .othersAdvancedMe
+                ? categories.filter { $0.kind.supports(.expense) }
+                : []
+        case .repayment:
+            return settlementDirection == .iAdvancedOthers
+                ? categories.filter { $0.kind.supports(.income) }
+                : categories.filter { $0.kind.supports(.expense) }
+        case .unknown:
+            return []
+        }
+    }
+
+    private var requiresOwnAccount: Bool {
+        switch linkKind {
+        case .selfExpense, .repayment:
+            return true
+        case .initial:
+            return settlementDirection == .iAdvancedOthers
+        case .unknown:
+            return false
+        }
     }
 
     private var canSubmit: Bool {
-        !isLoading
-            && fromAccount != nil
-            && toAccount != nil
-            && positiveDecimal(from: amountOutString) != nil
-            && positiveDecimal(from: amountInString) != nil
+        guard !isLoading, errorMessage == nil, positiveDecimal(from: amountString) != nil else {
+            return false
+        }
+        if requiresOwnAccount && selectedAccount == nil {
+            return false
+        }
+        switch linkKind {
+        case .selfExpense, .repayment:
+            return positiveDecimal(from: normalizedAmountString) != nil
+        case .initial, .unknown:
+            return true
+        }
     }
 
     private var titleText: String {
         switch linkKind {
+        case .selfExpense:
+            return "編輯自己的份額"
+        case .initial:
+            return "編輯代墊"
         case .repayment:
             return "編輯代墊還款"
-        case .initial, .unknown:
-            return "編輯代墊"
+        case .unknown:
+            return "編輯代墊紀錄"
         }
     }
 
@@ -83,112 +127,14 @@ struct EditAdvanceTransferView: View {
         NavigationStack {
             Form {
                 if isLoading {
-                    ProgressView("載入代墊交易中...")
+                    ProgressView("載入代墊紀錄中...")
                 } else if let errorMessage {
                     Text("無法編輯：\(errorMessage)")
                         .foregroundStyle(.red)
                 } else {
-                    Section("轉出方") {
-                        Picker("從帳戶", selection: $fromAccount) {
-                            Text("選擇帳戶").tag(nil as Account?)
-                            ForEach(activeAccounts) { account in
-                                Text(account.name).tag(account as Account?)
-                            }
-                        }
-                        .onChange(of: fromAccount) { _, newValue in
-                            guard let newValue else { return }
-                            currencyOut = newValue.currency
-                        }
-
-                        HStack {
-                            Picker("幣種", selection: $currencyOut) {
-                                ForEach(currencies, id: \.self) { code in
-                                    Text(code).tag(code)
-                                }
-                            }
-                            .frame(width: 110)
-
-                            TextField("轉出金額", text: Binding(
-                                get: { amountOutString },
-                                set: { amountOutString = sanitizePositiveDecimalInput($0) }
-                            ))
-                            .keyboardType(.decimalPad)
-                            .focused($focusedField, equals: .amountOut)
-                        }
-                    }
-
-                    Section("轉入方") {
-                        Picker("到帳戶", selection: $toAccount) {
-                            Text("選擇帳戶").tag(nil as Account?)
-                            ForEach(activeAccounts) { account in
-                                Text(account.name).tag(account as Account?)
-                            }
-                        }
-                        .onChange(of: toAccount) { _, newValue in
-                            guard let newValue else { return }
-                            currencyIn = newValue.currency
-                        }
-
-                        HStack {
-                            Picker("幣種", selection: $currencyIn) {
-                                ForEach(currencies, id: \.self) { code in
-                                    Text(code).tag(code)
-                                }
-                            }
-                            .frame(width: 110)
-
-                            TextField("轉入金額", text: Binding(
-                                get: { amountInString },
-                                set: { amountInString = sanitizePositiveDecimalInput($0) }
-                            ))
-                            .keyboardType(.decimalPad)
-                            .focused($focusedField, equals: .amountIn)
-                        }
-                    }
-
-                    Section("自己的入帳標記") {
-                        Picker("分類", selection: $selectedCategory) {
-                            Text("不設定").tag(nil as Category?)
-                            ForEach(incomeCategories) { category in
-                                Text(category.name).tag(category as Category?)
-                            }
-                        }
-
-                        HStack {
-                            Text("標籤")
-                            Spacer()
-                            Button {
-                                showingAddTag = true
-                            } label: {
-                                Label("新增", systemImage: "plus")
-                                    .font(.caption)
-                            }
-                        }
-
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack {
-                                ForEach(tags) { tag in
-                                    let isSelected = selectedTags.contains(tag)
-                                    Button {
-                                        if isSelected {
-                                            selectedTags.remove(tag)
-                                        } else {
-                                            selectedTags.insert(tag)
-                                        }
-                                    } label: {
-                                        Text(tag.name)
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 6)
-                                            .background(isSelected ? Color.blue : Color.gray.opacity(0.2))
-                                            .foregroundStyle(isSelected ? .white : .primary)
-                                            .cornerRadius(16)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                            }
-                        }
-                    }
-
+                    summarySection
+                    amountSection
+                    metadataSection
                     Section("其他") {
                         DatePicker("日期", selection: $date, displayedComponents: [.date, .hourAndMinute])
                             .accessibilityIdentifier("advanceTransferEditor.datePicker")
@@ -200,16 +146,6 @@ struct EditAdvanceTransferView: View {
             }
             .interactiveKeyboardDismiss()
             .navigationTitle(titleText)
-            .alert("輸入錯誤", isPresented: $showingValidationAlert) {
-                Button("確定", role: .cancel) {}
-            } message: {
-                Text(validationMessage)
-            }
-            .alert("新增標籤", isPresented: $showingAddTag) {
-                TextField("標籤名稱", text: $newTagName)
-                Button("取消", role: .cancel) { newTagName = "" }
-                Button("新增") { createTag() }
-            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("取消") { dismiss() }
@@ -224,202 +160,467 @@ struct EditAdvanceTransferView: View {
                     Button("完成") { focusedField = nil }
                 }
             }
+            .alert("輸入錯誤", isPresented: $showingValidationAlert) {
+                Button("確定", role: .cancel) {}
+            } message: {
+                Text(validationMessage)
+            }
+            .alert("新增標籤", isPresented: $showingAddTag) {
+                TextField("標籤名稱", text: $newTagName)
+                Button("取消", role: .cancel) { newTagName = "" }
+                Button("新增") { createTag() }
+            }
             .onAppear { loadData() }
         }
     }
 
-    private func loadData() {
-        do {
-            guard let (outTx, inTx, groupID) = try resolveTransferPair(for: originalTransaction) else {
-                errorMessage = "找不到可編輯的代墊交易配對。"
-                isLoading = false
-                return
+    @ViewBuilder
+    private var summarySection: some View {
+        Section("案件") {
+            switch linkKind {
+            case .selfExpense(let advanceCase, _):
+                summaryRow("案件", advanceCase.title)
+                summaryRow("類型", "自己的份額")
+                summaryRow("案件幣種", advanceCase.currencyCode)
+            case .initial(let participant):
+                summaryRow("對象", participant.name)
+                summaryRow(
+                    "方向",
+                    settlementDirection == .iAdvancedOthers ? "我代墊他人" : "他人代墊我"
+                )
+                summaryRow("案件幣種", participant.advanceCase?.currencyCode ?? currencyCode)
+            case .repayment(let repayment):
+                summaryRow("對象", repayment.participant?.name ?? "未指定")
+                summaryRow(
+                    "方向",
+                    settlementDirection == .iAdvancedOthers ? "對方還款給我" : "我還款給對方"
+                )
+                summaryRow("案件幣種", repayment.advanceCase?.currencyCode ?? currencyCode)
+            case .unknown:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var amountSection: some View {
+        Section(linkKindAmountTitle) {
+            if requiresOwnAccount {
+                Picker(accountLabel, selection: $selectedAccount) {
+                    Text("選擇帳戶").tag(nil as Account?)
+                    ForEach(activeOwnAccounts) { account in
+                        Text(account.name).tag(account as Account?)
+                    }
+                }
+            } else {
+                Text("自己的帳戶沒有變動。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
-            outgoingTransaction = outTx
-            incomingTransaction = inTx
-            transferGroupID = groupID
+            HStack {
+                switch linkKind {
+                case .selfExpense, .repayment:
+                    Picker("幣種", selection: $currencyCode) {
+                        ForEach(availableCurrencies, id: \.self) { code in
+                            Text(code).tag(code)
+                        }
+                    }
+                    .frame(width: 105)
+                case .initial, .unknown:
+                    Text(currencyCode)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 70, alignment: .leading)
+                }
 
-            fromAccount = outTx.account
-            toAccount = inTx.account
-            currencyOut = outTx.currencyCode.isEmpty ? (outTx.account?.currency ?? "HKD") : outTx.currencyCode
-            currencyIn = inTx.currencyCode.isEmpty ? (inTx.account?.currency ?? "HKD") : inTx.currencyCode
-            amountOutString = decimalString(from: abs(outTx.amount))
-            amountInString = decimalString(from: abs(inTx.amount))
-            date = outTx.date
-            note = extractMemo(from: outTx.note)
+                TextField("金額", text: Binding(
+                    get: { amountString },
+                    set: { amountString = sanitizePositiveDecimalInput($0) }
+                ))
+                .keyboardType(.decimalPad)
+                .focused($focusedField, equals: .amount)
+            }
 
-            selectedCategory = inTx.category
-            selectedTags = Set(inTx.tags)
+            switch linkKind {
+            case .selfExpense(let advanceCase, _):
+                normalizedAmountField(
+                    title: "案件中的自己份額",
+                    currencyCode: advanceCase.currencyCode,
+                    helpText: "實際扣款可用其他幣種；這個金額用於代墊案件摘要。"
+                )
+            case .repayment(let repayment):
+                normalizedAmountField(
+                    title: "沖銷案件金額",
+                    currencyCode: repayment.advanceCase?.currencyCode ?? "",
+                    helpText: "此值會直接保存，不會在儲存時用目前匯率重新計算。"
+                )
+            case .initial, .unknown:
+                EmptyView()
+            }
+        }
+    }
 
-            if let groupID {
-                if let participant = participants.first(where: { $0.initialTransferGroupID == groupID }) {
-                    linkKind = .initial(participant)
-                } else if let repayment = repayments.first(where: { $0.linkedTransferGroupID == groupID }) {
-                    linkKind = .repayment(repayment)
-                } else {
-                    linkKind = .unknown
+    @ViewBuilder
+    private func normalizedAmountField(
+        title: String,
+        currencyCode: String,
+        helpText: String
+    ) -> some View {
+        HStack {
+            TextField(title, text: Binding(
+                get: { normalizedAmountString },
+                set: { normalizedAmountString = sanitizePositiveDecimalInput($0) }
+            ))
+            .keyboardType(.decimalPad)
+            .focused($focusedField, equals: .normalizedAmount)
+
+            Text(currencyCode)
+                .foregroundStyle(.secondary)
+        }
+        Text(helpText)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private var metadataSection: some View {
+        if !directionalCategories.isEmpty {
+            Section(categorySectionTitle) {
+                Picker("分類", selection: $selectedCategory) {
+                    Text("不設定").tag(nil as Category?)
+                    ForEach(directionalCategories) { category in
+                        Text(category.name).tag(category as Category?)
+                    }
+                }
+
+                HStack {
+                    Text("標籤")
+                    Spacer()
+                    Button {
+                        showingAddTag = true
+                    } label: {
+                        Label("新增", systemImage: "plus")
+                            .font(.caption)
+                    }
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        ForEach(tags) { tag in
+                            let isSelected = selectedTags.contains(tag)
+                            Button {
+                                if isSelected {
+                                    selectedTags.remove(tag)
+                                } else {
+                                    selectedTags.insert(tag)
+                                }
+                            } label: {
+                                Text(tag.name)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .background(isSelected ? Color.blue : Color.gray.opacity(0.2))
+                                    .foregroundStyle(isSelected ? .white : .primary)
+                                    .cornerRadius(16)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
                 }
             }
+        }
+    }
 
+    private var linkKindAmountTitle: String {
+        switch linkKind {
+        case .selfExpense:
+            return "實際扣款"
+        case .initial:
+            return "代墊金額"
+        case .repayment:
+            return settlementDirection == .iAdvancedOthers ? "實際收到" : "實際支付"
+        case .unknown:
+            return "金額"
+        }
+    }
+
+    private var accountLabel: String {
+        switch linkKind {
+        case .selfExpense:
+            return "支出帳戶"
+        case .initial:
+            return "付款帳戶"
+        case .repayment:
+            return settlementDirection == .iAdvancedOthers ? "入帳帳戶" : "付款帳戶"
+        case .unknown:
+            return "帳戶"
+        }
+    }
+
+    private var categorySectionTitle: String {
+        switch linkKind {
+        case .selfExpense:
+            return "支出分類與標籤"
+        case .initial:
+            return "支出分類與標籤"
+        case .repayment:
+            return settlementDirection == .iAdvancedOthers
+                ? "自己的入帳標記"
+                : "還款標記（不重複計入支出）"
+        case .unknown:
+            return "分類與標籤"
+        }
+    }
+
+    private func loadData() {
+        guard !didLoadDraft else { return }
+        didLoadDraft = true
+
+        if let directRepayment, let groupID = directRepayment.linkedTransferGroupID {
+            do {
+                try loadRepayment(directRepayment, groupID: groupID)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
             isLoading = false
+            return
+        }
+
+        if let transaction = originalTransaction,
+           let advanceCase = advanceCases.first(where: { $0.selfExpenseTransactionID == transaction.id }) {
+            loadSelfExpense(advanceCase, transaction: transaction)
+            isLoading = false
+            return
+        }
+
+        guard let groupID = originalTransaction?.transferGroupID else {
+            errorMessage = "找不到代墊關聯識別資料。"
+            isLoading = false
+            return
+        }
+
+        do {
+            if let repayment = repayments.first(where: { $0.linkedTransferGroupID == groupID }) {
+                try loadRepayment(repayment, groupID: groupID)
+            } else if let participant = participants.first(where: { $0.initialTransferGroupID == groupID }) {
+                try loadInitialParticipant(participant, groupID: groupID)
+            } else {
+                errorMessage = "找不到對應的代墊案件或還款紀錄。"
+            }
         } catch {
-            errorMessage = "讀取錯誤：\(error.localizedDescription)"
-            isLoading = false
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func loadRepayment(_ repayment: AdvanceRepayment, groupID: UUID) throws {
+        guard let participant = repayment.participant else {
+            throw AdvanceServiceError.missingRepaymentParticipant
+        }
+        let group = try fetchGroup(groupID)
+        guard group.count == 2 else {
+            throw AdvanceServiceError.invalidRepaymentStructure
+        }
+        settlementDirection = AdvanceService.inferSettlementDirection(
+            for: participant,
+            modelContext: modelContext
+        )
+        let ownLeg = group.first {
+            settlementDirection == .iAdvancedOthers
+                ? ($0.transferSide == .incoming || $0.amount > 0)
+                : ($0.transferSide == .outgoing || $0.amount < 0)
+        }
+        linkKind = .repayment(repayment)
+        selectedAccount = repayment.receivedAccount ?? ownLeg?.account
+        amountString = decimalString(repayment.amount)
+        currencyCode = repayment.currencyCode
+        normalizedAmountString = decimalString(repayment.normalizedAmount)
+        date = repayment.date
+        note = repayment.note
+        selectedCategory = ownLeg?.category
+        selectedTags = Set(ownLeg?.tags ?? [])
+    }
+
+    private func loadSelfExpense(
+        _ advanceCase: AdvanceCase,
+        transaction: FinancialTransaction
+    ) {
+        linkKind = .selfExpense(advanceCase, transaction)
+        selectedAccount = transaction.account
+        amountString = decimalString(abs(transaction.amount))
+        currencyCode = transaction.currencyCode
+        normalizedAmountString = decimalString(advanceCase.myShareAmount)
+        date = transaction.date
+        note = transaction.note
+        selectedCategory = transaction.category
+        selectedTags = Set(transaction.tags)
+    }
+
+    private func loadInitialParticipant(_ participant: AdvanceParticipant, groupID: UUID) throws {
+        guard let advanceCase = participant.advanceCase else {
+            throw AdvanceServiceError.participantNotInCase
+        }
+        let group = try fetchGroup(groupID)
+        settlementDirection = AdvanceService.inferSettlementDirection(
+            for: participant,
+            modelContext: modelContext
+        )
+        linkKind = .initial(participant)
+        amountString = decimalString(participant.owedAmount)
+        currencyCode = advanceCase.currencyCode
+        date = group.first?.date ?? advanceCase.date
+        note = extractMemo(group.first?.note ?? advanceCase.note)
+
+        switch settlementDirection {
+        case .iAdvancedOthers:
+            guard group.count == 2,
+                  let outgoing = group.first(where: { $0.transferSide == .outgoing || $0.amount < 0 })
+            else {
+                throw AdvanceServiceError.invalidRepaymentStructure
+            }
+            selectedAccount = outgoing.account
+        case .othersAdvancedMe:
+            guard group.count == 1, let expense = group.first else {
+                throw AdvanceServiceError.invalidRepaymentStructure
+            }
+            selectedAccount = nil
+            selectedCategory = expense.category
+            selectedTags = Set(expense.tags)
         }
     }
 
     private func saveChanges() {
-        guard let outTx = outgoingTransaction,
-              let inTx = incomingTransaction,
-              let from = fromAccount,
-              let to = toAccount
-        else {
-            showValidation("找不到可更新的交易資料。")
-            return
-        }
-
-        guard from.id != to.id else {
-            showValidation("轉出與轉入帳戶不可相同。")
-            return
-        }
-
-        guard let amountOut = positiveDecimal(from: amountOutString),
-              let amountIn = positiveDecimal(from: amountInString)
-        else {
+        guard let amount = positiveDecimal(from: amountString) else {
             showValidation("請輸入大於 0 的金額。")
             return
         }
 
-        let groupID = transferGroupID ?? outTx.transferGroupID ?? inTx.transferGroupID ?? UUID()
-        let baseNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
-        let now = Date()
-
-        outTx.type = .transfer
-        outTx.amount = -abs(amountOut)
-        outTx.currencyCode = currencyOut
-        outTx.date = date
-        outTx.account = from
-        outTx.transferSide = .outgoing
-        outTx.transferGroupID = groupID
-        outTx.updatedAt = now
-
-        inTx.type = .transfer
-        inTx.amount = abs(amountIn)
-        inTx.currencyCode = currencyIn
-        inTx.date = date
-        inTx.account = to
-        inTx.transferSide = .incoming
-        inTx.transferGroupID = groupID
-        inTx.category = selectedCategory
-        inTx.tags = Array(selectedTags)
-        inTx.updatedAt = now
-
-        outTx.linkedTransactionID = inTx.id
-        inTx.linkedTransactionID = outTx.id
-
-        switch linkKind {
-        case .initial:
-            outTx.note = baseNote.isEmpty ? "代墊 (代墊給 \(to.name))" : "\(baseNote) (代墊給 \(to.name))"
-            inTx.note = baseNote.isEmpty ? "代墊 (來自 \(from.name))" : "\(baseNote) (來自 \(from.name))"
-        case .repayment:
-            outTx.note = baseNote.isEmpty ? "還款 (還款至 \(to.name))" : "\(baseNote) (還款至 \(to.name))"
-            inTx.note = baseNote.isEmpty ? "還款 (來自 \(from.name))" : "\(baseNote) (來自 \(from.name))"
-        case .unknown:
-            outTx.note = baseNote.isEmpty ? "轉帳 (轉至 \(to.name))" : "\(baseNote) (轉至 \(to.name))"
-            inTx.note = baseNote.isEmpty ? "轉帳 (來自 \(from.name))" : "\(baseNote) (來自 \(from.name))"
-        }
-
         do {
-            try AdvanceService.syncLinkedTransferGroup(groupID: groupID, modelContext: modelContext)
-            try modelContext.save()
+            switch linkKind {
+            case .selfExpense(let advanceCase, let transaction):
+                guard let account = selectedAccount,
+                      let normalizedAmount = positiveDecimal(from: normalizedAmountString)
+                else {
+                    showValidation("請填寫完整的自己份額資料。")
+                    return
+                }
+                try AdvanceService.updateSelfExpense(
+                    advanceCase: advanceCase,
+                    transaction: transaction,
+                    draft: .init(
+                        account: account,
+                        amount: amount,
+                        currencyCode: currencyCode,
+                        normalizedAmount: normalizedAmount,
+                        date: date,
+                        note: note,
+                        category: selectedCategory,
+                        tags: Array(selectedTags)
+                    ),
+                    modelContext: modelContext
+                )
+            case .repayment(let repayment):
+                guard let advanceCase = repayment.advanceCase,
+                      let receiveAccount = selectedAccount,
+                      let normalizedAmount = positiveDecimal(from: normalizedAmountString)
+                else {
+                    showValidation("請填寫完整的還款資料。")
+                    return
+                }
+                try AdvanceService.updateRepayment(
+                    advanceCase: advanceCase,
+                    repayment: repayment,
+                    draft: .init(
+                        receiveAccount: receiveAccount,
+                        amount: amount,
+                        currencyCode: currencyCode,
+                        normalizedAmount: normalizedAmount,
+                        date: date,
+                        note: note,
+                        category: selectedCategory,
+                        tags: Array(selectedTags)
+                    ),
+                    modelContext: modelContext
+                )
+            case .initial(let participant):
+                guard let advanceCase = participant.advanceCase else {
+                    throw AdvanceServiceError.participantNotInCase
+                }
+                try AdvanceService.updateInitialEntry(
+                    advanceCase: advanceCase,
+                    participant: participant,
+                    draft: .init(
+                        payerAccount: selectedAccount,
+                        owedAmount: amount,
+                        date: date,
+                        note: note,
+                        category: selectedCategory,
+                        tags: Array(selectedTags)
+                    ),
+                    modelContext: modelContext
+                )
+            case .unknown:
+                throw AdvanceServiceError.invalidRepaymentStructure
+            }
             dismiss()
         } catch {
+            modelContext.rollback()
             showValidation("儲存失敗：\(error.localizedDescription)")
         }
     }
 
-    private func resolveTransferPair(for tx: FinancialTransaction) throws -> (FinancialTransaction, FinancialTransaction, UUID?)? {
-        if let groupID = tx.transferGroupID {
-            let descriptor = FetchDescriptor<FinancialTransaction>(
-                predicate: #Predicate { $0.transferGroupID == groupID }
-            )
-            let groupItems = try modelContext.fetch(descriptor)
-            if let outTx = groupItems.first(where: { isOutgoing($0) }),
-               let inTx = groupItems.first(where: { !isOutgoing($0) }) {
-                return (outTx, inTx, groupID)
-            }
-        }
-
-        if let linkedID = tx.linkedTransactionID {
-            let descriptor = FetchDescriptor<FinancialTransaction>(
-                predicate: #Predicate { $0.id == linkedID }
-            )
-            if let linked = try modelContext.fetch(descriptor).first {
-                let outTx = isOutgoing(tx) ? tx : linked
-                let inTx = isOutgoing(tx) ? linked : tx
-                let groupID = tx.transferGroupID ?? linked.transferGroupID
-                return (outTx, inTx, groupID)
-            }
-        }
-
-        return nil
+    private func fetchGroup(_ groupID: UUID) throws -> [FinancialTransaction] {
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        return try modelContext.fetch(descriptor)
     }
 
-    private func isOutgoing(_ tx: FinancialTransaction) -> Bool {
-        if let side = tx.transferSide {
-            return side == .outgoing
+    private func summaryRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
         }
-        return tx.amount < 0
     }
 
     private func createTag() {
         let trimmed = newTagName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-
         if let existing = tags.first(where: { $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }) {
             selectedTags.insert(existing)
-            newTagName = ""
-            return
+        } else {
+            let tag = Tag(name: trimmed)
+            modelContext.insert(tag)
+            selectedTags.insert(tag)
         }
-
-        let tag = Tag(name: trimmed)
-        modelContext.insert(tag)
-        selectedTags.insert(tag)
         newTagName = ""
     }
 
-    private func extractMemo(from note: String) -> String {
-        let separators = [
-            " (代墊給", " (還款至", " (轉至", " (來自", " (借入至", " (還款給"
-        ]
-
-        for separator in separators {
-            if let range = note.range(of: separator) {
-                return String(note[..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
-            }
+    private func extractMemo(_ value: String) -> String {
+        let separators = [" (代墊給", " (他人代墊我", " (還款至", " (還款給", " (來自"]
+        let indexes = separators.compactMap { value.range(of: $0)?.lowerBound }
+        guard let first = indexes.min() else {
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-
-        return note.trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(value[..<first]).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func decimalString(from value: Decimal) -> String {
-        NSDecimalNumber(decimal: value).stringValue
+    private func decimalString(_ value: Decimal) -> String {
+        NSDecimalNumber(decimal: abs(value)).stringValue
     }
 
     private func sanitizePositiveDecimalInput(_ value: String) -> String {
         let allowed = value.filter { "0123456789.".contains($0) }
         var result = ""
         var hasDot = false
-
-        for char in allowed {
-            if char == "." {
+        for character in allowed {
+            if character == "." {
                 if hasDot { continue }
                 hasDot = true
             }
-            result.append(char)
+            result.append(character)
         }
-
         return result == "." ? "" : result
     }
 

--- a/AI 記帳/Views/Transactions/EditTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditTransferView.swift
@@ -91,7 +91,7 @@ struct EditTransferView: View {
 
                                 HStack {
                                     Picker("幣種", selection: $leg.currency) {
-                                        ForEach(currencies, id: \.self) { code in
+                                        ForEach(availableCurrencies(including: leg.currency), id: \.self) { code in
                                             Text(code).tag(code)
                                         }
                                     }
@@ -152,7 +152,7 @@ struct EditTransferView: View {
 
                                 HStack {
                                     Picker("幣種", selection: $leg.currency) {
-                                        ForEach(currencies, id: \.self) { code in
+                                        ForEach(availableCurrencies(including: leg.currency), id: \.self) { code in
                                             Text(code).tag(code)
                                         }
                                     }
@@ -264,7 +264,7 @@ struct EditTransferView: View {
                     errorMessage = "這是債務管理分錄，請從債務管理編輯。"
                 case .debtForgiveness:
                     errorMessage = "這是免除債務紀錄，請從債務管理編輯。"
-                case .advanceInitial, .advanceRepayment:
+                case .advanceSelfExpense, .advanceInitial, .advanceRepayment:
                     errorMessage = "這是代墊關聯分錄，請從代墊詳情編輯。"
                 case .ordinary:
                     break
@@ -435,6 +435,10 @@ struct EditTransferView: View {
             return tx.currencyCode
         }
         return tx?.account?.currency ?? "HKD"
+    }
+
+    private func availableCurrencies(including selected: String) -> [String] {
+        currencies.contains(selected) ? currencies : [selected] + currencies
     }
 
     private func parseLegs(from legs: [TransferLegInput], sideName: String) throws -> [DesiredLeg] {

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -129,28 +129,29 @@ struct TransactionsListView: View {
 
     @ViewBuilder
     private func transactionEditor(for tx: FinancialTransaction, renderState: TransactionsRenderState) -> some View {
-        if tx.type == .transfer {
-            let group = TransferEditRoutingService.groupTransactions(
-                for: tx,
-                in: renderState.allTransactions
-            )
-            switch TransferEditRoutingService.classify(
-                transaction: tx,
-                groupTransactions: group,
-                advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
-                advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
-            ) {
-            case .advanceInitial, .advanceRepayment:
-                EditAdvanceTransferView(originalTransaction: tx)
-            case .debtForgiveness:
-                AddDebtView(existingForgivenessTransaction: tx)
-            case .debt:
-                AddDebtView(existingDebtTransaction: tx)
-            case .ordinary:
+        let group = TransferEditRoutingService.groupTransactions(
+            for: tx,
+            in: renderState.allTransactions
+        )
+        switch TransferEditRoutingService.classify(
+            transaction: tx,
+            groupTransactions: group,
+            advanceSelfExpenseTransactionIDs: Set(advanceCases.compactMap(\.selfExpenseTransactionID)),
+            advanceInitialGroupIDs: renderState.initialAdvanceGroupIDs,
+            advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
+        ) {
+        case .advanceSelfExpense, .advanceInitial, .advanceRepayment:
+            EditAdvanceTransferView(originalTransaction: tx)
+        case .debtForgiveness:
+            AddDebtView(existingForgivenessTransaction: tx)
+        case .debt:
+            AddDebtView(existingDebtTransaction: tx)
+        case .ordinary:
+            if tx.type == .transfer {
                 EditTransferView(originalTransaction: tx)
+            } else {
+                EditTransactionView(transaction: tx)
             }
-        } else {
-            EditTransactionView(transaction: tx)
         }
     }
 

--- a/AI 記帳Tests/AdvanceEditingTests.swift
+++ b/AI 記帳Tests/AdvanceEditingTests.swift
@@ -1,0 +1,487 @@
+import XCTest
+import SwiftData
+@testable import AI_記帳
+
+@MainActor
+final class AdvanceEditingTests: XCTestCase {
+    func testCrossCurrencyRepaymentEditPreservesExplicitNormalizedAmountAndIncomingMetadata() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let bank = Account(name: "Bank", currency: "HKD", type: .bank, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "JPY", type: .debt, baseBalance: 0)
+        let category = Category(name: "Repayment received", icon: "arrow.down", colorHex: "#123456", kind: .income)
+        let tag = Tag(name: "Edited")
+        [wallet, bank, friend].forEach(context.insert)
+        context.insert(category)
+        context.insert(tag)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Japan trip",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 2_000)],
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 50,
+            currencyCode: "HKD",
+            date: Date(timeIntervalSince1970: 20),
+            note: "First",
+            receiveAccount: wallet,
+            category: nil,
+            tags: [],
+            currencyService: .shared,
+            normalizedAmountOverride: 1_000,
+            direction: .iAdvancedOthers,
+            modelContext: context
+        )
+
+        try AdvanceService.updateRepayment(
+            advanceCase: advanceCase,
+            repayment: repayment,
+            draft: .init(
+                receiveAccount: bank,
+                amount: 60,
+                currencyCode: "HKD",
+                normalizedAmount: 900,
+                date: Date(timeIntervalSince1970: 30),
+                note: "Edited",
+                category: category,
+                tags: [tag]
+            ),
+            modelContext: context
+        )
+
+        XCTAssertEqual(Decimal(60), repayment.amount)
+        XCTAssertEqual(Decimal(900), repayment.normalizedAmount)
+        XCTAssertEqual(Decimal(900), participant.repaidAmount)
+        XCTAssertEqual(bank.id, repayment.receivedAccount?.id)
+
+        let groupID = try XCTUnwrap(repayment.linkedTransferGroupID)
+        let transactions = try fetchGroup(groupID, context: context)
+        let incoming = try XCTUnwrap(transactions.first { $0.transferSide == .incoming })
+        let outgoing = try XCTUnwrap(transactions.first { $0.transferSide == .outgoing })
+        XCTAssertEqual(bank.id, incoming.account?.id)
+        XCTAssertEqual(category.id, incoming.category?.id)
+        XCTAssertEqual([tag.id], incoming.tags.map(\.id))
+        XCTAssertNil(outgoing.category)
+        XCTAssertTrue(outgoing.tags.isEmpty)
+    }
+
+    func testOthersAdvancedMeEditTagsOutgoingOwnLegAndRollbackRestoresParticipant() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let category = Category(name: "Repayment paid", icon: "arrow.up", colorHex: "#654321", kind: .expense)
+        let tag = Tag(name: "Paid")
+        [wallet, friend].forEach(context.insert)
+        context.insert(category)
+        context.insert(tag)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Dinner",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: nil,
+            category: category,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 100)],
+            isBorrowedByMe: true,
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 40,
+            currencyCode: "HKD",
+            date: Date(timeIntervalSince1970: 20),
+            note: "",
+            receiveAccount: wallet,
+            category: nil,
+            tags: [],
+            currencyService: .shared,
+            normalizedAmountOverride: 40,
+            direction: .othersAdvancedMe,
+            modelContext: context
+        )
+
+        try AdvanceService.updateRepayment(
+            advanceCase: advanceCase,
+            repayment: repayment,
+            draft: .init(
+                receiveAccount: wallet,
+                amount: 35,
+                currencyCode: "HKD",
+                normalizedAmount: 35,
+                date: Date(timeIntervalSince1970: 30),
+                note: "Paid",
+                category: category,
+                tags: [tag]
+            ),
+            modelContext: context
+        )
+
+        let groupID = try XCTUnwrap(repayment.linkedTransferGroupID)
+        let outgoing = try XCTUnwrap(
+            fetchGroup(groupID, context: context).first { $0.transferSide == .outgoing }
+        )
+        XCTAssertEqual(wallet.id, outgoing.account?.id)
+        XCTAssertEqual(category.id, outgoing.category?.id)
+        XCTAssertEqual([tag.id], outgoing.tags.map(\.id))
+
+        try AdvanceService.rollbackRepayment(
+            advanceCase: advanceCase,
+            repayment: repayment,
+            modelContext: context
+        )
+
+        XCTAssertEqual(Decimal.zero, participant.repaidAmount)
+        XCTAssertTrue(try fetchGroup(groupID, context: context).isEmpty)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<AdvanceRepayment>()).isEmpty)
+    }
+
+    func testParticipantCorrectionUpdatesBorrowedInitialExpense() throws {
+        let context = try makeContext()
+        let friend = Account(name: "Friend", currency: "JPY", type: .debt, baseBalance: 0)
+        let category = Category(name: "Transport", icon: "tram", colorHex: "#123456", kind: .expense)
+        let tag = Tag(name: "Trip")
+        context.insert(friend)
+        context.insert(category)
+        context.insert(tag)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Taxi",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: nil,
+            category: category,
+            tags: [tag],
+            participants: [.init(debtAccount: friend, owedAmount: 1_000)],
+            isBorrowedByMe: true,
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+
+        try AdvanceService.updateParticipantOwedAmount(
+            advanceCase: advanceCase,
+            participant: participant,
+            newOwedAmount: 1_200,
+            modelContext: context
+        )
+
+        XCTAssertEqual(Decimal(1_200), participant.owedAmount)
+        let groupID = try XCTUnwrap(participant.initialTransferGroupID)
+        let expense = try XCTUnwrap(fetchGroup(groupID, context: context).first)
+        XCTAssertEqual(.expense, expense.type)
+        XCTAssertEqual(Decimal(-1_200), expense.amount)
+        XCTAssertEqual("JPY", expense.currencyCode)
+        XCTAssertEqual(category.id, expense.category?.id)
+        XCTAssertEqual([tag.id], expense.tags.map(\.id))
+
+        let report = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: [
+                    ReportTransactionSnapshot(
+                        id: expense.id,
+                        amount: expense.amount,
+                        currencyCode: expense.currencyCode,
+                        date: expense.date,
+                        type: expense.type,
+                        categoryID: expense.category?.id,
+                        categoryName: expense.category?.name,
+                        categoryColorHex: expense.category?.colorHex,
+                        tagNames: expense.tags.map(\.name)
+                    )
+                ],
+                flow: .expense,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: AdvanceEditingReportCurrencyConverter(mainCurrency: "JPY")
+        )
+
+        let slice = try XCTUnwrap(report.slices.first)
+        XCTAssertEqual("Transport", slice.name)
+        XCTAssertEqual(Decimal(1_200), slice.estimatedAmount)
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "JPY", amount: 1_200)],
+            slice.originalCurrencyTotals
+        )
+        XCTAssertEqual([expense.id], slice.transactionIDs)
+    }
+
+    func testInitialEntryEditUpdatesCaseMetadataAcrossEveryParticipant() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "JPY", type: .cash, baseBalance: 0)
+        let bank = Account(name: "Bank", currency: "JPY", type: .bank, baseBalance: 0)
+        let friendA = Account(name: "Friend A", currency: "JPY", type: .debt, baseBalance: 0)
+        let friendB = Account(name: "Friend B", currency: "JPY", type: .debt, baseBalance: 0)
+        [wallet, bank, friendA, friendB].forEach(context.insert)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Japan trip",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "Original",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [
+                .init(debtAccount: friendA, owedAmount: 100),
+                .init(debtAccount: friendB, owedAmount: 200),
+            ],
+            modelContext: context
+        )
+        let participantA = try XCTUnwrap(
+            advanceCase.participants.first { $0.debtAccount?.id == friendA.id }
+        )
+        let participantB = try XCTUnwrap(
+            advanceCase.participants.first { $0.debtAccount?.id == friendB.id }
+        )
+        let editedDate = Date(timeIntervalSince1970: 50)
+
+        try AdvanceService.updateInitialEntry(
+            advanceCase: advanceCase,
+            participant: participantA,
+            draft: .init(
+                payerAccount: bank,
+                owedAmount: 120,
+                date: editedDate,
+                note: "Edited",
+                category: nil,
+                tags: []
+            ),
+            modelContext: context
+        )
+
+        XCTAssertEqual(Decimal(120), participantA.owedAmount)
+        XCTAssertEqual(Decimal(200), participantB.owedAmount)
+        XCTAssertEqual(bank.id, advanceCase.payerAccount?.id)
+        XCTAssertEqual(editedDate, advanceCase.date)
+        XCTAssertEqual("Edited", advanceCase.note)
+
+        for participant in [participantA, participantB] {
+            let groupID = try XCTUnwrap(participant.initialTransferGroupID)
+            let transactions = try fetchGroup(groupID, context: context)
+            let outgoing = try XCTUnwrap(
+                transactions.first { $0.transferSide == .outgoing }
+            )
+            let incoming = try XCTUnwrap(
+                transactions.first { $0.transferSide == .incoming }
+            )
+            XCTAssertEqual(bank.id, outgoing.account?.id)
+            XCTAssertEqual(editedDate, outgoing.date)
+            XCTAssertEqual(editedDate, incoming.date)
+            XCTAssertTrue(incoming.note.contains(bank.name))
+            XCTAssertEqual(participant.owedAmount, abs(outgoing.amount))
+            XCTAssertEqual(participant.owedAmount, incoming.amount)
+        }
+    }
+
+    func testSelfExpenseEditPreservesActualCurrencyAndNormalisedCaseShare() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .creditCard, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "JPY", type: .debt, baseBalance: 0)
+        let category = Category(name: "Transport", icon: "tram", colorHex: "#123456", kind: .expense)
+        let tag = Tag(name: "LUUP")
+        [wallet, friend].forEach(context.insert)
+        context.insert(category)
+        context.insert(tag)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Japan trip",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 1_000,
+            note: "",
+            payerAccount: wallet,
+            category: category,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 2_000)],
+            modelContext: context
+        )
+        let transactionID = try XCTUnwrap(advanceCase.selfExpenseTransactionID)
+        let transaction = try XCTUnwrap(
+            try context.fetch(
+                FetchDescriptor<FinancialTransaction>(
+                    predicate: #Predicate { $0.id == transactionID }
+                )
+            ).first
+        )
+
+        try AdvanceService.updateSelfExpense(
+            advanceCase: advanceCase,
+            transaction: transaction,
+            draft: .init(
+                account: wallet,
+                amount: Decimal(string: "35.59")!,
+                currencyCode: "CHF",
+                normalizedAmount: 725,
+                date: Date(timeIntervalSince1970: 20),
+                note: "LUUP",
+                category: category,
+                tags: [tag]
+            ),
+            modelContext: context
+        )
+
+        XCTAssertEqual(Decimal(string: "-35.59")!, transaction.amount)
+        XCTAssertEqual("CHF", transaction.currencyCode)
+        XCTAssertEqual(Decimal(725), advanceCase.myShareAmount)
+        XCTAssertEqual(category.id, transaction.category?.id)
+        XCTAssertEqual([tag.id], transaction.tags.map(\.id))
+
+        let report = ReportAggregationService.aggregate(
+            request: ReportAggregationRequest(
+                transactions: [
+                    ReportTransactionSnapshot(
+                        id: transaction.id,
+                        amount: transaction.amount,
+                        currencyCode: transaction.currencyCode,
+                        date: transaction.date,
+                        type: transaction.type,
+                        categoryID: transaction.category?.id,
+                        categoryName: transaction.category?.name,
+                        categoryColorHex: transaction.category?.colorHex,
+                        tagNames: transaction.tags.map(\.name)
+                    )
+                ],
+                flow: .expense,
+                grouping: .category,
+                startDate: nil,
+                endDate: nil
+            ),
+            currencyConverter: AdvanceEditingReportCurrencyConverter(mainCurrency: "CHF")
+        )
+
+        let slice = try XCTUnwrap(report.slices.first)
+        XCTAssertEqual(Decimal(string: "35.59")!, slice.estimatedAmount)
+        XCTAssertEqual(
+            [ReportCurrencyTotal(currencyCode: "CHF", amount: Decimal(string: "35.59")!)],
+            slice.originalCurrencyTotals
+        )
+    }
+
+    func testRepaymentEditRejectsCategoryForWrongSettlementDirection() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let expenseCategory = Category(
+            name: "Wrong direction",
+            icon: "xmark",
+            colorHex: "#123456",
+            kind: .expense
+        )
+        [wallet, friend].forEach(context.insert)
+        context.insert(expenseCategory)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Dinner",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 100)],
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 40,
+            currencyCode: "HKD",
+            date: Date(timeIntervalSince1970: 20),
+            note: "",
+            receiveAccount: wallet,
+            category: nil,
+            tags: [],
+            currencyService: .shared,
+            normalizedAmountOverride: 40,
+            modelContext: context
+        )
+
+        XCTAssertThrowsError(
+            try AdvanceService.updateRepayment(
+                advanceCase: advanceCase,
+                repayment: repayment,
+                draft: .init(
+                    receiveAccount: wallet,
+                    amount: 35,
+                    currencyCode: "HKD",
+                    normalizedAmount: 35,
+                    date: Date(timeIntervalSince1970: 30),
+                    note: "",
+                    category: expenseCategory,
+                    tags: []
+                ),
+                modelContext: context
+            )
+        ) { error in
+            XCTAssertEqual(
+                AdvanceServiceError.invalidSettlementCategory.localizedDescription,
+                error.localizedDescription
+            )
+        }
+        XCTAssertEqual(Decimal(40), repayment.amount)
+        XCTAssertEqual(Decimal(40), participant.repaidAmount)
+    }
+
+    private func makeContext() throws -> ModelContext {
+        let schema = Schema([
+            Account.self,
+            FinancialTransaction.self,
+            Category.self,
+            Tag.self,
+            Shortcut.self,
+            RecurringRule.self,
+            RecurringOccurrence.self,
+            CategoryMonthlyBudget.self,
+            BudgetMonthlyHistory.self,
+            BudgetSettings.self,
+            AdvanceCase.self,
+            AdvanceParticipant.self,
+            AdvanceRepayment.self,
+        ])
+        let container = try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func fetchGroup(_ groupID: UUID, context: ModelContext) throws -> [FinancialTransaction] {
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        return try context.fetch(descriptor)
+    }
+}
+
+private struct AdvanceEditingReportCurrencyConverter: ReportCurrencyConverting {
+    let mainCurrency: String
+
+    func estimateInMainCurrency(amount: Decimal, from currencyCode: String) -> ReportConversion? {
+        guard currencyCode.caseInsensitiveCompare(mainCurrency) == .orderedSame else {
+            return nil
+        }
+        return ReportConversion(amount: amount, status: .exact)
+    }
+}

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -483,6 +483,18 @@ final class BackupCompatibilityTests: XCTestCase {
         let repayments = try modelContext.fetch(FetchDescriptor<AdvanceRepayment>())
         XCTAssertEqual(2, repayments.count)
         XCTAssertTrue(repayments.allSatisfy { AdvanceService.mutualDebtOffsetID(from: $0.note) == result.offsetGroupID })
+        XCTAssertThrowsError(
+            try AdvanceService.rollbackRepayment(
+                advanceCase: try XCTUnwrap(repayments.first?.advanceCase),
+                repayment: try XCTUnwrap(repayments.first),
+                modelContext: modelContext
+            )
+        ) { error in
+            XCTAssertEqual(
+                AdvanceServiceError.specialRepaymentRequiresGroupRollback.localizedDescription,
+                error.localizedDescription
+            )
+        }
 
         let rollbackCount = try AdvanceService.rollbackMutualDebtOffset(
             offsetGroupID: result.offsetGroupID,
@@ -547,6 +559,27 @@ final class BackupCompatibilityTests: XCTestCase {
             modelContext: modelContext
         )
         XCTAssertTrue(semanticBalances.isEmpty)
+
+        XCTAssertThrowsError(
+            try AdvanceService.rollbackRepayment(
+                advanceCase: advanceCase,
+                repayment: try XCTUnwrap(repayments.first),
+                modelContext: modelContext
+            )
+        ) { error in
+            XCTAssertEqual(
+                AdvanceServiceError.specialRepaymentRequiresGroupRollback.localizedDescription,
+                error.localizedDescription
+            )
+        }
+
+        let rollbackCount = try AdvanceService.rollbackManualDebtSettlement(
+            settlementID: result.settlementID,
+            modelContext: modelContext
+        )
+        XCTAssertEqual(1, rollbackCount)
+        XCTAssertEqual(Decimal(1230), advanceCase.participants.first?.remainingAmount)
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<AdvanceRepayment>()).isEmpty)
     }
 
     func testRepaymentReconciliation_repairsUnderstatedParticipantTotal() throws {

--- a/AI 記帳Tests/TransferEditRoutingServiceTests.swift
+++ b/AI 記帳Tests/TransferEditRoutingServiceTests.swift
@@ -77,4 +77,69 @@ final class TransferEditRoutingServiceTests: XCTestCase {
             )
         )
     }
+
+    func testBorrowedAdvanceExpenseRoutesAsAdvanceInitial() {
+        let debt = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let groupID = UUID()
+        let expense = FinancialTransaction(
+            amount: -100,
+            currencyCode: "HKD",
+            type: .expense,
+            transferGroupID: groupID,
+            transferSide: .outgoing,
+            account: debt
+        )
+
+        XCTAssertEqual(
+            .advanceInitial,
+            TransferEditRoutingService.classify(
+                transaction: expense,
+                groupTransactions: [expense],
+                advanceInitialGroupIDs: [groupID],
+                advanceRepaymentGroupIDs: []
+            )
+        )
+    }
+
+    func testBorrowedAdvanceCurrentMarkerRoutesWithoutRelationshipIndexes() {
+        let debt = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let expense = FinancialTransaction(
+            amount: -100,
+            currencyCode: "HKD",
+            note: "Dinner (他人代墊我：Friend)",
+            type: .expense,
+            account: debt
+        )
+
+        XCTAssertEqual(
+            .advanceInitial,
+            TransferEditRoutingService.classify(
+                transaction: expense,
+                groupTransactions: [expense],
+                advanceInitialGroupIDs: [],
+                advanceRepaymentGroupIDs: []
+            )
+        )
+    }
+
+    func testAdvanceSelfExpenseRoutesToAdvanceEditor() {
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let expense = FinancialTransaction(
+            amount: -35.59,
+            currencyCode: "HKD",
+            type: .expense,
+            account: wallet
+        )
+
+        XCTAssertEqual(
+            .advanceSelfExpense,
+            TransferEditRoutingService.classify(
+                transaction: expense,
+                groupTransactions: [expense],
+                advanceSelfExpenseTransactionIDs: [expense.id],
+                advanceInitialGroupIDs: [],
+                advanceRepaymentGroupIDs: []
+            )
+        )
+    }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -115,6 +115,55 @@ data class TransferGroupReplacementDraft(
     val legs: List<TransferReplacementLeg>
 )
 
+enum class AdvanceSettlementDirection {
+    IAdvancedOthers,
+    OthersAdvancedMe
+}
+
+data class AdvanceRepaymentEditDraft(
+    val repaymentId: UUID,
+    val receiveAccountId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val normalizedAmount: BigDecimal,
+    val date: Instant,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>
+)
+
+data class AdvanceRepaymentCreateDraft(
+    val receiveAccountId: UUID,
+    val amount: BigDecimal,
+    val normalizedAmount: BigDecimal,
+    val currencyCode: String,
+    val date: Instant,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>
+)
+
+data class AdvanceSelfExpenseEditDraft(
+    val caseId: UUID,
+    val accountId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val normalizedAmount: BigDecimal,
+    val date: Instant,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>
+)
+
+data class AdvanceInitialMetadataEditDraft(
+    val caseId: UUID,
+    val payerAccountId: UUID?,
+    val date: Instant,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>
+)
+
 data class LegacyBorrowedAdvanceRepairResult(
     val repairedParticipantCount: Int,
     val removedInflatedAccountTransactionCount: Int
@@ -326,6 +375,12 @@ class AccountingRepository(
         return advanceDao.getAdvanceCase(caseId)
     }
 
+    suspend fun findAdvanceCaseIdBySelfExpense(transactionId: UUID): UUID? {
+        return advanceDao.getAllCases()
+            .firstOrNull { it.selfExpenseTransactionId == transactionId }
+            ?.id
+    }
+
     suspend fun mutualDebtOffsetCandidate(debtAccountId: UUID, currencyCode: String): MutualDebtOffsetCandidate? {
         val debtAccount = accountDao.getAccount(debtAccountId) ?: return null
         val offsetable = offsetableParticipants(debtAccountId, currencyCode, advanceDao.getAllCasesWithDetails())
@@ -384,16 +439,7 @@ class AccountingRepository(
         return database.withTransaction {
             val repayments = advanceDao.getAllRepayments()
                 .filter { mutualDebtOffsetId(it.note) == offsetGroupId }
-            repayments.forEach { repayment ->
-                val participant = repayment.participantId?.let { participantId ->
-                    advanceDao.getAllParticipants().firstOrNull { it.id == participantId }
-                }
-                if (participant != null) {
-                    val updatedRepaid = (participant.repaidAmount - repayment.normalizedAmount).max(BigDecimal.ZERO)
-                    advanceDao.upsertParticipants(listOf(participant.copy(repaidAmount = updatedRepaid, updatedAt = Instant.now())))
-                }
-                advanceDao.deleteRepayment(repayment)
-            }
+            rollbackRepayments(repayments)
             repayments.size
         }
     }
@@ -436,6 +482,15 @@ class AccountingRepository(
                 currencyCode = currencyCode,
                 repaymentCount = repaymentCount
             )
+        }
+    }
+
+    suspend fun rollbackManualDebtSettlement(settlementId: UUID): Int {
+        return database.withTransaction {
+            val repayments = advanceDao.getAllRepayments()
+                .filter { manualDebtSettlementId(it.note) == settlementId }
+            rollbackRepayments(repayments)
+            repayments.size
         }
     }
 
@@ -1444,119 +1499,637 @@ class AccountingRepository(
         note: String,
         receiveAccount: AccountEntity,
         category: CategoryEntity?,
-        tagIds: List<UUID>,
-        isBorrowedByMe: Boolean = false
+        tagIds: List<UUID>
     ) {
-        database.withTransaction {
-            val now = Instant.now()
-            val normalized = normalizedAmount.abs()
-            val transferGroupId = UUID.randomUUID()
-            val outId = UUID.randomUUID()
-            val inId = UUID.randomUUID()
-
-            val transferMemo = note.trim().ifBlank { advanceCase.title }
-
-            val outTx: TransactionEntity
-            val inTx: TransactionEntity
-            val taggedTxId: UUID
-            if (isBorrowedByMe) {
-                outTx = TransactionEntity(
-                    id = outId,
-                    amount = amount.abs().negate(),
+        recordAdvanceRepayments(
+            advanceCaseId = advanceCase.id,
+            participantId = participant.id,
+            drafts = listOf(
+                AdvanceRepaymentCreateDraft(
+                    receiveAccountId = receiveAccount.id,
+                    amount = amount,
+                    normalizedAmount = normalizedAmount,
                     currencyCode = currencyCode,
                     date = date,
-                    note = "$transferMemo (還款給 ${participant.name})",
-                    photoPath = null,
-                    type = TransactionType.Transfer,
-                    linkedTransactionId = inId,
-                    transferGroupId = transferGroupId,
-                    transferSide = TransferSide.Outgoing,
-                    createdAt = now,
-                    updatedAt = now,
-                    accountId = receiveAccount.id,
-                    categoryId = category?.id
+                    note = note,
+                    categoryId = category?.id,
+                    tagIds = tagIds
                 )
-                inTx = TransactionEntity(
-                    id = inId,
-                    amount = amount.abs(),
-                    currencyCode = currencyCode,
-                    date = date,
-                    note = "$transferMemo (來自 ${receiveAccount.name})",
-                    photoPath = null,
-                    type = TransactionType.Transfer,
-                    linkedTransactionId = outId,
-                    transferGroupId = transferGroupId,
-                    transferSide = TransferSide.Incoming,
-                    createdAt = now,
-                    updatedAt = now,
-                    accountId = participant.debtAccountId,
-                    categoryId = null
-                )
-                taggedTxId = outId
-            } else {
-                outTx = TransactionEntity(
-                    id = outId,
-                    amount = amount.abs().negate(),
-                    currencyCode = currencyCode,
-                    date = date,
-                    note = "$transferMemo (還款至 ${receiveAccount.name})",
-                    photoPath = null,
-                    type = TransactionType.Transfer,
-                    linkedTransactionId = inId,
-                    transferGroupId = transferGroupId,
-                    transferSide = TransferSide.Outgoing,
-                    createdAt = now,
-                    updatedAt = now,
-                    accountId = participant.debtAccountId,
-                    categoryId = null
-                )
-                inTx = TransactionEntity(
-                    id = inId,
-                    amount = amount.abs(),
-                    currencyCode = currencyCode,
-                    date = date,
-                    note = "$transferMemo (來自 ${participant.name})",
-                    photoPath = null,
-                    type = TransactionType.Transfer,
-                    linkedTransactionId = outId,
-                    transferGroupId = transferGroupId,
-                    transferSide = TransferSide.Incoming,
-                    createdAt = now,
-                    updatedAt = now,
-                    accountId = receiveAccount.id,
-                    categoryId = category?.id
-                )
-                taggedTxId = inId
-            }
-
-            transactionDao.upsertAll(listOf(outTx, inTx))
-            if (tagIds.isNotEmpty()) {
-                transactionDao.insertTransactionTags(
-                    tagIds.map { tagId -> TransactionTagCrossRef(taggedTxId, tagId) }
-                )
-            }
-
-            val updatedParticipant = participant.copy(
-                repaidAmount = participant.repaidAmount + normalized,
-                updatedAt = now
             )
-            advanceDao.upsertParticipants(listOf(updatedParticipant))
-            advanceDao.upsertCase(advanceCase.copy(updatedAt = now))
+        )
+    }
 
-            val repayment = AdvanceRepaymentEntity(
+    suspend fun recordAdvanceRepayments(
+        advanceCaseId: UUID,
+        participantId: UUID,
+        drafts: List<AdvanceRepaymentCreateDraft>
+    ) {
+        require(drafts.isNotEmpty()) { "請至少提供一筆還款。" }
+        database.withTransaction {
+            drafts.forEach { draft ->
+                recordAdvanceRepaymentLocked(advanceCaseId, participantId, draft)
+            }
+        }
+    }
+
+    private suspend fun recordAdvanceRepaymentLocked(
+        advanceCaseId: UUID,
+        participantId: UUID,
+        draft: AdvanceRepaymentCreateDraft
+    ) {
+        require(draft.amount > BigDecimal.ZERO) { "還款金額必須大於 0。" }
+        require(draft.normalizedAmount > BigDecimal.ZERO) { "沖銷金額必須大於 0。" }
+        require(draft.currencyCode.isNotBlank()) { "請選擇還款幣種。" }
+
+        val currentCase = requireNotNull(
+            advanceDao.getAllCases().firstOrNull { it.id == advanceCaseId }
+        ) { "找不到代墊案件。" }
+        val currentParticipant = requireNotNull(
+            advanceDao.getAllParticipants().firstOrNull { it.id == participantId }
+        ) { "找不到還款對象。" }
+        require(currentParticipant.advanceCaseId == currentCase.id) {
+            "該還款對象不屬於此代墊案件。"
+        }
+        val currentReceiveAccount = requireNotNull(accountDao.getAccount(draft.receiveAccountId)) {
+            "找不到所選帳戶。"
+        }
+        require(currentReceiveAccount.type != AccountType.Debt && !currentReceiveAccount.isArchived) {
+            "請選擇未歸檔的非借貸帳戶。"
+        }
+        val direction = advanceSettlementDirectionLocked(currentParticipant)
+        val currentCategory = draft.categoryId?.let {
+            requireNotNull(categoryDao.getCategory(it)) { "找不到所選分類。" }
+        }
+        require(
+            currentCategory == null ||
+                currentCategory.kind.supports(
+                    if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                        TransactionType.Income
+                    } else {
+                        TransactionType.Expense
+                    }
+                )
+        ) { "所選分類與這筆還款方向不相符。" }
+
+        val now = Instant.now()
+        val normalized = draft.normalizedAmount.abs()
+        val remaining = (currentParticipant.owedAmount - currentParticipant.repaidAmount)
+            .max(BigDecimal.ZERO)
+        require(normalized - remaining <= BigDecimal("0.0001")) {
+            "沖銷金額超過未還餘額。"
+        }
+        val transferGroupId = UUID.randomUUID()
+        val outId = UUID.randomUUID()
+        val inId = UUID.randomUUID()
+        val amount = draft.amount.abs()
+        val currency = draft.currencyCode.trim().uppercase()
+        val transferMemo = draft.note.trim().ifBlank { currentCase.title }
+
+        val outTx: TransactionEntity
+        val inTx: TransactionEntity
+        val taggedTxId: UUID
+        if (direction == AdvanceSettlementDirection.OthersAdvancedMe) {
+            outTx = TransactionEntity(
+                id = outId,
+                amount = amount.negate(),
+                currencyCode = currency,
+                date = draft.date,
+                note = "$transferMemo (還款給 ${currentParticipant.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = inId,
+                transferGroupId = transferGroupId,
+                transferSide = TransferSide.Outgoing,
+                createdAt = now,
+                updatedAt = now,
+                accountId = currentReceiveAccount.id,
+                categoryId = currentCategory?.id
+            )
+            inTx = TransactionEntity(
+                id = inId,
+                amount = amount,
+                currencyCode = currency,
+                date = draft.date,
+                note = "$transferMemo (來自 ${currentReceiveAccount.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = outId,
+                transferGroupId = transferGroupId,
+                transferSide = TransferSide.Incoming,
+                createdAt = now,
+                updatedAt = now,
+                accountId = currentParticipant.debtAccountId,
+                categoryId = null
+            )
+            taggedTxId = outId
+        } else {
+            outTx = TransactionEntity(
+                id = outId,
+                amount = amount.negate(),
+                currencyCode = currency,
+                date = draft.date,
+                note = "$transferMemo (還款至 ${currentReceiveAccount.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = inId,
+                transferGroupId = transferGroupId,
+                transferSide = TransferSide.Outgoing,
+                createdAt = now,
+                updatedAt = now,
+                accountId = currentParticipant.debtAccountId,
+                categoryId = null
+            )
+            inTx = TransactionEntity(
+                id = inId,
+                amount = amount,
+                currencyCode = currency,
+                date = draft.date,
+                note = "$transferMemo (來自 ${currentParticipant.name})",
+                photoPath = null,
+                type = TransactionType.Transfer,
+                linkedTransactionId = outId,
+                transferGroupId = transferGroupId,
+                transferSide = TransferSide.Incoming,
+                createdAt = now,
+                updatedAt = now,
+                accountId = currentReceiveAccount.id,
+                categoryId = currentCategory?.id
+            )
+            taggedTxId = inId
+        }
+
+        transactionDao.upsertAll(listOf(outTx, inTx))
+        if (draft.tagIds.isNotEmpty()) {
+            transactionDao.insertTransactionTags(
+                draft.tagIds.distinct().map { tagId -> TransactionTagCrossRef(taggedTxId, tagId) }
+            )
+        }
+        advanceDao.upsertParticipants(
+            listOf(
+                currentParticipant.copy(
+                    repaidAmount = (currentParticipant.repaidAmount + normalized)
+                        .min(currentParticipant.owedAmount),
+                    updatedAt = now
+                )
+            )
+        )
+        advanceDao.upsertCase(currentCase.copy(updatedAt = now))
+        advanceDao.upsertRepayment(
+            AdvanceRepaymentEntity(
                 id = UUID.randomUUID(),
-                amount = amount.abs(),
-                currencyCode = currencyCode,
+                amount = amount,
+                currencyCode = currency,
                 normalizedAmount = normalized,
-                date = date,
-                note = note.trim(),
+                date = draft.date,
+                note = draft.note.trim(),
                 linkedTransferGroupId = transferGroupId,
                 createdAt = now,
-                advanceCaseId = advanceCase.id,
-                participantId = participant.id,
-                receivedAccountId = receiveAccount.id
+                advanceCaseId = currentCase.id,
+                participantId = currentParticipant.id,
+                receivedAccountId = currentReceiveAccount.id
             )
-            advanceDao.upsertRepayment(repayment)
+        )
+    }
+
+    suspend fun updateAdvanceSelfExpense(draft: AdvanceSelfExpenseEditDraft) {
+        require(draft.amount > BigDecimal.ZERO) { "實際扣款金額必須大於 0。" }
+        require(draft.normalizedAmount > BigDecimal.ZERO) { "案件中的自己份額必須大於 0。" }
+        require(draft.currencyCode.isNotBlank()) { "請選擇實際扣款幣種。" }
+
+        database.withTransaction {
+            val advanceCase = requireNotNull(
+                advanceDao.getAllCases().firstOrNull { it.id == draft.caseId }
+            ) { "找不到代墊案件。" }
+            val transactionId = requireNotNull(advanceCase.selfExpenseTransactionId) {
+                "找不到代墊案件對應的自己份額支出。"
+            }
+            val transaction = requireNotNull(transactionDao.getTransaction(transactionId)?.transaction) {
+                "找不到代墊案件對應的自己份額支出。"
+            }
+            require(
+                transaction.type == TransactionType.Expense &&
+                    transaction.transferGroupId == null &&
+                    transaction.linkedTransactionId == null
+            ) { "自己份額支出結構不完整，無法安全編輯。" }
+
+            val account = requireNotNull(accountDao.getAccount(draft.accountId)) {
+                "找不到所選支出帳戶。"
+            }
+            require(account.type != AccountType.Debt && !account.isArchived) {
+                "請選擇未歸檔的非借貸帳戶。"
+            }
+            val category = draft.categoryId?.let { categoryId ->
+                requireNotNull(categoryDao.getCategory(categoryId)) { "找不到所選分類。" }
+            }
+            require(category == null || category.kind.supports(TransactionType.Expense)) {
+                "自己的份額只能使用支出分類。"
+            }
+
+            val now = Instant.now()
+            transactionDao.upsert(
+                transaction.copy(
+                    amount = draft.amount.abs().negate(),
+                    currencyCode = draft.currencyCode.trim().uppercase(),
+                    date = draft.date,
+                    note = draft.note.trim(),
+                    updatedAt = now,
+                    accountId = account.id,
+                    categoryId = category?.id
+                )
+            )
+            transactionDao.clearTransactionTags(transaction.id)
+            if (draft.tagIds.isNotEmpty()) {
+                transactionDao.insertTransactionTags(
+                    draft.tagIds.distinct().map { tagId ->
+                        TransactionTagCrossRef(transaction.id, tagId)
+                    }
+                )
+            }
+            advanceDao.upsertCase(
+                advanceCase.copy(
+                    myShareAmount = draft.normalizedAmount.abs(),
+                    expenseCategoryId = category?.id,
+                    updatedAt = now
+                )
+            )
+            syncAllBudgetHistory()
+        }
+    }
+
+    suspend fun updateAdvanceRepayment(draft: AdvanceRepaymentEditDraft) {
+        require(draft.amount > BigDecimal.ZERO) { "還款金額必須大於 0。" }
+        require(draft.normalizedAmount > BigDecimal.ZERO) { "沖銷金額必須大於 0。" }
+        require(draft.currencyCode.isNotBlank()) { "請選擇還款幣種。" }
+
+        database.withTransaction {
+            val repayment = requireNotNull(
+                advanceDao.getAllRepayments().firstOrNull { it.id == draft.repaymentId }
+            ) { "找不到還款紀錄。" }
+            val participant = requireNotNull(
+                repayment.participantId?.let { participantId ->
+                    advanceDao.getAllParticipants().firstOrNull { it.id == participantId }
+                }
+            ) { "找不到還款對象。" }
+            val advanceCase = requireNotNull(
+                repayment.advanceCaseId?.let { caseId ->
+                    advanceDao.getAllCases().firstOrNull { it.id == caseId }
+                }
+            ) { "找不到代墊案件。" }
+            require(
+                !isMutualDebtOffset(repayment.note) &&
+                    !isManualDebtSettlement(repayment.note)
+            ) {
+                "債務抵銷或跨幣種平賬必須整組撤銷，不能當作普通還款編輯。"
+            }
+            val receiveAccount = requireNotNull(accountDao.getAccount(draft.receiveAccountId)) {
+                "找不到所選帳戶。"
+            }
+            require(receiveAccount.type != AccountType.Debt && !receiveAccount.isArchived) {
+                "請選擇未歸檔的非借貸帳戶。"
+            }
+            val direction = advanceSettlementDirectionLocked(participant)
+            val category = draft.categoryId?.let { categoryId ->
+                requireNotNull(categoryDao.getCategory(categoryId)) { "找不到所選分類。" }
+            }
+            require(
+                category == null ||
+                    category.kind.supports(
+                        if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                            TransactionType.Income
+                        } else {
+                            TransactionType.Expense
+                        }
+                    )
+            ) { "所選分類與這筆還款方向不相符。" }
+            val groupId = requireNotNull(repayment.linkedTransferGroupId) { "此還款沒有可編輯的轉帳分錄。" }
+            val group = transactionDao.getTransferGroup(groupId)
+            require(group.size == 2) { "還款轉帳分錄不完整。" }
+
+            val otherNormalized = advanceDao.getAllRepayments()
+                .filter { it.participantId == participant.id && it.id != repayment.id }
+                .fold(BigDecimal.ZERO) { total, item -> total + item.normalizedAmount }
+            val updatedRepaid = otherNormalized + draft.normalizedAmount.abs()
+            require(updatedRepaid - participant.owedAmount <= BigDecimal("0.0001")) {
+                "沖銷金額超過未還餘額。"
+            }
+
+            val debtAccountId = requireNotNull(participant.debtAccountId) { "找不到債務對象帳戶。" }
+            val existingBySide = group.associateBy { effectiveTransferSide(it.transaction) }
+            val outgoing = requireNotNull(existingBySide[TransferSide.Outgoing]?.transaction)
+            val incoming = requireNotNull(existingBySide[TransferSide.Incoming]?.transaction)
+            val amount = draft.amount.abs()
+            val currency = draft.currencyCode.trim().uppercase()
+            val memo = draft.note.trim().ifBlank { advanceCase.title }
+            val now = Instant.now()
+
+            val updatedOutgoing: TransactionEntity
+            val updatedIncoming: TransactionEntity
+            val ownLegId: UUID
+            when (direction) {
+                AdvanceSettlementDirection.IAdvancedOthers -> {
+                    updatedOutgoing = outgoing.copy(
+                        amount = amount.negate(),
+                        currencyCode = currency,
+                        date = draft.date,
+                        note = "$memo (還款至 ${receiveAccount.name})",
+                        linkedTransactionId = incoming.id,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Outgoing,
+                        updatedAt = now,
+                        accountId = debtAccountId,
+                        categoryId = null
+                    )
+                    updatedIncoming = incoming.copy(
+                        amount = amount,
+                        currencyCode = currency,
+                        date = draft.date,
+                        note = "$memo (來自 ${participant.name})",
+                        linkedTransactionId = outgoing.id,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Incoming,
+                        updatedAt = now,
+                        accountId = receiveAccount.id,
+                        categoryId = category?.id
+                    )
+                    ownLegId = incoming.id
+                }
+                AdvanceSettlementDirection.OthersAdvancedMe -> {
+                    updatedOutgoing = outgoing.copy(
+                        amount = amount.negate(),
+                        currencyCode = currency,
+                        date = draft.date,
+                        note = "$memo (還款給 ${participant.name})",
+                        linkedTransactionId = incoming.id,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Outgoing,
+                        updatedAt = now,
+                        accountId = receiveAccount.id,
+                        categoryId = category?.id
+                    )
+                    updatedIncoming = incoming.copy(
+                        amount = amount,
+                        currencyCode = currency,
+                        date = draft.date,
+                        note = "$memo (來自 ${receiveAccount.name})",
+                        linkedTransactionId = outgoing.id,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Incoming,
+                        updatedAt = now,
+                        accountId = debtAccountId,
+                        categoryId = null
+                    )
+                    ownLegId = outgoing.id
+                }
+            }
+
+            transactionDao.upsertAll(listOf(updatedOutgoing, updatedIncoming))
+            group.forEach { transactionDao.clearTransactionTags(it.transaction.id) }
+            if (draft.tagIds.isNotEmpty()) {
+                transactionDao.insertTransactionTags(
+                    draft.tagIds.distinct().map { tagId -> TransactionTagCrossRef(ownLegId, tagId) }
+                )
+            }
+            advanceDao.upsertRepayment(
+                repayment.copy(
+                    amount = amount,
+                    currencyCode = currency,
+                    normalizedAmount = draft.normalizedAmount.abs(),
+                    date = draft.date,
+                    note = draft.note.trim(),
+                    receivedAccountId = receiveAccount.id
+                )
+            )
+            advanceDao.upsertParticipants(
+                listOf(
+                    participant.copy(
+                        repaidAmount = updatedRepaid.min(participant.owedAmount),
+                        updatedAt = now
+                    )
+                )
+            )
+            advanceDao.upsertCase(advanceCase.copy(updatedAt = now))
+        }
+    }
+
+    suspend fun rollbackAdvanceRepayment(repaymentId: UUID) {
+        database.withTransaction {
+            val repayment = requireNotNull(
+                advanceDao.getAllRepayments().firstOrNull { it.id == repaymentId }
+            ) { "找不到還款紀錄。" }
+            require(
+                !isMutualDebtOffset(repayment.note) &&
+                    !isManualDebtSettlement(repayment.note)
+            ) {
+                "債務抵銷或跨幣種平賬必須整組撤銷，不能當作普通還款單筆沖銷。"
+            }
+            rollbackRepayments(listOf(repayment))
+            syncAllBudgetHistory()
+        }
+    }
+
+    suspend fun updateAdvanceParticipantOwedAmount(participantId: UUID, newOwedAmount: BigDecimal) {
+        require(newOwedAmount > BigDecimal.ZERO) { "欠款金額必須大於 0。" }
+
+        database.withTransaction {
+            val participant = requireNotNull(
+                advanceDao.getAllParticipants().firstOrNull { it.id == participantId }
+            ) { "找不到代墊對象。" }
+            require(newOwedAmount + BigDecimal("0.0001") >= participant.repaidAmount) {
+                "欠款金額不可低於已還金額。"
+            }
+            val advanceCase = requireNotNull(
+                participant.advanceCaseId?.let { caseId ->
+                    advanceDao.getAllCases().firstOrNull { it.id == caseId }
+                }
+            ) { "找不到代墊案件。" }
+            val groupId = requireNotNull(participant.initialTransferGroupId) { "找不到初始代墊分錄。" }
+            val group = transactionDao.getTransferGroup(groupId)
+            require(group.isNotEmpty()) { "找不到初始代墊分錄。" }
+            val amount = newOwedAmount.abs()
+            val now = Instant.now()
+            val direction = advanceSettlementDirectionLocked(participant)
+
+            val updatedTransactions = when (direction) {
+                AdvanceSettlementDirection.OthersAdvancedMe -> {
+                    require(group.size == 1) { "他人代墊我的初始支出結構不完整。" }
+                    listOf(
+                        group.single().transaction.copy(
+                            amount = amount.negate(),
+                            currencyCode = advanceCase.currencyCode,
+                            date = advanceCase.date,
+                            type = TransactionType.Expense,
+                            linkedTransactionId = null,
+                            transferGroupId = groupId,
+                            transferSide = TransferSide.Outgoing,
+                            updatedAt = now,
+                            accountId = participant.debtAccountId,
+                            categoryId = advanceCase.expenseCategoryId
+                        )
+                    )
+                }
+                AdvanceSettlementDirection.IAdvancedOthers -> {
+                    require(group.size == 2) { "我代墊他人的初始轉帳結構不完整。" }
+                    group.map { item ->
+                        val side = effectiveTransferSide(item.transaction)
+                        item.transaction.copy(
+                            amount = if (side == TransferSide.Outgoing) amount.negate() else amount,
+                            currencyCode = advanceCase.currencyCode,
+                            date = advanceCase.date,
+                            transferSide = side,
+                            updatedAt = now
+                        )
+                    }
+                }
+            }
+
+            transactionDao.upsertAll(updatedTransactions)
+            advanceDao.upsertParticipants(
+                listOf(
+                    participant.copy(
+                        owedAmount = amount,
+                        repaidAmount = participant.repaidAmount.min(amount),
+                        updatedAt = now
+                    )
+                )
+            )
+            advanceDao.upsertCase(advanceCase.copy(updatedAt = now))
+            syncAllBudgetHistory()
+        }
+    }
+
+    suspend fun updateAdvanceInitialMetadata(draft: AdvanceInitialMetadataEditDraft) {
+        database.withTransaction {
+            val advanceCase = requireNotNull(
+                advanceDao.getAllCases().firstOrNull { it.id == draft.caseId }
+            ) { "找不到代墊案件。" }
+            val participants = advanceDao.getAllParticipants()
+                .filter { it.advanceCaseId == advanceCase.id }
+            require(participants.isNotEmpty()) { "代墊案件沒有可更新的對象。" }
+
+            val direction = advanceSettlementDirectionLocked(participants.first())
+            val payerAccount = draft.payerAccountId?.let { accountId ->
+                requireNotNull(accountDao.getAccount(accountId)) { "找不到所選付款帳戶。" }
+            }
+            if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                require(payerAccount != null && payerAccount.type != AccountType.Debt && !payerAccount.isArchived) {
+                    "請選擇未歸檔的非借貸付款帳戶。"
+                }
+            }
+            val category = draft.categoryId?.let { categoryId ->
+                requireNotNull(categoryDao.getCategory(categoryId)) { "找不到所選分類。" }
+            }
+            if (direction == AdvanceSettlementDirection.OthersAdvancedMe) {
+                require(category == null || category.kind.supports(TransactionType.Expense)) {
+                    "他人代墊我的初始分錄只能使用支出分類。"
+                }
+            }
+
+            val entries = participants.map { participant ->
+                require(advanceSettlementDirectionLocked(participant) == direction) {
+                    "同一代墊案件含有不一致的方向。"
+                }
+                val groupId = requireNotNull(participant.initialTransferGroupId) {
+                    "找不到初始代墊分錄。"
+                }
+                val group = transactionDao.getTransferGroup(groupId)
+                when (direction) {
+                    AdvanceSettlementDirection.IAdvancedOthers -> require(group.size == 2) {
+                        "我代墊他人的初始轉帳結構不完整。"
+                    }
+                    AdvanceSettlementDirection.OthersAdvancedMe -> require(
+                        group.size == 1 && participant.debtAccountId != null
+                    ) {
+                        "他人代墊我的初始支出結構不完整。"
+                    }
+                }
+                participant to group
+            }
+
+            val memo = draft.note.trim()
+            val baseMemo = memo.ifBlank { advanceCase.title }
+            val now = Instant.now()
+            entries.forEach { (participant, group) ->
+                val amount = participant.owedAmount.abs()
+                when (direction) {
+                    AdvanceSettlementDirection.IAdvancedOthers -> {
+                        val outgoing = requireNotNull(
+                            group.firstOrNull {
+                                effectiveTransferSide(it.transaction) == TransferSide.Outgoing
+                            }?.transaction
+                        )
+                        val incoming = requireNotNull(
+                            group.firstOrNull {
+                                effectiveTransferSide(it.transaction) == TransferSide.Incoming
+                            }?.transaction
+                        )
+                        transactionDao.upsertAll(
+                            listOf(
+                                outgoing.copy(
+                                    amount = amount.negate(),
+                                    currencyCode = advanceCase.currencyCode,
+                                    date = draft.date,
+                                    note = "$baseMemo (代墊給 ${participant.name})",
+                                    linkedTransactionId = incoming.id,
+                                    transferSide = TransferSide.Outgoing,
+                                    updatedAt = now,
+                                    accountId = requireNotNull(payerAccount).id,
+                                    categoryId = null
+                                ),
+                                incoming.copy(
+                                    amount = amount,
+                                    currencyCode = advanceCase.currencyCode,
+                                    date = draft.date,
+                                    note = "$baseMemo (來自 ${payerAccount.name})",
+                                    linkedTransactionId = outgoing.id,
+                                    transferSide = TransferSide.Incoming,
+                                    updatedAt = now,
+                                    accountId = participant.debtAccountId,
+                                    categoryId = null
+                                )
+                            )
+                        )
+                        group.forEach { transactionDao.clearTransactionTags(it.transaction.id) }
+                    }
+                    AdvanceSettlementDirection.OthersAdvancedMe -> {
+                        val expense = group.single().transaction
+                        transactionDao.upsert(
+                            expense.copy(
+                                amount = amount.negate(),
+                                currencyCode = advanceCase.currencyCode,
+                                date = draft.date,
+                                note = "$baseMemo (他人代墊我：${participant.name})",
+                                type = TransactionType.Expense,
+                                linkedTransactionId = null,
+                                transferSide = TransferSide.Outgoing,
+                                updatedAt = now,
+                                accountId = participant.debtAccountId,
+                                categoryId = category?.id
+                            )
+                        )
+                        transactionDao.clearTransactionTags(expense.id)
+                        if (draft.tagIds.isNotEmpty()) {
+                            transactionDao.insertTransactionTags(
+                                draft.tagIds.distinct().map { tagId ->
+                                    TransactionTagCrossRef(expense.id, tagId)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            advanceDao.upsertCase(
+                advanceCase.copy(
+                    date = draft.date,
+                    note = memo,
+                    updatedAt = now,
+                    payerAccountId =
+                        if (direction == AdvanceSettlementDirection.IAdvancedOthers) payerAccount?.id else null,
+                    expenseCategoryId =
+                        if (direction == AdvanceSettlementDirection.OthersAdvancedMe) category?.id
+                        else advanceCase.expenseCategoryId
+                )
+            )
+            syncAllBudgetHistory()
         }
     }
 
@@ -2288,6 +2861,26 @@ class AccountingRepository(
             ?: if (transaction.amount < BigDecimal.ZERO) TransferSide.Outgoing else TransferSide.Incoming
     }
 
+    private suspend fun advanceSettlementDirectionLocked(
+        participant: AdvanceParticipantEntity
+    ): AdvanceSettlementDirection {
+        val groupId = participant.initialTransferGroupId
+            ?: return AdvanceSettlementDirection.IAdvancedOthers
+        val group = transactionDao.getTransferGroup(groupId)
+        val outgoing = group.firstOrNull {
+            effectiveTransferSide(it.transaction) == TransferSide.Outgoing
+        }?.transaction ?: return AdvanceSettlementDirection.IAdvancedOthers
+
+        return if (
+            outgoing.accountId == participant.debtAccountId ||
+            outgoing.note.replace(" ", "").contains("(他人代墊我")
+        ) {
+            AdvanceSettlementDirection.OthersAdvancedMe
+        } else {
+            AdvanceSettlementDirection.IAdvancedOthers
+        }
+    }
+
     private fun transferReplacementNote(
         semantic: TransferGroupSemantic,
         side: TransferSide,
@@ -2328,30 +2921,40 @@ class AccountingRepository(
             .groupBy { it.transferGroupId }
 
         val now = Instant.now()
-        repayments.forEach { repayment ->
-            repayment.linkedTransferGroupId?.let { groupId ->
+        repayments.mapNotNull { it.linkedTransferGroupId }
+            .distinct()
+            .forEach { groupId ->
                 deleteTransactions(transactionByGroupId[groupId].orEmpty())
             }
 
-            repayment.participantId?.let { participantId ->
-                participantById[participantId]?.let { participant ->
-                    advanceDao.upsertParticipants(
-                        listOf(
-                            participant.copy(
-                                repaidAmount = (participant.repaidAmount - repayment.normalizedAmount).max(BigDecimal.ZERO),
-                                updatedAt = now
-                            )
+        repayments.mapNotNull { it.participantId }
+            .distinct()
+            .forEach { participantId ->
+                val participant = participantById[participantId] ?: return@forEach
+                val rollbackAmount = repayments
+                    .filter { it.participantId == participantId }
+                    .fold(BigDecimal.ZERO) { total, repayment ->
+                        total + repayment.normalizedAmount
+                    }
+                advanceDao.upsertParticipants(
+                    listOf(
+                        participant.copy(
+                            repaidAmount = (participant.repaidAmount - rollbackAmount).max(BigDecimal.ZERO),
+                            updatedAt = now
                         )
                     )
-                }
+                )
             }
 
-            repayment.advanceCaseId?.let { caseId ->
+        repayments.mapNotNull { it.advanceCaseId }
+            .distinct()
+            .forEach { caseId ->
                 caseById[caseId]?.let { advanceCase ->
                     advanceDao.upsertCase(advanceCase.copy(updatedAt = now))
                 }
             }
 
+        repayments.forEach { repayment ->
             advanceDao.deleteRepayment(repayment)
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/SectionComponents.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/components/SectionComponents.kt
@@ -173,7 +173,12 @@ fun CurrencyPicker(
     onSelect: (String) -> Unit,
     buttonStyle: CurrencyButtonStyle = CurrencyButtonStyle.Tonal
 ) {
-    val currencies = listOf("HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP")
+    val standardCurrencies = listOf("HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP")
+    val currencies = if (selected in standardCurrencies) {
+        standardCurrencies
+    } else {
+        listOf(selected) + standardCurrencies
+    }
     val expanded = remember { mutableStateOf(false) }
     val onClick = { expanded.value = true }
     when (buttonStyle) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/routing/TransactionEditRouting.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/routing/TransactionEditRouting.kt
@@ -18,27 +18,35 @@ suspend fun resolveTransactionEditDestination(
     item: TransactionWithDetails
 ): TransactionEditDestination {
     val transaction = item.transaction
-    if (transaction.type != TransactionType.Transfer) {
-        return TransactionEditDestination.Ordinary(transaction.id.toString())
-    }
     if (TransactionSemantics.isDebtForgiveness(transaction.note)) {
         return TransactionEditDestination.Debt(transaction.id.toString())
     }
 
+    repository.findAdvanceCaseIdBySelfExpense(transaction.id)?.let { caseId ->
+        return TransactionEditDestination.Advance(caseId.toString())
+    }
+
     val groupId = transaction.transferGroupId
-        ?: return TransactionEditDestination.Ordinary(transaction.id.toString())
-    val classification = repository.classifyTransferGroup(groupId)
-    return when (classification?.semantic) {
-        TransferGroupSemantic.Debt ->
-            TransactionEditDestination.Debt(transaction.id.toString())
-        TransferGroupSemantic.AdvanceInitial,
-        TransferGroupSemantic.AdvanceRepayment -> {
-            val caseId = requireNotNull(classification.advanceCaseId) {
-                "代墊分錄缺少案件關聯。"
+    if (groupId != null) {
+        val classification = repository.classifyTransferGroup(groupId)
+        when (classification?.semantic) {
+            TransferGroupSemantic.Debt ->
+                return TransactionEditDestination.Debt(transaction.id.toString())
+            TransferGroupSemantic.AdvanceInitial,
+            TransferGroupSemantic.AdvanceRepayment -> {
+                val caseId = requireNotNull(classification.advanceCaseId) {
+                    "代墊分錄缺少案件關聯。"
+                }
+                return TransactionEditDestination.Advance(caseId.toString())
             }
-            TransactionEditDestination.Advance(caseId.toString())
+            TransferGroupSemantic.Ordinary,
+            null -> Unit
         }
-        TransferGroupSemantic.Ordinary,
-        null -> TransactionEditDestination.Transfer(groupId.toString())
+    }
+
+    return if (transaction.type == TransactionType.Transfer && groupId != null) {
+        TransactionEditDestination.Transfer(groupId.toString())
+    } else {
+        TransactionEditDestination.Ordinary(transaction.id.toString())
     }
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
@@ -1,5 +1,6 @@
 package org.duckdns.lhfser.aiaccounting.ui.screens
 
+import android.app.DatePickerDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
@@ -23,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.AccountType
@@ -30,8 +33,14 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceParticipantEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceRepaymentEntity
 import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TransactionWithDetails
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceInitialMetadataEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentCreateDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSelfExpenseEditDraft
 import org.duckdns.lhfser.aiaccounting.ui.LocalCurrencyService
 import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
 import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
@@ -42,12 +51,19 @@ import org.duckdns.lhfser.aiaccounting.ui.utils.toDateText
 import org.duckdns.lhfser.aiaccounting.ui.theme.AppSpacing
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.ZoneId
 import java.util.UUID
 
 private enum class RepaymentMode(val label: String) {
     Normal("一般"),
     Split("分拆 (1 -> 多)"),
     Merge("合併 (多 -> 1)")
+}
+
+private enum class RepaymentRecordKind(val label: String) {
+    Ordinary("還款"),
+    MutualDebtOffset("債務抵銷"),
+    ManualDebtSettlement("跨幣種平賬")
 }
 
 private data class RepaymentSplitLeg(
@@ -65,6 +81,7 @@ private data class RepaymentMergeLeg(
 
 @Composable
 fun AdvanceDetailScreen(caseId: String?) {
+    val context = LocalContext.current
     val repository = LocalRepository.current
     val currencyService = LocalCurrencyService.current
     val scope = rememberCoroutineScope()
@@ -95,6 +112,27 @@ fun AdvanceDetailScreen(caseId: String?) {
     var splitLegs by remember { mutableStateOf(listOf(RepaymentSplitLeg())) }
     var mergeLegs by remember { mutableStateOf(listOf(RepaymentMergeLeg())) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+    var repaymentDate by remember { mutableStateOf(Instant.now()) }
+    var editingRepayment by remember { mutableStateOf<AdvanceRepaymentEntity?>(null) }
+    var repaymentToRollback by remember { mutableStateOf<AdvanceRepaymentEntity?>(null) }
+    var participantToEdit by remember { mutableStateOf<AdvanceParticipantEntity?>(null) }
+    var editedParticipantAmount by remember { mutableStateOf("") }
+    var selfExpense by remember { mutableStateOf<TransactionWithDetails?>(null) }
+    var isEditingSelfExpense by remember { mutableStateOf(false) }
+    var selfExpenseAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var selfExpenseAmount by remember { mutableStateOf("") }
+    var selfExpenseCurrency by remember { mutableStateOf("HKD") }
+    var selfExpenseNormalizedAmount by remember { mutableStateOf("") }
+    var selfExpenseCategory by remember { mutableStateOf<CategoryEntity?>(null) }
+    var selfExpenseTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
+    var selfExpenseDate by remember { mutableStateOf(Instant.now()) }
+    var selfExpenseNote by remember { mutableStateOf("") }
+    var isEditingInitialMetadata by remember { mutableStateOf(false) }
+    var initialPayerAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var initialCategory by remember { mutableStateOf<CategoryEntity?>(null) }
+    var initialTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
+    var initialDate by remember { mutableStateOf(Instant.now()) }
+    var initialNote by remember { mutableStateOf("") }
 
     if (advanceCase == null) {
         Column(modifier = Modifier.padding(AppSpacing.screenHorizontal)) {
@@ -105,6 +143,7 @@ fun AdvanceDetailScreen(caseId: String?) {
 
     val caseData = advanceCase ?: return
     val caseCurrency = caseData.advanceCase.currencyCode
+    val selfExpenseCategories = categories.filter { it.kind.supports(TransactionType.Expense) }
     val directionalCategories = if (isBorrowedByMe) {
         categories.filter { it.kind.supports(TransactionType.Expense) }
     } else {
@@ -112,10 +151,41 @@ fun AdvanceDetailScreen(caseId: String?) {
     }
     val accountLabel = if (isBorrowedByMe) "付款帳戶" else "入帳帳戶"
 
-    LaunchedEffect(caseData.participants) {
-        if (selectedParticipant == null) {
-            selectedParticipant = caseData.participants.firstOrNull()
+    LaunchedEffect(caseData.advanceCase.id, receiveAccounts, categories) {
+        if (!isEditingInitialMetadata) {
+            initialPayerAccount = receiveAccounts.firstOrNull {
+                it.id == caseData.advanceCase.payerAccountId
+            }
+            initialCategory = categories.firstOrNull {
+                it.id == caseData.advanceCase.expenseCategoryId
+            }
+            initialDate = caseData.advanceCase.date
+            initialNote = caseData.advanceCase.note
         }
+    }
+
+    LaunchedEffect(caseData.advanceCase.selfExpenseTransactionId) {
+        val transactionId = caseData.advanceCase.selfExpenseTransactionId
+        val transaction = transactionId?.let { repository.getTransaction(it) }
+        selfExpense = transaction
+        if (!isEditingSelfExpense && transaction != null) {
+            selfExpenseAccount = transaction.account
+            selfExpenseAmount = transaction.transaction.amount.abs().stripTrailingZeros().toPlainString()
+            selfExpenseCurrency = transaction.transaction.currencyCode
+            selfExpenseNormalizedAmount =
+                caseData.advanceCase.myShareAmount.stripTrailingZeros().toPlainString()
+            selfExpenseCategory = transaction.category
+            selfExpenseTags = transaction.tags
+            selfExpenseDate = transaction.transaction.date
+            selfExpenseNote = transaction.transaction.note
+        }
+    }
+
+    LaunchedEffect(caseData.participants) {
+        val selectedParticipantId = selectedParticipant?.id
+        selectedParticipant = caseData.participants.firstOrNull {
+            it.id == selectedParticipantId
+        } ?: caseData.participants.firstOrNull()
         val firstParticipant = caseData.participants.firstOrNull()
         val groupId = firstParticipant?.initialTransferGroupId
         if (groupId != null) {
@@ -130,6 +200,13 @@ fun AdvanceDetailScreen(caseId: String?) {
                 outgoing.note.contains("(代墊給我") -> true
                 else -> false
             }
+            if (!isEditingInitialMetadata) {
+                initialTags = if (isBorrowedByMe) {
+                    transfers.firstOrNull()?.tags.orEmpty()
+                } else {
+                    emptyList()
+                }
+            }
         } else {
             isBorrowedByMe = false
         }
@@ -137,9 +214,12 @@ fun AdvanceDetailScreen(caseId: String?) {
 
     LaunchedEffect(receiveAccounts) {
         if (selectedReceiveAccount == null) {
-            selectedReceiveAccount = receiveAccounts.firstOrNull()
+            val defaultAccount = receiveAccounts.firstOrNull()
+            selectedReceiveAccount = defaultAccount
+            if (defaultAccount != null) {
+                selectedCurrency = defaultAccount.currency
+            }
         }
-        selectedReceiveAccount?.let { selectedCurrency = it.currency }
         if (splitLegs.firstOrNull()?.account == null) {
             val defaultAccount = receiveAccounts.firstOrNull()
             if (defaultAccount != null) {
@@ -159,6 +239,7 @@ fun AdvanceDetailScreen(caseId: String?) {
     val remaining = selectedParticipant?.let {
         (it.owedAmount - it.repaidAmount).max(BigDecimal.ZERO)
     } ?: BigDecimal.ZERO
+    val editableRemaining = remaining + (editingRepayment?.normalizedAmount ?: BigDecimal.ZERO)
     val parsedAmount = parsePositive(amountInput)
     val isCrossCurrencyRepayment = !selectedCurrency.equals(caseCurrency, ignoreCase = true)
     val settlementEstimate = parsedAmount?.let { currencyService.estimate(it, selectedCurrency, caseCurrency) }
@@ -204,6 +285,248 @@ fun AdvanceDetailScreen(caseId: String?) {
                     Text("日期：${caseData.advanceCase.date.toDateText()}")
                     Text("幣種：$caseCurrency")
                     Text("備註：${caseData.advanceCase.note.ifBlank { "-" }}")
+                    if (!isEditingInitialMetadata) {
+                        TextButton(onClick = {
+                            initialPayerAccount = receiveAccounts.firstOrNull {
+                                it.id == caseData.advanceCase.payerAccountId
+                            }
+                            initialCategory = categories.firstOrNull {
+                                it.id == caseData.advanceCase.expenseCategoryId
+                            }
+                            initialDate = caseData.advanceCase.date
+                            initialNote = caseData.advanceCase.note
+                            scope.launch {
+                                val firstGroupId =
+                                    caseData.participants.firstOrNull()?.initialTransferGroupId
+                                initialTags = if (isBorrowedByMe && firstGroupId != null) {
+                                    repository.getTransferGroup(firstGroupId).firstOrNull()?.tags.orEmpty()
+                                } else {
+                                    emptyList()
+                                }
+                            }
+                            isEditingInitialMetadata = true
+                        }) {
+                            Text("編輯案件記帳資料")
+                        }
+                    } else {
+                        if (isBorrowedByMe) {
+                            CategoryPicker(
+                                categories = selfExpenseCategories,
+                                selected = initialCategory,
+                                onSelect = { initialCategory = it }
+                            )
+                            TagPicker(
+                                tags = tags,
+                                selected = initialTags,
+                                onChange = { initialTags = it }
+                            )
+                            Text(
+                                "他人代墊我不會使用自己的付款帳戶。",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        } else {
+                            AccountPicker(
+                                label = "付款帳戶",
+                                accounts = receiveAccounts,
+                                selected = initialPayerAccount,
+                                onSelect = { initialPayerAccount = it }
+                            )
+                        }
+                        TextButton(onClick = {
+                            showRepaymentDatePicker(context, initialDate) {
+                                initialDate = it
+                            }
+                        }) {
+                            Text("日期：${initialDate.toDateText()}")
+                        }
+                        OutlinedTextField(
+                            value = initialNote,
+                            onValueChange = { initialNote = it },
+                            label = { Text("備註") },
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                            ),
+                            keyboardActions =
+                                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = {
+                                    scope.launch {
+                                        runCatching {
+                                            repository.updateAdvanceInitialMetadata(
+                                                AdvanceInitialMetadataEditDraft(
+                                                    caseId = caseData.advanceCase.id,
+                                                    payerAccountId =
+                                                        if (isBorrowedByMe) null else initialPayerAccount?.id,
+                                                    date = initialDate,
+                                                    note = initialNote,
+                                                    categoryId =
+                                                        if (isBorrowedByMe) initialCategory?.id else null,
+                                                    tagIds =
+                                                        if (isBorrowedByMe) initialTags.map { it.id }
+                                                        else emptyList()
+                                                )
+                                            )
+                                        }.onSuccess {
+                                            advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
+                                            isEditingInitialMetadata = false
+                                            errorMessage = null
+                                        }.onFailure {
+                                            errorMessage = it.localizedMessage ?: "無法更新案件資料。"
+                                        }
+                                    }
+                                },
+                                enabled = isBorrowedByMe || initialPayerAccount != null
+                            ) {
+                                Text("儲存")
+                            }
+                            TextButton(onClick = { isEditingInitialMetadata = false }) {
+                                Text("取消")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        selfExpense?.let { expense ->
+            item {
+                Text("自己的份額", style = MaterialTheme.typography.titleMedium)
+                SectionCard {
+                    if (!isEditingSelfExpense) {
+                        Text(
+                            expense.transaction.amount.abs()
+                                .asCurrencyText(expense.transaction.currencyCode),
+                            style = MaterialTheme.typography.titleLarge
+                        )
+                        Text(
+                            "案件份額 ${caseData.advanceCase.myShareAmount.asCurrencyText(caseCurrency)}",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            expense.account?.name ?: "未指定帳戶",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        TextButton(onClick = {
+                            selfExpenseAccount = expense.account
+                            selfExpenseAmount =
+                                expense.transaction.amount.abs().stripTrailingZeros().toPlainString()
+                            selfExpenseCurrency = expense.transaction.currencyCode
+                            selfExpenseNormalizedAmount =
+                                caseData.advanceCase.myShareAmount.stripTrailingZeros().toPlainString()
+                            selfExpenseCategory = expense.category
+                            selfExpenseTags = expense.tags
+                            selfExpenseDate = expense.transaction.date
+                            selfExpenseNote = expense.transaction.note
+                            isEditingSelfExpense = true
+                        }) {
+                            Text("編輯自己的份額")
+                        }
+                    } else {
+                        AccountPicker(
+                            label = "支出帳戶",
+                            accounts = receiveAccounts,
+                            selected = selfExpenseAccount,
+                            onSelect = { selfExpenseAccount = it }
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            CurrencyPicker(
+                                selected = selfExpenseCurrency,
+                                onSelect = { selfExpenseCurrency = it },
+                                buttonStyle = CurrencyButtonStyle.Text
+                            )
+                            OutlinedTextField(
+                                value = selfExpenseAmount,
+                                onValueChange = { selfExpenseAmount = sanitizeAmount(it) },
+                                label = { Text("實際扣款") },
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        OutlinedTextField(
+                            value = selfExpenseNormalizedAmount,
+                            onValueChange = { selfExpenseNormalizedAmount = sanitizeAmount(it) },
+                            label = { Text("案件中的自己份額 ($caseCurrency)") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Text(
+                            "實際扣款可用其他幣種；案件份額用於代墊摘要。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        CategoryPicker(
+                            categories = selfExpenseCategories,
+                            selected = selfExpenseCategory,
+                            onSelect = { selfExpenseCategory = it }
+                        )
+                        TagPicker(
+                            tags = tags,
+                            selected = selfExpenseTags,
+                            onChange = { selfExpenseTags = it }
+                        )
+                        TextButton(onClick = {
+                            showRepaymentDatePicker(context, selfExpenseDate) {
+                                selfExpenseDate = it
+                            }
+                        }) {
+                            Text("日期：${selfExpenseDate.toDateText()}")
+                        }
+                        OutlinedTextField(
+                            value = selfExpenseNote,
+                            onValueChange = { selfExpenseNote = it },
+                            label = { Text("備註") },
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                            ),
+                            keyboardActions =
+                                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = {
+                                    val account = selfExpenseAccount ?: return@Button
+                                    val actualAmount = parsePositive(selfExpenseAmount) ?: return@Button
+                                    val normalizedAmount =
+                                        parsePositive(selfExpenseNormalizedAmount) ?: return@Button
+                                    scope.launch {
+                                        runCatching {
+                                            repository.updateAdvanceSelfExpense(
+                                                AdvanceSelfExpenseEditDraft(
+                                                    caseId = caseData.advanceCase.id,
+                                                    accountId = account.id,
+                                                    amount = actualAmount,
+                                                    currencyCode = selfExpenseCurrency,
+                                                    normalizedAmount = normalizedAmount,
+                                                    date = selfExpenseDate,
+                                                    note = selfExpenseNote,
+                                                    categoryId = selfExpenseCategory?.id,
+                                                    tagIds = selfExpenseTags.map { it.id }
+                                                )
+                                            )
+                                        }.onSuccess {
+                                            advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
+                                            selfExpense = repository.getTransaction(expense.transaction.id)
+                                            isEditingSelfExpense = false
+                                            errorMessage = null
+                                        }.onFailure {
+                                            errorMessage = it.localizedMessage ?: "無法更新自己的份額。"
+                                        }
+                                    }
+                                },
+                                enabled = selfExpenseAccount != null &&
+                                    parsePositive(selfExpenseAmount) != null &&
+                                    parsePositive(selfExpenseNormalizedAmount) != null
+                            ) {
+                                Text("儲存")
+                            }
+                            TextButton(onClick = { isEditingSelfExpense = false }) {
+                                Text("取消")
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -212,13 +535,99 @@ fun AdvanceDetailScreen(caseId: String?) {
             Text("代墊對象", style = MaterialTheme.typography.titleMedium)
             SectionCard {
                 caseData.participants.forEach { participant ->
-                    ParticipantRow(participant = participant, currency = caseCurrency)
+                    ParticipantRow(
+                        participant = participant,
+                        currency = caseCurrency,
+                        onEdit = {
+                            participantToEdit = participant
+                            editedParticipantAmount = participant.owedAmount.stripTrailingZeros().toPlainString()
+                        }
+                    )
                 }
             }
         }
 
         item {
-            Text("記錄還款", style = MaterialTheme.typography.titleMedium)
+            Text("還款紀錄", style = MaterialTheme.typography.titleMedium)
+            SectionCard {
+                if (caseData.repayments.isEmpty()) {
+                    Text("尚未記錄還款", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                } else {
+                    caseData.repayments.sortedByDescending { it.date }.forEach { repayment ->
+                        val recordKind = repaymentRecordKind(repayment.note)
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 6.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                "${recordKind.label} · ${repayment.amount.asCurrencyText(repayment.currencyCode)} · 沖銷 ${repayment.normalizedAmount.asCurrencyText(caseCurrency)}",
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            Text(
+                                repayment.date.toDateText(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                if (recordKind == RepaymentRecordKind.Ordinary &&
+                                    repayment.linkedTransferGroupId != null
+                                ) {
+                                    TextButton(onClick = {
+                                        scope.launch {
+                                            val participant = caseData.participants.firstOrNull {
+                                                it.id == repayment.participantId
+                                            } ?: return@launch
+                                            val account = receiveAccounts.firstOrNull {
+                                                it.id == repayment.receivedAccountId
+                                            }
+                                            val group = repository.getTransferGroup(repayment.linkedTransferGroupId)
+                                            val ownLeg = group.firstOrNull {
+                                                if (isBorrowedByMe) {
+                                                    it.transaction.accountId == repayment.receivedAccountId &&
+                                                        (it.transaction.transferSide == org.duckdns.lhfser.aiaccounting.core.model.TransferSide.Outgoing ||
+                                                            it.transaction.amount < BigDecimal.ZERO)
+                                                } else {
+                                                    it.transaction.accountId == repayment.receivedAccountId &&
+                                                        (it.transaction.transferSide == org.duckdns.lhfser.aiaccounting.core.model.TransferSide.Incoming ||
+                                                            it.transaction.amount > BigDecimal.ZERO)
+                                                }
+                                            }
+                                            editingRepayment = repayment
+                                            selectedParticipant = participant
+                                            selectedReceiveAccount = account
+                                            amountInput = repayment.amount.stripTrailingZeros().toPlainString()
+                                            selectedCurrency = repayment.currencyCode
+                                            settlementAmountInput = repayment.normalizedAmount.stripTrailingZeros().toPlainString()
+                                            settlementManuallyEdited = true
+                                            repaymentDate = repayment.date
+                                            note = repayment.note
+                                            mode = RepaymentMode.Normal
+                                            selectedCategory = categories.firstOrNull {
+                                                it.id == ownLeg?.transaction?.categoryId
+                                            }
+                                            selectedTags = ownLeg?.tags.orEmpty()
+                                        }
+                                    }) {
+                                        Text("編輯")
+                                    }
+                                }
+                                TextButton(onClick = { repaymentToRollback = repayment }) {
+                                    Text("撤銷", color = MaterialTheme.colorScheme.error)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Text(
+                if (editingRepayment == null) "記錄還款" else "編輯還款",
+                style = MaterialTheme.typography.titleMedium
+            )
             SectionCard {
                 ParticipantPicker(
                     participants = caseData.participants,
@@ -226,14 +635,16 @@ fun AdvanceDetailScreen(caseId: String?) {
                     onSelect = { selectedParticipant = it }
                 )
 
-                Text("模式", style = MaterialTheme.typography.titleSmall)
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    RepaymentMode.values().forEach { item ->
-                        FilterChip(
-                            selected = mode == item,
-                            onClick = { mode = item },
-                            label = { Text(item.label) }
-                        )
+                if (editingRepayment == null) {
+                    Text("模式", style = MaterialTheme.typography.titleSmall)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        RepaymentMode.values().forEach { item ->
+                            FilterChip(
+                                selected = mode == item,
+                                onClick = { mode = item },
+                                label = { Text(item.label) }
+                            )
+                        }
                     }
                 }
 
@@ -242,10 +653,7 @@ fun AdvanceDetailScreen(caseId: String?) {
                         label = accountLabel,
                         accounts = receiveAccounts,
                         selected = selectedReceiveAccount,
-                        onSelect = { acc ->
-                            selectedReceiveAccount = acc
-                            if (acc != null) selectedCurrency = acc.currency
-                        }
+                        onSelect = { selectedReceiveAccount = it }
                     )
                 }
 
@@ -318,6 +726,11 @@ fun AdvanceDetailScreen(caseId: String?) {
                     selectedCategory = it
                 }
                 TagPicker(tags = tags, selected = selectedTags, onChange = { selectedTags = it })
+                TextButton(onClick = {
+                    showRepaymentDatePicker(context, repaymentDate) { repaymentDate = it }
+                }) {
+                    Text("日期：${repaymentDate.toDateText()}")
+                }
                 OutlinedTextField(
                     value = note,
                     onValueChange = { note = it },
@@ -331,105 +744,162 @@ fun AdvanceDetailScreen(caseId: String?) {
                     onClick = {
                         scope.launch {
                             val participant = selectedParticipant ?: return@launch
-                            when (mode) {
-	                                RepaymentMode.Normal -> {
-	                                    val receiveAccount = selectedReceiveAccount ?: return@launch
-	                                    val amount = parsePositive(amountInput) ?: return@launch
-	                                    val normalizedAmount = parsedSettlementAmount ?: return@launch
-	                                    if (normalizedAmount - remaining > BigDecimal("0.0001")) {
-	                                        errorMessage = "沖銷金額超過未還餘額。"
-	                                        return@launch
-	                                    }
-	                                    recordSingleRepayment(
-	                                        repository = repository,
-	                                        advanceCase = caseData,
-	                                        participant = participant,
-	                                        receiveAccount = receiveAccount,
-	                                        amount = amount,
-	                                        currency = selectedCurrency,
-	                                        normalizedAmount = normalizedAmount,
-	                                        note = note,
-	                                        category = selectedCategory,
-	                                        tagIds = selectedTags.map { it.id },
-                                        isBorrowedByMe = isBorrowedByMe
-                                    )
-                                }
-                                RepaymentMode.Split -> {
-                                    val legs = splitLegs.mapNotNull { leg ->
-                                        val account = leg.account ?: return@mapNotNull null
-	                                        val amount = parsePositive(leg.amount) ?: return@mapNotNull null
-	                                        Triple(account, amount, leg.currency)
-	                                    }
-	                                    val normalizedLegs = legs.map { leg ->
-	                                        normalizedAmount(currencyService, leg.second, leg.third, caseCurrency)
-	                                    }
-	                                    if (normalizedLegs.any { it == null }) {
-	                                        errorMessage = "暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。"
-	                                        return@launch
-	                                    }
-	                                    if (!validateTotal(remaining, normalizedLegs.filterNotNull())) {
-	                                        errorMessage = "分拆總金額超過未還餘額。"
-	                                        return@launch
-	                                    }
-	                                    legs.forEachIndexed { index, leg ->
-	                                        recordSingleRepayment(
-	                                            repository = repository,
-	                                            advanceCase = caseData,
-	                                            participant = participant,
-	                                            receiveAccount = leg.first,
-	                                            amount = leg.second,
-	                                            currency = leg.third,
-	                                            normalizedAmount = normalizedLegs[index] ?: return@launch,
-	                                            note = indexedNote(note, "分拆", index, legs.size),
-	                                            category = selectedCategory,
-	                                            tagIds = selectedTags.map { it.id },
-                                            isBorrowedByMe = isBorrowedByMe
+                            try {
+                                when (mode) {
+                                    RepaymentMode.Normal -> {
+                                        val receiveAccount = selectedReceiveAccount ?: return@launch
+                                        val amount = parsePositive(amountInput) ?: return@launch
+                                        val normalizedAmount = parsedSettlementAmount ?: return@launch
+                                        if (normalizedAmount - editableRemaining > BigDecimal("0.0001")) {
+                                            errorMessage = "沖銷金額超過未還餘額。"
+                                            return@launch
+                                        }
+                                        val existingRepayment = editingRepayment
+                                        if (existingRepayment == null) {
+                                            recordSingleRepayment(
+                                                repository = repository,
+                                                advanceCase = caseData,
+                                                participant = participant,
+                                                receiveAccount = receiveAccount,
+                                                amount = amount,
+                                                currency = selectedCurrency,
+                                                normalizedAmount = normalizedAmount,
+                                                date = repaymentDate,
+                                                note = note,
+                                                category = selectedCategory,
+                                                tagIds = selectedTags.map { it.id }
+                                            )
+                                        } else {
+                                            repository.updateAdvanceRepayment(
+                                                AdvanceRepaymentEditDraft(
+                                                    repaymentId = existingRepayment.id,
+                                                    receiveAccountId = receiveAccount.id,
+                                                    amount = amount,
+                                                    currencyCode = selectedCurrency,
+                                                    normalizedAmount = normalizedAmount,
+                                                    date = repaymentDate,
+                                                    note = note,
+                                                    categoryId = selectedCategory?.id,
+                                                    tagIds = selectedTags.map { it.id }
+                                                )
+                                            )
+                                        }
+                                    }
+                                    RepaymentMode.Split -> {
+                                        val legs = mutableListOf<Triple<AccountEntity, BigDecimal, String>>()
+                                        splitLegs.forEach { leg ->
+                                            val account = leg.account
+                                            val amount = parsePositive(leg.amount)
+                                            if (account == null || amount == null) {
+                                                errorMessage = "分拆模式下，請為每一項選擇帳戶並填入金額。"
+                                                return@launch
+                                            }
+                                            legs += Triple(account, amount, leg.currency)
+                                        }
+                                        val normalizedLegs = legs.map { leg ->
+                                            normalizedAmount(currencyService, leg.second, leg.third, caseCurrency)
+                                        }
+                                        if (normalizedLegs.any { it == null }) {
+                                            errorMessage = "暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。"
+                                            return@launch
+                                        }
+                                        if (!validateTotal(remaining, normalizedLegs.filterNotNull())) {
+                                            errorMessage = "分拆總金額超過未還餘額。"
+                                            return@launch
+                                        }
+                                        repository.recordAdvanceRepayments(
+                                            advanceCaseId = caseData.advanceCase.id,
+                                            participantId = participant.id,
+                                            drafts = legs.mapIndexed { index, leg ->
+                                                AdvanceRepaymentCreateDraft(
+                                                    receiveAccountId = leg.first.id,
+                                                    amount = leg.second,
+                                                    normalizedAmount =
+                                                        normalizedLegs[index] ?: return@launch,
+                                                    currencyCode = leg.third,
+                                                    date = repaymentDate,
+                                                    note = indexedNote(note, "分拆", index, legs.size),
+                                                    categoryId = selectedCategory?.id,
+                                                    tagIds = selectedTags.map { it.id }
+                                                )
+                                            }
+                                        )
+                                    }
+                                    RepaymentMode.Merge -> {
+                                        val receiveAccount = selectedReceiveAccount ?: return@launch
+                                        val legs = mutableListOf<Pair<BigDecimal, String>>()
+                                        mergeLegs.forEach { leg ->
+                                            val amount = parsePositive(leg.amount)
+                                            if (amount == null) {
+                                                errorMessage = "合併模式下，請為每一項填入金額。"
+                                                return@launch
+                                            }
+                                            legs += amount to leg.currency
+                                        }
+                                        val normalizedLegs = legs.map { leg ->
+                                            normalizedAmount(currencyService, leg.first, leg.second, caseCurrency)
+                                        }
+                                        if (normalizedLegs.any { it == null }) {
+                                            errorMessage = "暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。"
+                                            return@launch
+                                        }
+                                        if (!validateTotal(remaining, normalizedLegs.filterNotNull())) {
+                                            errorMessage = "合併總金額超過未還餘額。"
+                                            return@launch
+                                        }
+                                        repository.recordAdvanceRepayments(
+                                            advanceCaseId = caseData.advanceCase.id,
+                                            participantId = participant.id,
+                                            drafts = legs.mapIndexed { index, item ->
+                                                AdvanceRepaymentCreateDraft(
+                                                    receiveAccountId = receiveAccount.id,
+                                                    amount = item.first,
+                                                    normalizedAmount =
+                                                        normalizedLegs[index] ?: return@launch,
+                                                    currencyCode = item.second,
+                                                    date = repaymentDate,
+                                                    note = indexedNote(note, "合併", index, legs.size),
+                                                    categoryId = selectedCategory?.id,
+                                                    tagIds = selectedTags.map { it.id }
+                                                )
+                                            }
                                         )
                                     }
                                 }
-                                RepaymentMode.Merge -> {
-                                    val receiveAccount = selectedReceiveAccount ?: return@launch
-                                    val legs = mergeLegs.mapNotNull { leg ->
-	                                        val amount = parsePositive(leg.amount) ?: return@mapNotNull null
-	                                        amount to leg.currency
-	                                    }
-	                                    val normalizedLegs = legs.map { leg ->
-	                                        normalizedAmount(currencyService, leg.first, leg.second, caseCurrency)
-	                                    }
-	                                    if (normalizedLegs.any { it == null }) {
-	                                        errorMessage = "暫時無法取得其中一項幣種的匯率，請改用一般模式並手動輸入沖銷金額。"
-	                                        return@launch
-	                                    }
-	                                    if (!validateTotal(remaining, normalizedLegs.filterNotNull())) {
-	                                        errorMessage = "合併總金額超過未還餘額。"
-	                                        return@launch
-	                                    }
-	                                    legs.forEachIndexed { index, item ->
-	                                        recordSingleRepayment(
-	                                            repository = repository,
-	                                            advanceCase = caseData,
-	                                            participant = participant,
-	                                            receiveAccount = receiveAccount,
-	                                            amount = item.first,
-	                                            currency = item.second,
-	                                            normalizedAmount = normalizedLegs[index] ?: return@launch,
-	                                            note = indexedNote(note, "合併", index, legs.size),
-	                                            category = selectedCategory,
-                                            tagIds = selectedTags.map { it.id },
-                                            isBorrowedByMe = isBorrowedByMe
-                                        )
-                                    }
-                                }
+                            } catch (error: Exception) {
+                                errorMessage = error.localizedMessage ?: "無法儲存還款。"
+                                return@launch
                             }
                             errorMessage = null
+                            editingRepayment = null
                             amountInput = ""
+                            settlementAmountInput = ""
+                            settlementManuallyEdited = false
                             note = ""
+                            selectedCategory = null
+                            selectedTags = emptyList()
+                            repaymentDate = Instant.now()
                             advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
                         }
                     },
                     enabled = canSubmit
                 ) {
-                    Text("儲存")
+                    Text(if (editingRepayment == null) "儲存" else "更新還款")
+                }
+
+                if (editingRepayment != null) {
+                    TextButton(onClick = {
+                        editingRepayment = null
+                        amountInput = ""
+                        settlementAmountInput = ""
+                        settlementManuallyEdited = false
+                        note = ""
+                        selectedCategory = null
+                        selectedTags = emptyList()
+                        repaymentDate = Instant.now()
+                    }) {
+                        Text("取消編輯")
+                    }
                 }
 
                 if (errorMessage != null) {
@@ -438,17 +908,122 @@ fun AdvanceDetailScreen(caseId: String?) {
             }
         }
     }
+
+    repaymentToRollback?.let { repayment ->
+        val recordKind = repaymentRecordKind(repayment.note)
+        AlertDialog(
+            onDismissRequest = { repaymentToRollback = null },
+            title = { Text("確認撤銷${recordKind.label}？") },
+            text = {
+                Text(
+                    when (recordKind) {
+                        RepaymentRecordKind.Ordinary ->
+                            "會刪除還款紀錄及其關聯轉帳，並回復未還金額。"
+                        RepaymentRecordKind.MutualDebtOffset ->
+                            "會整組撤銷這次債務抵銷，並回復所有受影響案件的未清金額。"
+                        RepaymentRecordKind.ManualDebtSettlement ->
+                            "會整組撤銷這次跨幣種平賬，並回復所有受影響案件的未清金額。"
+                    }
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    scope.launch {
+                        runCatching {
+                            when (recordKind) {
+                                RepaymentRecordKind.Ordinary ->
+                                    repository.rollbackAdvanceRepayment(repayment.id)
+                                RepaymentRecordKind.MutualDebtOffset -> {
+                                    val offsetId = requireNotNull(
+                                        org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+                                            .mutualDebtOffsetId(repayment.note)
+                                    )
+                                    repository.rollbackMutualDebtOffset(offsetId)
+                                }
+                                RepaymentRecordKind.ManualDebtSettlement -> {
+                                    val settlementId = requireNotNull(
+                                        org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+                                            .manualDebtSettlementId(repayment.note)
+                                    )
+                                    repository.rollbackManualDebtSettlement(settlementId)
+                                }
+                            }
+                        }.onSuccess {
+                            advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
+                        }.onFailure {
+                            errorMessage = it.localizedMessage ?: "無法沖銷還款。"
+                        }
+                        repaymentToRollback = null
+                    }
+                }) { Text("撤銷") }
+            },
+            dismissButton = {
+                TextButton(onClick = { repaymentToRollback = null }) { Text("取消") }
+            }
+        )
+    }
+
+    participantToEdit?.let { participant ->
+        AlertDialog(
+            onDismissRequest = { participantToEdit = null },
+            title = { Text("更正欠款") },
+            text = {
+                OutlinedTextField(
+                    value = editedParticipantAmount,
+                    onValueChange = { editedParticipantAmount = sanitizeAmount(it) },
+                    label = { Text("欠款金額 ($caseCurrency)") }
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val amount = parsePositive(editedParticipantAmount)
+                    if (amount == null) {
+                        errorMessage = "請輸入大於 0 的欠款金額。"
+                    } else {
+                        scope.launch {
+                            runCatching {
+                                repository.updateAdvanceParticipantOwedAmount(participant.id, amount)
+                            }.onSuccess {
+                                advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
+                            }.onFailure {
+                                errorMessage = it.localizedMessage ?: "無法更正欠款。"
+                            }
+                            participantToEdit = null
+                        }
+                    }
+                }) { Text("儲存") }
+            },
+            dismissButton = {
+                TextButton(onClick = { participantToEdit = null }) { Text("取消") }
+            }
+        )
+    }
+}
+
+private fun repaymentRecordKind(note: String): RepaymentRecordKind {
+    return when {
+        org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+            .isMutualDebtOffset(note) -> RepaymentRecordKind.MutualDebtOffset
+        org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+            .isManualDebtSettlement(note) -> RepaymentRecordKind.ManualDebtSettlement
+        else -> RepaymentRecordKind.Ordinary
+    }
 }
 
 
 @Composable
-private fun ParticipantRow(participant: AdvanceParticipantEntity, currency: String) {
+private fun ParticipantRow(
+    participant: AdvanceParticipantEntity,
+    currency: String,
+    onEdit: () -> Unit
+) {
     val remaining = (participant.owedAmount - participant.repaidAmount).max(BigDecimal.ZERO)
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(participant.name, style = MaterialTheme.typography.bodyLarge)
         Text("欠款：${participant.owedAmount.asCurrencyText(currency)}")
         Text("已還：${participant.repaidAmount.asCurrencyText(currency)}")
         Text("未還：${remaining.asCurrencyText(currency)}")
+        TextButton(onClick = onEdit) { Text("更正欠款") }
     }
 }
 
@@ -699,10 +1274,10 @@ private suspend fun recordSingleRepayment(
     amount: BigDecimal,
     currency: String,
     normalizedAmount: BigDecimal,
+    date: Instant,
     note: String,
     category: CategoryEntity?,
-    tagIds: List<UUID>,
-    isBorrowedByMe: Boolean
+    tagIds: List<UUID>
 ) {
     repository.recordAdvanceRepayment(
         advanceCase = advanceCase.advanceCase,
@@ -710,13 +1285,36 @@ private suspend fun recordSingleRepayment(
         amount = amount.abs(),
         normalizedAmount = normalizedAmount.abs(),
         currencyCode = currency,
-        date = Instant.now(),
+        date = date,
         note = note.trim(),
         receiveAccount = receiveAccount,
         category = category,
-        tagIds = tagIds,
-        isBorrowedByMe = isBorrowedByMe
+        tagIds = tagIds
     )
+}
+
+private fun showRepaymentDatePicker(
+    context: android.content.Context,
+    initial: Instant,
+    onPicked: (Instant) -> Unit
+) {
+    val zone = ZoneId.systemDefault()
+    val date = initial.atZone(zone).toLocalDate()
+    DatePickerDialog(
+        context,
+        { _, year, month, day ->
+            val originalTime = initial.atZone(zone).toLocalTime()
+            onPicked(
+                java.time.LocalDate.of(year, month + 1, day)
+                    .atTime(originalTime)
+                    .atZone(zone)
+                    .toInstant()
+            )
+        },
+        date.year,
+        date.monthValue - 1,
+        date.dayOfMonth
+    ).show()
 }
 
 private fun indexedNote(base: String, mode: String, index: Int, count: Int): String {

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
@@ -1,0 +1,610 @@
+package org.duckdns.lhfser.aiaccounting.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.duckdns.lhfser.aiaccounting.core.currency.CurrencyService
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.CategoryKind
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
+import org.duckdns.lhfser.aiaccounting.core.report.ReportAggregationRequest
+import org.duckdns.lhfser.aiaccounting.core.report.ReportAggregationService
+import org.duckdns.lhfser.aiaccounting.core.report.ReportConversion
+import org.duckdns.lhfser.aiaccounting.core.report.ReportCurrencyConverting
+import org.duckdns.lhfser.aiaccounting.core.report.ReportCurrencyTotal
+import org.duckdns.lhfser.aiaccounting.core.report.ReportEstimateStatus
+import org.duckdns.lhfser.aiaccounting.core.report.ReportFlow
+import org.duckdns.lhfser.aiaccounting.core.report.ReportGroupingMode
+import org.duckdns.lhfser.aiaccounting.core.report.ReportTransactionSnapshot
+import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceInitialMetadataEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentCreateDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSelfExpenseEditDraft
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class AdvanceEditingTest {
+    private lateinit var database: AIAccountingDatabase
+    private lateinit var repository: AccountingRepository
+    private lateinit var wallet: AccountEntity
+    private lateinit var bank: AccountEntity
+    private lateinit var friend: AccountEntity
+    private lateinit var incomeCategory: CategoryEntity
+    private lateinit var expenseCategory: CategoryEntity
+    private lateinit var editedTag: TagEntity
+
+    @Before
+    fun setUp() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AIAccountingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = AccountingRepository(database, CurrencyService(context))
+        wallet = account("Wallet", AccountType.Cash, 0)
+        bank = account("Bank", AccountType.Bank, 1)
+        friend = account("Friend", AccountType.Debt, 2)
+        incomeCategory = category("Repayment received", CategoryKind.Income)
+        expenseCategory = category("Repayment paid", CategoryKind.Expense)
+        editedTag = TagEntity(UUID.randomUUID(), "Edited")
+        repository.upsertAccount(wallet)
+        repository.upsertAccount(bank)
+        repository.upsertAccount(friend)
+        repository.upsertCategory(incomeCategory)
+        repository.upsertCategory(expenseCategory)
+        repository.upsertTag(editedTag)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun crossCurrencyRepaymentEdit_preservesExplicitSettlementAndMovesMetadataToIncomingOwnLeg() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Japan trip",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("2000")))
+        )
+        val caseData = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = caseData.participants.single()
+        repository.recordAdvanceRepayment(
+            advanceCase = caseData.advanceCase,
+            participant = participant,
+            amount = BigDecimal("50"),
+            normalizedAmount = BigDecimal("1000"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "First",
+            receiveAccount = wallet,
+            category = null,
+            tagIds = emptyList()
+        )
+        val repayment = requireNotNull(repository.getAdvanceCase(caseId)).repayments.single()
+
+        repository.updateAdvanceRepayment(
+            AdvanceRepaymentEditDraft(
+                repaymentId = repayment.id,
+                receiveAccountId = bank.id,
+                amount = BigDecimal("60"),
+                currencyCode = "HKD",
+                normalizedAmount = BigDecimal("900"),
+                date = Instant.parse("2026-06-03T10:00:00Z"),
+                note = "Edited",
+                categoryId = incomeCategory.id,
+                tagIds = listOf(editedTag.id)
+            )
+        )
+
+        val updatedCase = requireNotNull(repository.getAdvanceCase(caseId))
+        val updatedRepayment = updatedCase.repayments.single()
+        assertEquals(BigDecimal("60"), updatedRepayment.amount)
+        assertEquals(BigDecimal("900"), updatedRepayment.normalizedAmount)
+        assertEquals(BigDecimal("900"), updatedCase.participants.single().repaidAmount)
+        assertEquals(bank.id, updatedRepayment.receivedAccountId)
+
+        val group = repository.getTransferGroup(requireNotNull(updatedRepayment.linkedTransferGroupId))
+        val ownIncoming = group.single { it.transaction.transferSide == TransferSide.Incoming }
+        val debtOutgoing = group.single { it.transaction.transferSide == TransferSide.Outgoing }
+        assertEquals(bank.id, ownIncoming.transaction.accountId)
+        assertEquals(incomeCategory.id, ownIncoming.transaction.categoryId)
+        assertEquals(listOf(editedTag.id), ownIncoming.tags.map { it.id })
+        assertEquals(null, debtOutgoing.transaction.categoryId)
+        assertTrue(debtOutgoing.tags.isEmpty())
+    }
+
+    @Test
+    fun othersAdvancedMeRepaymentEdit_tagsOutgoingOwnLegAndRollbackRestoresParticipant() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Dinner",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = null,
+            expenseCategory = expenseCategory,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100"))),
+            isBorrowedByMe = true
+        )
+        val caseData = requireNotNull(repository.getAdvanceCase(caseId))
+        repository.recordAdvanceRepayment(
+            advanceCase = caseData.advanceCase,
+            participant = caseData.participants.single(),
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "",
+            receiveAccount = wallet,
+            category = null,
+            tagIds = emptyList()
+        )
+        val repayment = requireNotNull(repository.getAdvanceCase(caseId)).repayments.single()
+
+        repository.updateAdvanceRepayment(
+            AdvanceRepaymentEditDraft(
+                repaymentId = repayment.id,
+                receiveAccountId = wallet.id,
+                amount = BigDecimal("35"),
+                currencyCode = "HKD",
+                normalizedAmount = BigDecimal("35"),
+                date = Instant.parse("2026-06-03T10:00:00Z"),
+                note = "Paid",
+                categoryId = expenseCategory.id,
+                tagIds = listOf(editedTag.id)
+            )
+        )
+
+        val updatedRepayment = requireNotNull(repository.getAdvanceCase(caseId)).repayments.single()
+        val groupId = requireNotNull(updatedRepayment.linkedTransferGroupId)
+        val group = repository.getTransferGroup(groupId)
+        val ownOutgoing = group.single { it.transaction.transferSide == TransferSide.Outgoing }
+        assertEquals(wallet.id, ownOutgoing.transaction.accountId)
+        assertEquals(expenseCategory.id, ownOutgoing.transaction.categoryId)
+        assertEquals(listOf(editedTag.id), ownOutgoing.tags.map { it.id })
+
+        repository.rollbackAdvanceRepayment(updatedRepayment.id)
+
+        val rolledBack = requireNotNull(repository.getAdvanceCase(caseId))
+        assertTrue(rolledBack.repayments.isEmpty())
+        assertEquals(BigDecimal.ZERO, rolledBack.participants.single().repaidAmount)
+        assertTrue(repository.getTransferGroup(groupId).isEmpty())
+    }
+
+    @Test
+    fun participantCorrection_updatesBorrowedInitialExpenseAtomically() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Taxi",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = null,
+            expenseCategory = expenseCategory,
+            tagIds = listOf(editedTag.id),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("1000"))),
+            isBorrowedByMe = true
+        )
+        val caseData = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = caseData.participants.single()
+
+        repository.updateAdvanceParticipantOwedAmount(participant.id, BigDecimal("1200"))
+
+        val updated = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(BigDecimal("1200"), updated.participants.single().owedAmount)
+        val initial = repository.getTransferGroup(requireNotNull(participant.initialTransferGroupId)).single()
+        assertEquals(TransactionType.Expense, initial.transaction.type)
+        assertEquals(BigDecimal("-1200"), initial.transaction.amount)
+        assertEquals("JPY", initial.transaction.currencyCode)
+        assertEquals(expenseCategory.id, initial.transaction.categoryId)
+        assertEquals(listOf(editedTag.id), initial.tags.map { it.id })
+
+        val report = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = listOf(
+                    ReportTransactionSnapshot(
+                        id = initial.transaction.id,
+                        amount = initial.transaction.amount,
+                        currencyCode = initial.transaction.currencyCode,
+                        date = initial.transaction.date,
+                        type = initial.transaction.type,
+                        categoryId = initial.transaction.categoryId,
+                        categoryName = expenseCategory.name,
+                        categoryColorHex = expenseCategory.colorHex,
+                        tagNames = initial.tags.map { it.name }
+                    )
+                ),
+                flow = ReportFlow.Expense,
+                grouping = ReportGroupingMode.Category
+            ),
+            currencyConverter = object : ReportCurrencyConverting {
+                override val mainCurrency = "JPY"
+
+                override fun estimateInMainCurrency(
+                    amount: BigDecimal,
+                    currencyCode: String
+                ): ReportConversion? {
+                    if (!currencyCode.equals(mainCurrency, ignoreCase = true)) return null
+                    return ReportConversion(amount, ReportEstimateStatus.Exact)
+                }
+            }
+        )
+
+        val slice = report.slices.single()
+        assertEquals("Repayment paid", slice.name)
+        assertEquals(0, BigDecimal("1200").compareTo(slice.estimatedAmount))
+        assertEquals(
+            listOf(ReportCurrencyTotal("JPY", BigDecimal("1200"))),
+            slice.originalCurrencyTotals
+        )
+        assertEquals(listOf(initial.transaction.id), slice.transactionIds)
+    }
+
+    @Test
+    fun initialMetadataEdit_updatesEveryParticipantGroup() = runBlocking {
+        val friendB = account("Friend B", AccountType.Debt, 3)
+        repository.upsertAccount(friendB)
+        val caseId = repository.createAdvanceCase(
+            title = "Japan trip",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "Original",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(
+                AdvanceParticipantInput(friend, BigDecimal("100")),
+                AdvanceParticipantInput(friendB, BigDecimal("200"))
+            )
+        )
+        val editedDate = Instant.parse("2026-06-03T10:00:00Z")
+
+        repository.updateAdvanceInitialMetadata(
+            AdvanceInitialMetadataEditDraft(
+                caseId = caseId,
+                payerAccountId = bank.id,
+                date = editedDate,
+                note = "Edited",
+                categoryId = null,
+                tagIds = emptyList()
+            )
+        )
+
+        val updated = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(bank.id, updated.advanceCase.payerAccountId)
+        assertEquals(editedDate, updated.advanceCase.date)
+        assertEquals("Edited", updated.advanceCase.note)
+        updated.participants.forEach { participant ->
+            val group = repository.getTransferGroup(requireNotNull(participant.initialTransferGroupId))
+            val outgoing = group.single { it.transaction.transferSide == TransferSide.Outgoing }
+            val incoming = group.single { it.transaction.transferSide == TransferSide.Incoming }
+            assertEquals(bank.id, outgoing.transaction.accountId)
+            assertEquals(editedDate, outgoing.transaction.date)
+            assertEquals(editedDate, incoming.transaction.date)
+            assertTrue(incoming.transaction.note.contains(bank.name))
+            assertEquals(participant.owedAmount.negate(), outgoing.transaction.amount)
+            assertEquals(participant.owedAmount, incoming.transaction.amount)
+        }
+    }
+
+    @Test
+    fun sequentialRepayments_refreshParticipantInsideTransaction() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Split repayment",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val staleCase = requireNotNull(repository.getAdvanceCase(caseId))
+        val staleParticipant = staleCase.participants.single()
+
+        repository.recordAdvanceRepayment(
+            advanceCase = staleCase.advanceCase,
+            participant = staleParticipant,
+            amount = BigDecimal("30"),
+            normalizedAmount = BigDecimal("30"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "First leg",
+            receiveAccount = wallet,
+            category = incomeCategory,
+            tagIds = emptyList()
+        )
+        repository.recordAdvanceRepayment(
+            advanceCase = staleCase.advanceCase,
+            participant = staleParticipant,
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:01:00Z"),
+            note = "Second leg",
+            receiveAccount = bank,
+            category = incomeCategory,
+            tagIds = emptyList()
+        )
+
+        val updated = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(BigDecimal("70"), updated.participants.single().repaidAmount)
+        assertEquals(2, updated.repayments.size)
+    }
+
+    @Test
+    fun repaymentBatch_rollsBackEveryLegWhenOneLegIsInvalid() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Atomic split repayment",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val participant = requireNotNull(repository.getAdvanceCase(caseId)).participants.single()
+
+        try {
+            repository.recordAdvanceRepayments(
+                advanceCaseId = caseId,
+                participantId = participant.id,
+                drafts = listOf(
+                    AdvanceRepaymentCreateDraft(
+                        receiveAccountId = wallet.id,
+                        amount = BigDecimal("30"),
+                        normalizedAmount = BigDecimal("30"),
+                        currencyCode = "HKD",
+                        date = Instant.parse("2026-06-02T10:00:00Z"),
+                        note = "First",
+                        categoryId = incomeCategory.id,
+                        tagIds = emptyList()
+                    ),
+                    AdvanceRepaymentCreateDraft(
+                        receiveAccountId = bank.id,
+                        amount = BigDecimal("80"),
+                        normalizedAmount = BigDecimal("80"),
+                        currencyCode = "HKD",
+                        date = Instant.parse("2026-06-02T10:01:00Z"),
+                        note = "Second",
+                        categoryId = incomeCategory.id,
+                        tagIds = emptyList()
+                    )
+                )
+            )
+            fail("Expected the overpayment leg to roll back the whole batch.")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message.orEmpty().contains("超過"))
+        }
+
+        val unchanged = requireNotNull(repository.getAdvanceCase(caseId))
+        assertTrue(unchanged.repayments.isEmpty())
+        assertEquals(BigDecimal.ZERO, unchanged.participants.single().repaidAmount)
+    }
+
+    @Test
+    fun accountDeletion_rollsBackMultipleRepaymentsForSameParticipantWithoutLeavingResidualTotal() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Multiple repayments",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val caseData = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = caseData.participants.single()
+        repository.recordAdvanceRepayment(
+            advanceCase = caseData.advanceCase,
+            participant = participant,
+            amount = BigDecimal("30"),
+            normalizedAmount = BigDecimal("30"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "First",
+            receiveAccount = bank,
+            category = incomeCategory,
+            tagIds = emptyList()
+        )
+        repository.recordAdvanceRepayment(
+            advanceCase = caseData.advanceCase,
+            participant = participant,
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T11:00:00Z"),
+            note = "Second",
+            receiveAccount = bank,
+            category = incomeCategory,
+            tagIds = emptyList()
+        )
+
+        repository.deleteAccount(bank.id, deleteRelatedBookkeeping = true)
+
+        val updated = requireNotNull(repository.getAdvanceCase(caseId))
+        assertTrue(updated.repayments.isEmpty())
+        assertEquals(BigDecimal.ZERO, updated.participants.single().repaidAmount)
+    }
+
+    @Test
+    fun selfExpenseEdit_preservesActualCurrencyAndNormalizedCaseShare() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Japan trip",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal("1000"),
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = expenseCategory,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("2000")))
+        )
+
+        repository.updateAdvanceSelfExpense(
+            AdvanceSelfExpenseEditDraft(
+                caseId = caseId,
+                accountId = wallet.id,
+                amount = BigDecimal("35.59"),
+                currencyCode = "CHF",
+                normalizedAmount = BigDecimal("725"),
+                date = Instant.parse("2026-06-02T10:00:00Z"),
+                note = "LUUP",
+                categoryId = expenseCategory.id,
+                tagIds = listOf(editedTag.id)
+            )
+        )
+
+        val updatedCase = requireNotNull(repository.getAdvanceCase(caseId))
+        val transactionId = requireNotNull(updatedCase.advanceCase.selfExpenseTransactionId)
+        val transaction = requireNotNull(repository.getTransaction(transactionId))
+        assertEquals(BigDecimal("-35.59"), transaction.transaction.amount)
+        assertEquals("CHF", transaction.transaction.currencyCode)
+        assertEquals(BigDecimal("725"), updatedCase.advanceCase.myShareAmount)
+        assertEquals(expenseCategory.id, transaction.transaction.categoryId)
+        assertEquals(listOf(editedTag.id), transaction.tags.map { it.id })
+
+        val report = ReportAggregationService.aggregate(
+            request = ReportAggregationRequest(
+                transactions = listOf(
+                    ReportTransactionSnapshot(
+                        id = transaction.transaction.id,
+                        amount = transaction.transaction.amount,
+                        currencyCode = transaction.transaction.currencyCode,
+                        date = transaction.transaction.date,
+                        type = transaction.transaction.type,
+                        categoryId = transaction.transaction.categoryId,
+                        categoryName = expenseCategory.name,
+                        categoryColorHex = expenseCategory.colorHex,
+                        tagNames = transaction.tags.map { it.name }
+                    )
+                ),
+                flow = ReportFlow.Expense,
+                grouping = ReportGroupingMode.Category
+            ),
+            currencyConverter = object : ReportCurrencyConverting {
+                override val mainCurrency = "CHF"
+
+                override fun estimateInMainCurrency(
+                    amount: BigDecimal,
+                    currencyCode: String
+                ): ReportConversion? {
+                    if (!currencyCode.equals(mainCurrency, ignoreCase = true)) return null
+                    return ReportConversion(amount, ReportEstimateStatus.Exact)
+                }
+            }
+        )
+
+        val slice = report.slices.single()
+        assertEquals(0, BigDecimal("35.59").compareTo(slice.estimatedAmount))
+        assertEquals(
+            listOf(ReportCurrencyTotal("CHF", BigDecimal("35.59"))),
+            slice.originalCurrencyTotals
+        )
+    }
+
+    @Test
+    fun repaymentEdit_rejectsCategoryForWrongSettlementDirection() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Dinner",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val caseData = requireNotNull(repository.getAdvanceCase(caseId))
+        repository.recordAdvanceRepayment(
+            advanceCase = caseData.advanceCase,
+            participant = caseData.participants.single(),
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "",
+            receiveAccount = wallet,
+            category = null,
+            tagIds = emptyList()
+        )
+        val repayment = requireNotNull(repository.getAdvanceCase(caseId)).repayments.single()
+
+        try {
+            repository.updateAdvanceRepayment(
+                AdvanceRepaymentEditDraft(
+                    repaymentId = repayment.id,
+                    receiveAccountId = wallet.id,
+                    amount = BigDecimal("35"),
+                    currencyCode = "HKD",
+                    normalizedAmount = BigDecimal("35"),
+                    date = Instant.parse("2026-06-03T10:00:00Z"),
+                    note = "",
+                    categoryId = expenseCategory.id,
+                    tagIds = emptyList()
+                )
+            )
+            fail("Expected repayment category validation to reject an expense category.")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message.orEmpty().contains("分類"))
+        }
+
+        val unchanged = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(BigDecimal("40"), unchanged.repayments.single().amount)
+        assertEquals(BigDecimal("40"), unchanged.participants.single().repaidAmount)
+    }
+
+    private fun account(name: String, type: AccountType, order: Int): AccountEntity {
+        return AccountEntity(
+            id = UUID.randomUUID(),
+            name = name,
+            currency = "HKD",
+            type = type,
+            baseBalance = BigDecimal.ZERO,
+            sortOrder = order,
+            isArchived = false
+        )
+    }
+
+    private fun category(name: String, kind: CategoryKind): CategoryEntity {
+        return CategoryEntity(
+            id = UUID.randomUUID(),
+            name = name,
+            icon = "tag",
+            colorHex = "#123456",
+            kind = kind
+        )
+    }
+}

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -234,8 +234,7 @@ class BackupRoundTripTest {
             note = "還款",
             receiveAccount = ownAccount,
             category = null,
-            tagIds = emptyList(),
-            isBorrowedByMe = true
+            tagIds = emptyList()
         )
 
         val updatedCase = checkNotNull(repository.getAdvanceCase(caseId))
@@ -389,6 +388,16 @@ class BackupRoundTripTest {
         val exported = BackupJsonAdapter.gson.fromJson(repository.exportBackupJson(), FullBackupData::class.java)
         assertEquals(2, exported.advanceRepayments?.count { it.note?.contains("[債務抵銷:") == true })
 
+        val specialRepayment = checkNotNull(repository.getAdvanceCase(receivableCaseId))
+            .repayments
+            .single()
+        try {
+            repository.rollbackAdvanceRepayment(specialRepayment.id)
+            throw AssertionError("Expected special repayment rollback to require the group API.")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message.orEmpty().contains("整組撤銷"))
+        }
+
         val rollbackCount = repository.rollbackMutualDebtOffset(result.offsetGroupId)
         assertEquals(2, rollbackCount)
         val rolledBackReceivable = checkNotNull(repository.getAdvanceCase(receivableCaseId))
@@ -462,6 +471,22 @@ class BackupRoundTripTest {
 
         val exported = BackupJsonAdapter.gson.fromJson(repository.exportBackupJson(), FullBackupData::class.java)
         assertEquals(1, exported.advanceRepayments?.count { it.note?.contains("[跨幣種平賬:") == true })
+
+        try {
+            repository.rollbackAdvanceRepayment(advanceCase.repayments.single().id)
+            throw AssertionError("Expected manual settlement rollback to require the group API.")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message.orEmpty().contains("整組撤銷"))
+        }
+
+        val rollbackCount = repository.rollbackManualDebtSettlement(result.settlementId)
+        assertEquals(1, rollbackCount)
+        val rolledBack = checkNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(
+            BigDecimal("1230"),
+            rolledBack.participants.single().owedAmount - rolledBack.participants.single().repaidAmount
+        )
+        assertTrue(rolledBack.repayments.isEmpty())
     }
 
     @Test
@@ -521,8 +546,7 @@ class BackupRoundTripTest {
             note = "朋友用人民幣還款",
             receiveAccount = receiveAccount,
             category = null,
-            tagIds = emptyList(),
-            isBorrowedByMe = false
+            tagIds = emptyList()
         )
 
         val updatedCase = checkNotNull(repository.getAdvanceCase(caseId))
@@ -598,8 +622,7 @@ class BackupRoundTripTest {
             note = "朋友用港幣還款",
             receiveAccount = receiveAccount,
             category = null,
-            tagIds = emptyList(),
-            isBorrowedByMe = false
+            tagIds = emptyList()
         )
 
         val updatedCase = checkNotNull(repository.getAdvanceCase(caseId))

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/TransferGroupReplacementTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/TransferGroupReplacementTest.kt
@@ -261,6 +261,54 @@ class TransferGroupReplacementTest {
         assertProtected(repaymentGroupId)
     }
 
+    @Test
+    fun borrowedAdvanceExpense_routesToAdvanceEditorEvenThoughItIsNotATransfer() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Taxi",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = null,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100"))),
+            isBorrowedByMe = true
+        )
+        val participant = requireNotNull(repository.getAdvanceCase(caseId)).participants.single()
+        val initialGroupId = requireNotNull(participant.initialTransferGroupId)
+        val expense = repository.getTransferGroup(initialGroupId).single()
+
+        assertEquals(TransactionType.Expense, expense.transaction.type)
+        assertEquals(
+            TransactionEditDestination.Advance(caseId.toString()),
+            resolveTransactionEditDestination(repository, expense)
+        )
+    }
+
+    @Test
+    fun advanceSelfExpense_routesToAdvanceEditor() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Trip",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal("500"),
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("1000")))
+        )
+        val advanceCase = requireNotNull(repository.getAdvanceCase(caseId))
+        val selfExpenseId = requireNotNull(advanceCase.advanceCase.selfExpenseTransactionId)
+        val selfExpense = requireNotNull(repository.getTransaction(selfExpenseId))
+
+        assertEquals(
+            TransactionEditDestination.Advance(caseId.toString()),
+            resolveTransactionEditDestination(repository, selfExpense)
+        )
+    }
+
     private fun assertProtected(groupId: UUID) {
         assertThrows(IllegalArgumentException::class.java) {
             runBlocking {

--- a/docs/specs/parity-test-vectors.md
+++ b/docs/specs/parity-test-vectors.md
@@ -254,6 +254,50 @@ Expected:
 - Report drill-down shows refund reduction `2000 JPY` separately from settlement-only `550 JPY`.
 - Income report contribution: `0`.
 
+## Vector 17: Cross-Currency Advance Repayment Edit
+
+Input:
+- Case currency: `JPY`.
+- Existing actual repayment: `50 HKD`.
+- Existing normalized settlement: `1000 JPY`.
+- Edit actual repayment to `60 HKD`.
+- Explicitly edit normalized settlement to `900 JPY`.
+
+Expected:
+- Actual repayment remains `60 HKD` on both transfer legs.
+- Participant repaid total becomes `900 JPY`; no current exchange rate is applied during save.
+- For `我代墊他人`, income category/tags are stored on the incoming own-account leg.
+- For `他人代墊我`, expense category/tags are stored on the outgoing own-account leg.
+- Creation timestamp and transfer-group identity remain unchanged.
+
+## Vector 18: Advance Own Share And Participant Correction
+
+Input:
+- Case currency: `JPY`.
+- Existing own-share expense: `725 JPY`.
+- Edit actual own-account debit to `35.59 CHF`, normalized case share to `725 JPY`.
+- Correct one participant owed amount from `1000 JPY` to `1200 JPY`.
+
+Expected:
+- The own-account expense stores `-35.59 CHF`.
+- The case summary continues to store the explicitly entered `725 JPY` share.
+- The participant and its initial transfer/expense bookkeeping both store `1200 JPY`.
+- Case-wide metadata edits update every participant's initial record atomically.
+- Reports use the edited expense category/tags without detaching the record from its advance case.
+
+## Vector 19: Special Settlement Group Rollback
+
+Input:
+- A mutual debt offset creates multiple repayments sharing `[債務抵銷:<UUID>]`.
+- A manual settlement creates one or more repayments sharing `[跨幣種平賬:<UUID>]`.
+
+Expected:
+- Generic single-repayment edit and rollback APIs reject both marker types.
+- The dedicated rollback API deletes every repayment with the matching marker.
+- Every affected participant's repaid total is reduced by the full grouped allocation.
+- No financial transaction is created or deleted by these marker-only rollbacks.
+- The advance detail UI labels these records as offset/settlement rather than ordinary repayment.
+
 ## Automated Coverage
 
 | Vector | iOS | Android |
@@ -266,6 +310,9 @@ Expected:
 | 10, 12, 13 | `LedgerSemanticVectorsTests.testVector13_settlementRecordsAreExcludedFromReports` | `ParityVectorsTest.vector13_settlementRecordsAreExcludedFromReports` |
 | 11 | `testExportImport_preservesSameAccountCrossCurrencyTransferAndBudgetHistory_excludesUIPreferences` | `backupRoundTrip_preservesSameAccountCrossCurrencyTransferAndBudgetHistory` |
 | 14-16 | `RefundSemanticsServiceTests`, `ReportAggregationServiceTests.testRefundAggregation_reducesExpenseWithoutCountingIncome`, `ReportAggregationServiceTests.testRefundAggregation_capsExpenseReductionAndKeepsExcessSettlementOnly` | `RefundSemanticsTest`, `ReportAggregationTest.refundAggregation_reducesExpenseWithoutCountingIncome`, `ReportAggregationTest.refundAggregation_capsExpenseReductionAndKeepsExcessSettlementOnly` |
+| 17 | `AdvanceEditingTests.testCrossCurrencyRepaymentEditPreservesExplicitNormalizedAmountAndIncomingMetadata`, `AdvanceEditingTests.testOthersAdvancedMeEditTagsOutgoingOwnLegAndRollbackRestoresParticipant` | `AdvanceEditingTest.crossCurrencyRepaymentEdit_preservesExplicitSettlementAndMovesMetadataToIncomingOwnLeg`, `AdvanceEditingTest.othersAdvancedMeRepaymentEdit_tagsOutgoingOwnLegAndRollbackRestoresParticipant` |
+| 18 | `AdvanceEditingTests.testSelfExpenseEditPreservesActualCurrencyAndNormalisedCaseShare`, `AdvanceEditingTests.testParticipantCorrectionUpdatesBorrowedInitialExpense`, `AdvanceEditingTests.testInitialEntryEditUpdatesCaseMetadataAcrossEveryParticipant` | `AdvanceEditingTest.selfExpenseEdit_preservesActualCurrencyAndNormalizedCaseShare`, `AdvanceEditingTest.participantCorrection_updatesBorrowedInitialExpenseAtomically`, `AdvanceEditingTest.initialMetadataEdit_updatesEveryParticipantGroup` |
+| 19 | `BackupCompatibilityTests.testMutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions`, `BackupCompatibilityTests.testManualDebtSettlement_closesSingleCurrencyAdvanceWithoutTransactions` | `BackupRoundTripTest.mutualDebtOffset_settlesBidirectionalAdvancesWithoutTransactions`, `BackupRoundTripTest.manualDebtSettlement_closesSingleCurrencyAdvanceWithoutTransactions` |
 
 ## CI Gate Recommendation
 


### PR DESCRIPTION
## Summary
- route advance own-share, initial, and repayment records to semantic editors on iOS and Android
- preserve actual transaction amount/currency separately from normalized case-currency settlement values
- keep participant totals, transfer legs, categories, tags, budget history, and special settlement rollback consistent
- preserve non-standard imported currencies across relevant editors
- add cross-platform parity vectors and regression coverage, including report aggregation

## Validation
- Android `./gradlew testDebugUnitTest assembleDebug` passed twice
- Swift source and test syntax parse passed repeatedly
- actual `Backup.json` LUUP self-expense link verified
- no persistence schema or backup format changes
- local iOS 26.5 simulator runtime installation and full Xcode test passes are still running; PR will not merge until they and CI pass

Closes #134
