### PR TITLE
Fix advance repayment row build

### DIFF
--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -467,7 +467,7 @@ struct AdvanceCaseDetailView: View {
     
     private func repaymentRow(_ repayment: AdvanceRepayment) -> some View {
         let recordKind = AdvanceService.repaymentRecordKind(note: repayment.note)
-        VStack(alignment: .leading, spacing: 6) {
+        return VStack(alignment: .leading, spacing: 6) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(repayment.participant?.name ?? "未指定對象")


### PR DESCRIPTION
## Summary
- return the repayment row view explicitly after the local record-kind binding
- resolve the opaque return-type error and the cascading unused `padding` diagnostic
- exclude local Xcode scheme changes

## Validation
- full generic iOS device build passed
- second incremental iOS device build passed
- no priors/read, compiler error, or warning diagnostics in the second build