### PR TITLE
Add explicit advance bookkeeping links

### DIFF
--- a/AI 記帳/ContentView.swift
+++ b/AI 記帳/ContentView.swift
@@ -182,6 +182,10 @@ struct ContentView: View {
             guard !isRunningXCTest, !didReconcileAdvanceRepayments else { return }
             didReconcileAdvanceRepayments = true
             do {
+                let links = try AdvanceService.backfillExplicitLinks(modelContext: modelContext)
+                if links.linkedTransactionCount > 0 {
+                    print("✅ 已回填代墊明確連結 \(links.linkedTransactionCount) 筆")
+                }
                 let result = try AdvanceService.reconcileUnderstatedRepaymentTotals(modelContext: modelContext)
                 if result.updatedParticipantCount > 0 {
                     print("✅ 已修復代墊還款累計 \(result.updatedParticipantCount) 筆")

--- a/AI 記帳/Models/DataModels.swift
+++ b/AI 記帳/Models/DataModels.swift
@@ -186,6 +186,19 @@ final class Tag {
     }
 }
 
+enum AdvanceDirection: String, Codable, CaseIterable {
+    case iAdvancedOthers = "IAdvancedOthers"
+    case othersAdvancedMe = "OthersAdvancedMe"
+}
+
+enum AdvanceEntryRole: String, Codable, CaseIterable {
+    case selfExpense = "SelfExpense"
+    case initialAsset = "InitialAsset"
+    case initialDebt = "InitialDebt"
+    case repaymentAsset = "RepaymentAsset"
+    case repaymentDebt = "RepaymentDebt"
+}
+
 @Model
 final class FinancialTransaction {
     @Attribute(.unique) var id: UUID
@@ -199,6 +212,10 @@ final class FinancialTransaction {
     var linkedTransactionID: UUID?
     var transferGroupID: UUID?
     var transferSide: TransferSide?
+    var advanceCaseID: UUID?
+    var advanceParticipantID: UUID?
+    var advanceRepaymentID: UUID?
+    var advanceEntryRoleRaw: String?
     var createdAt: Date = Date()
     var updatedAt: Date = Date()
     
@@ -216,6 +233,10 @@ final class FinancialTransaction {
          linkedTransactionID: UUID? = nil,
          transferGroupID: UUID? = nil,
          transferSide: TransferSide? = nil,
+         advanceCaseID: UUID? = nil,
+         advanceParticipantID: UUID? = nil,
+         advanceRepaymentID: UUID? = nil,
+         advanceEntryRole: AdvanceEntryRole? = nil,
          account: Account? = nil,
          category: Category? = nil,
          tags: [Tag] = [],
@@ -231,11 +252,20 @@ final class FinancialTransaction {
         self.linkedTransactionID = linkedTransactionID
         self.transferGroupID = transferGroupID
         self.transferSide = transferSide
+        self.advanceCaseID = advanceCaseID
+        self.advanceParticipantID = advanceParticipantID
+        self.advanceRepaymentID = advanceRepaymentID
+        self.advanceEntryRoleRaw = advanceEntryRole?.rawValue
         self.account = account
         self.category = category
         self.tags = tags
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+
+    var advanceEntryRole: AdvanceEntryRole? {
+        get { advanceEntryRoleRaw.flatMap(AdvanceEntryRole.init(rawValue:)) }
+        set { advanceEntryRoleRaw = newValue?.rawValue }
     }
 }
 
@@ -494,6 +524,8 @@ final class AdvanceCase {
     var myShareAmount: Decimal
     var note: String
     var selfExpenseTransactionID: UUID?
+    var directionRaw: String?
+    var tagIDs: [UUID]
     var createdAt: Date
     var updatedAt: Date
     
@@ -514,6 +546,8 @@ final class AdvanceCase {
         myShareAmount: Decimal = 0,
         note: String = "",
         selfExpenseTransactionID: UUID? = nil,
+        direction: AdvanceDirection? = nil,
+        tagIDs: [UUID] = [],
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         payerAccount: Account? = nil,
@@ -526,10 +560,17 @@ final class AdvanceCase {
         self.myShareAmount = myShareAmount
         self.note = note
         self.selfExpenseTransactionID = selfExpenseTransactionID
+        self.directionRaw = direction?.rawValue
+        self.tagIDs = tagIDs
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.payerAccount = payerAccount
         self.expenseCategory = expenseCategory
+    }
+
+    var direction: AdvanceDirection? {
+        get { directionRaw.flatMap(AdvanceDirection.init(rawValue:)) }
+        set { directionRaw = newValue?.rawValue }
     }
 }
 

--- a/AI 記帳/Services/AdvanceCaseEditingService.swift
+++ b/AI 記帳/Services/AdvanceCaseEditingService.swift
@@ -1,0 +1,212 @@
+import Foundation
+import SwiftData
+
+struct AdvancePaymentLegDraft {
+    let transactionID: UUID?
+    let account: Account
+    let amount: Decimal
+    let currencyCode: String
+}
+
+struct AdvanceShareDraft {
+    let transactionID: UUID?
+    let account: Account
+    let amount: Decimal
+    let normalizedAmount: Decimal
+    let currencyCode: String
+}
+
+struct AdvanceParticipantDraft {
+    let participant: AdvanceParticipant
+    let name: String
+    let debtAccount: Account
+    let owedAmount: Decimal
+    let paymentLegs: [AdvancePaymentLegDraft]
+}
+
+struct AdvanceRepaymentDraft {
+    let repayment: AdvanceRepayment
+    let account: Account
+    let amount: Decimal
+    let currencyCode: String
+    let normalizedAmount: Decimal
+    let date: Date
+    let note: String
+    let category: Category?
+    let tags: [Tag]
+}
+
+struct AdvanceCaseEditDraft {
+    let advanceCase: AdvanceCase
+    let title: String
+    let date: Date
+    let direction: AdvanceDirection
+    let currencyCode: String
+    let note: String
+    let category: Category?
+    let tags: [Tag]
+    let share: AdvanceShareDraft?
+    let participants: [AdvanceParticipantDraft]
+    let repayments: [AdvanceRepaymentDraft]
+}
+
+struct AdvanceCaseImpactPreview {
+    let changesDirection: Bool
+    let changesCurrency: Bool
+    let affectedTransactionCount: Int
+    let affectedParticipantCount: Int
+    let affectedRepaymentCount: Int
+    let warnings: [String]
+}
+
+enum AdvanceCaseEditingError: LocalizedError {
+    case emptyTitle
+    case invalidCurrency
+    case noParticipants
+    case duplicateParticipant
+    case invalidPaymentLeg
+    case unsupportedDirectionChange
+    case unsupportedSplitPaymentEdit
+    case currencyChangeRequiresExplicitAmounts
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyTitle: return "請輸入案件名稱。"
+        case .invalidCurrency: return "請選擇案件幣種。"
+        case .noParticipants: return "請至少保留一位代墊對象。"
+        case .duplicateParticipant: return "同一債務對象不可重複。"
+        case .invalidPaymentLeg: return "實際付款帳戶、金額或幣種無效。"
+        case .unsupportedDirectionChange:
+            return "改變代墊方向需要重建底層分錄，請使用案件完整編輯流程。"
+        case .unsupportedSplitPaymentEdit:
+            return "多付款來源需要使用案件完整編輯流程。"
+        case .currencyChangeRequiresExplicitAmounts:
+            return "改變案件幣種前，必須重新確認每位對象與每筆還款的沖銷金額。"
+        }
+    }
+}
+
+enum AdvanceCaseEditingService {
+    @MainActor
+    static func preview(_ draft: AdvanceCaseEditDraft, modelContext: ModelContext) throws -> AdvanceCaseImpactPreview {
+        try validate(draft)
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let affected = transactions.filter { $0.advanceCaseID == draft.advanceCase.id }
+        var warnings: [String] = []
+        if draft.direction != draft.advanceCase.direction {
+            warnings.append("改變方向會重建案件的初始帳務分錄。")
+        }
+        if draft.currencyCode != draft.advanceCase.currencyCode {
+            warnings.append("案件幣種改變後，舊金額不會自動換算。")
+        }
+        return AdvanceCaseImpactPreview(
+            changesDirection: draft.direction != draft.advanceCase.direction,
+            changesCurrency: draft.currencyCode != draft.advanceCase.currencyCode,
+            affectedTransactionCount: affected.count,
+            affectedParticipantCount: draft.participants.count,
+            affectedRepaymentCount: draft.repayments.count,
+            warnings: warnings
+        )
+    }
+
+    @MainActor
+    static func apply(_ draft: AdvanceCaseEditDraft, modelContext: ModelContext) throws {
+        try validate(draft)
+        if draft.direction != draft.advanceCase.direction {
+            throw AdvanceCaseEditingError.unsupportedDirectionChange
+        }
+
+        let now = Date()
+        draft.advanceCase.title = draft.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        draft.advanceCase.date = draft.date
+        draft.advanceCase.direction = draft.direction
+        draft.advanceCase.currencyCode = draft.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        draft.advanceCase.note = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        draft.advanceCase.expenseCategory = draft.category
+        draft.advanceCase.tagIDs = draft.tags.map(\.id)
+        draft.advanceCase.updatedAt = now
+
+        for participantDraft in draft.participants {
+            if participantDraft.paymentLegs.count > 1 {
+                throw AdvanceCaseEditingError.unsupportedSplitPaymentEdit
+            }
+            let payment = participantDraft.paymentLegs.first
+            if draft.direction == .iAdvancedOthers, payment == nil {
+                throw AdvanceCaseEditingError.invalidPaymentLeg
+            }
+            participantDraft.participant.name = participantDraft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            participantDraft.participant.debtAccount = participantDraft.debtAccount
+            try AdvanceService.updateInitialEntry(
+                advanceCase: draft.advanceCase,
+                participant: participantDraft.participant,
+                draft: .init(
+                    payerAccount: draft.direction == .iAdvancedOthers ? payment?.account : nil,
+                    owedAmount: participantDraft.owedAmount,
+                    paymentAmount: payment?.amount,
+                    paymentCurrencyCode: payment?.currencyCode,
+                    date: draft.date,
+                    note: draft.note,
+                    category: draft.category,
+                    tags: draft.tags
+                ),
+                modelContext: modelContext
+            )
+        }
+
+        for repaymentDraft in draft.repayments {
+            try AdvanceService.updateRepayment(
+                advanceCase: draft.advanceCase,
+                repayment: repaymentDraft.repayment,
+                draft: .init(
+                    receiveAccount: repaymentDraft.account,
+                    amount: repaymentDraft.amount,
+                    currencyCode: repaymentDraft.currencyCode,
+                    normalizedAmount: repaymentDraft.normalizedAmount,
+                    date: repaymentDraft.date,
+                    note: repaymentDraft.note,
+                    category: repaymentDraft.category,
+                    tags: repaymentDraft.tags
+                ),
+                modelContext: modelContext
+            )
+        }
+        try modelContext.save()
+    }
+
+    private static func validate(_ draft: AdvanceCaseEditDraft) throws {
+        guard !draft.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AdvanceCaseEditingError.emptyTitle
+        }
+        guard !draft.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AdvanceCaseEditingError.invalidCurrency
+        }
+        guard !draft.participants.isEmpty else {
+            throw AdvanceCaseEditingError.noParticipants
+        }
+        let accountIDs = draft.participants.map(\.debtAccount.id)
+        guard Set(accountIDs).count == accountIDs.count else {
+            throw AdvanceCaseEditingError.duplicateParticipant
+        }
+        for participant in draft.participants {
+            guard participant.owedAmount > 0,
+                  participant.owedAmount >= participant.participant.repaidAmount
+            else {
+                throw AdvanceServiceError.adjustedOwedLowerThanRepaid
+            }
+            guard draft.direction == .othersAdvancedMe || (
+                !participant.paymentLegs.isEmpty && participant.paymentLegs.allSatisfy({
+                $0.account.type != .debt &&
+                    !$0.account.isArchived &&
+                    $0.amount > 0 &&
+                    !$0.currencyCode.isEmpty
+                })
+            ) else {
+                throw AdvanceCaseEditingError.invalidPaymentLeg
+            }
+        }
+        if draft.currencyCode != draft.advanceCase.currencyCode,
+           draft.repayments.contains(where: { $0.normalizedAmount <= 0 }) {
+            throw AdvanceCaseEditingError.currencyChangeRequiresExplicitAmounts
+        }
+    }
+}

--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -109,6 +109,8 @@ enum AdvanceService {
     struct InitialEntryEditDraft {
         let payerAccount: Account?
         let owedAmount: Decimal
+        let paymentAmount: Decimal?
+        let paymentCurrencyCode: String?
         let date: Date
         let note: String
         let category: Category?
@@ -133,6 +135,12 @@ enum AdvanceService {
         var totalUnresolved: Int {
             unresolvedCaseLinkCount + unresolvedParticipantLinkCount
         }
+    }
+
+    struct ExplicitLinkBackfillResult {
+        let linkedTransactionCount: Int
+        let updatedCaseCount: Int
+        let unresolvedRecordCount: Int
     }
 
     struct LegacyBorrowedAdvanceRepairResult {
@@ -480,6 +488,8 @@ enum AdvanceService {
             currencyCode: currencyCode,
             myShareAmount: myShareAmount,
             note: finalNote,
+            direction: isBorrowedByMe ? .othersAdvancedMe : .iAdvancedOthers,
+            tagIDs: tags.map(\.id),
             createdAt: now,
             updatedAt: now,
             payerAccount: payerAccount,
@@ -499,6 +509,8 @@ enum AdvanceService {
                 date: date,
                 note: expenseNote,
                 type: .expense,
+                advanceCaseID: advanceCase.id,
+                advanceEntryRole: .selfExpense,
                 account: payerAccount,
                 category: category,
                 tags: tags
@@ -541,6 +553,9 @@ enum AdvanceService {
                     linkedTransactionID: nil,
                     transferGroupID: transferGroupID,
                     transferSide: .outgoing,
+                    advanceCaseID: advanceCase.id,
+                    advanceParticipantID: participant.id,
+                    advanceEntryRole: .initialDebt,
                     account: input.debtAccount,
                     category: category,
                     tags: tags
@@ -562,6 +577,9 @@ enum AdvanceService {
                     linkedTransactionID: inID,
                     transferGroupID: transferGroupID,
                     transferSide: .outgoing,
+                    advanceCaseID: advanceCase.id,
+                    advanceParticipantID: participant.id,
+                    advanceEntryRole: .initialAsset,
                     account: payerAccount
                 )
 
@@ -575,6 +593,9 @@ enum AdvanceService {
                     linkedTransactionID: outID,
                     transferGroupID: transferGroupID,
                     transferSide: .incoming,
+                    advanceCaseID: advanceCase.id,
+                    advanceParticipantID: participant.id,
+                    advanceEntryRole: .initialDebt,
                     account: input.debtAccount
                 )
             }
@@ -789,6 +810,21 @@ enum AdvanceService {
             receivedAccount: receiveAccount
         )
         modelContext.insert(repayment)
+
+        outTx.advanceCaseID = advanceCase.id
+        outTx.advanceParticipantID = participant.id
+        outTx.advanceRepaymentID = repayment.id
+        inTx.advanceCaseID = advanceCase.id
+        inTx.advanceParticipantID = participant.id
+        inTx.advanceRepaymentID = repayment.id
+        switch settlementDirection {
+        case .iAdvancedOthers:
+            outTx.advanceEntryRole = .repaymentDebt
+            inTx.advanceEntryRole = .repaymentAsset
+        case .othersAdvancedMe:
+            outTx.advanceEntryRole = .repaymentAsset
+            inTx.advanceEntryRole = .repaymentDebt
+        }
         
         let updatedRepaid = participant.repaidAmount + normalizedAmount
         if participant.owedAmount - updatedRepaid < roundingTolerance {
@@ -1070,9 +1106,15 @@ enum AdvanceService {
                 else {
                     throw AdvanceServiceError.invalidRepaymentStructure
                 }
+                let paymentAmount = caseParticipant.id == participant.id
+                    ? abs(draft.paymentAmount ?? draft.owedAmount)
+                    : abs(outgoing.amount)
+                let paymentCurrency = caseParticipant.id == participant.id
+                    ? (draft.paymentCurrencyCode ?? advanceCase.currencyCode)
+                    : outgoing.currencyCode
                 outgoing.type = .transfer
-                outgoing.amount = -amount
-                outgoing.currencyCode = advanceCase.currencyCode
+                outgoing.amount = -paymentAmount
+                outgoing.currencyCode = paymentCurrency
                 outgoing.date = draft.date
                 outgoing.note = "\(baseMemo) (代墊給 \(caseParticipant.name))"
                 outgoing.account = payerAccount
@@ -1080,6 +1122,9 @@ enum AdvanceService {
                 outgoing.tags = []
                 outgoing.transferSide = .outgoing
                 outgoing.linkedTransactionID = incoming.id
+                outgoing.advanceCaseID = advanceCase.id
+                outgoing.advanceParticipantID = caseParticipant.id
+                outgoing.advanceEntryRole = .initialAsset
                 outgoing.updatedAt = now
 
                 incoming.type = .transfer
@@ -1092,6 +1137,9 @@ enum AdvanceService {
                 incoming.tags = []
                 incoming.transferSide = .incoming
                 incoming.linkedTransactionID = outgoing.id
+                incoming.advanceCaseID = advanceCase.id
+                incoming.advanceParticipantID = caseParticipant.id
+                incoming.advanceEntryRole = .initialDebt
                 incoming.updatedAt = now
             case .othersAdvancedMe:
                 guard let expense = transactions.first,
@@ -1109,6 +1157,9 @@ enum AdvanceService {
                 expense.tags = draft.tags
                 expense.linkedTransactionID = nil
                 expense.transferSide = .outgoing
+                expense.advanceCaseID = advanceCase.id
+                expense.advanceParticipantID = caseParticipant.id
+                expense.advanceEntryRole = .initialDebt
                 expense.updatedAt = now
             }
         }
@@ -1117,6 +1168,8 @@ enum AdvanceService {
         participant.repaidAmount = min(participant.repaidAmount, participant.owedAmount)
         participant.updatedAt = now
         advanceCase.payerAccount = direction == .iAdvancedOthers ? draft.payerAccount : nil
+        advanceCase.direction = direction == .iAdvancedOthers ? .iAdvancedOthers : .othersAdvancedMe
+        advanceCase.tagIDs = draft.tags.map(\.id)
         if direction == .othersAdvancedMe {
             advanceCase.expenseCategory = draft.category
         }
@@ -1652,6 +1705,101 @@ enum AdvanceService {
             unresolvedCaseLinkCount: unresolvedCaseLinkCount,
             updatedParticipantLinkCount: updatedParticipantLinkCount,
             unresolvedParticipantLinkCount: unresolvedParticipantLinkCount
+        )
+    }
+
+    @MainActor
+    static func backfillExplicitLinks(modelContext: ModelContext) throws -> ExplicitLinkBackfillResult {
+        let advanceCases = try modelContext.fetch(FetchDescriptor<AdvanceCase>())
+        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let transactionByID = Dictionary(uniqueKeysWithValues: transactions.map { ($0.id, $0) })
+        let transactionsByGroup = Dictionary(
+            grouping: transactions.compactMap { transaction -> (UUID, FinancialTransaction)? in
+                transaction.transferGroupID.map { ($0, transaction) }
+            },
+            by: \.0
+        ).mapValues { $0.map(\.1) }
+
+        var linkedTransactionCount = 0
+        var updatedCaseCount = 0
+        var unresolvedRecordCount = 0
+
+        for advanceCase in advanceCases {
+            if advanceCase.direction == nil {
+                if let participant = advanceCase.participants.first {
+                    advanceCase.direction = inferSettlementDirection(
+                        for: participant,
+                        modelContext: modelContext
+                    ) == .iAdvancedOthers ? .iAdvancedOthers : .othersAdvancedMe
+                    updatedCaseCount += 1
+                } else {
+                    unresolvedRecordCount += 1
+                }
+            }
+
+            if advanceCase.tagIDs.isEmpty,
+               let expenseID = advanceCase.selfExpenseTransactionID,
+               let expense = transactionByID[expenseID] {
+                advanceCase.tagIDs = expense.tags.map(\.id)
+                updatedCaseCount += 1
+            }
+
+            if let expenseID = advanceCase.selfExpenseTransactionID,
+               let expense = transactionByID[expenseID] {
+                if expense.advanceCaseID == nil {
+                    expense.advanceCaseID = advanceCase.id
+                    expense.advanceEntryRole = .selfExpense
+                    linkedTransactionCount += 1
+                }
+            } else if advanceCase.myShareAmount > 0, advanceCase.direction == .iAdvancedOthers {
+                unresolvedRecordCount += 1
+            }
+
+            for participant in advanceCase.participants {
+                guard let groupID = participant.initialTransferGroupID,
+                      let entries = transactionsByGroup[groupID],
+                      !entries.isEmpty
+                else {
+                    unresolvedRecordCount += 1
+                    continue
+                }
+                for entry in entries {
+                    guard entry.advanceCaseID == nil else { continue }
+                    entry.advanceCaseID = advanceCase.id
+                    entry.advanceParticipantID = participant.id
+                    entry.advanceEntryRole = entry.account?.type == .debt ? .initialDebt : .initialAsset
+                    linkedTransactionCount += 1
+                }
+            }
+
+            for repayment in advanceCase.repayments {
+                guard let groupID = repayment.linkedTransferGroupID,
+                      let entries = transactionsByGroup[groupID],
+                      !entries.isEmpty
+                else {
+                    if repaymentRecordKind(note: repayment.note) == .ordinary {
+                        unresolvedRecordCount += 1
+                    }
+                    continue
+                }
+                for entry in entries {
+                    guard entry.advanceCaseID == nil else { continue }
+                    entry.advanceCaseID = advanceCase.id
+                    entry.advanceParticipantID = repayment.participant?.id
+                    entry.advanceRepaymentID = repayment.id
+                    entry.advanceEntryRole = entry.account?.type == .debt ? .repaymentDebt : .repaymentAsset
+                    linkedTransactionCount += 1
+                }
+            }
+        }
+
+        if linkedTransactionCount > 0 || updatedCaseCount > 0 {
+            try modelContext.save()
+        }
+        return ExplicitLinkBackfillResult(
+            linkedTransactionCount: linkedTransactionCount,
+            updatedCaseCount: updatedCaseCount,
+            unresolvedRecordCount: unresolvedRecordCount
         )
     }
     

--- a/AI 記帳/Services/BackupManager.swift
+++ b/AI 記帳/Services/BackupManager.swift
@@ -43,6 +43,10 @@ struct FullBackupData: Codable {
         let createdAt: Date?
         let updatedAt: Date?
         let accountID: UUID?; let categoryID: UUID?; let tagIDs: [UUID]
+        let advanceCaseID: UUID?
+        let advanceParticipantID: UUID?
+        let advanceRepaymentID: UUID?
+        let advanceEntryRole: String?
     }
     struct ShortcutCodable: Codable {
         let id: UUID; let name: String; let icon: String; let amount: Decimal; let type: String; let note: String
@@ -119,6 +123,8 @@ struct FullBackupData: Codable {
         let expenseCategoryID: UUID?
         let createdAt: Date?
         let updatedAt: Date?
+        let direction: String?
+        let tagIDs: [UUID]?
     }
     struct AdvanceParticipantCodable: Codable {
         let id: UUID
@@ -217,7 +223,7 @@ class BackupManager: NSObject, ObservableObject {
         let advanceParticipants = (try? modelContext.fetch(FetchDescriptor<AdvanceParticipant>())) ?? []
         let advanceRepayments = (try? modelContext.fetch(FetchDescriptor<AdvanceRepayment>())) ?? []
         
-        return FullBackupData(version: "1.8", timestamp: Date(),
+        return FullBackupData(version: "1.9", timestamp: Date(),
             accounts: accounts.map { FullBackupData.AccountCodable(id: $0.id, name: $0.name, currency: $0.currency, type: $0.type.rawValue, baseBalance: $0.baseBalance, sortOrder: $0.sortOrder, isArchived: $0.isArchived) },
             categories: categories.map { FullBackupData.CategoryCodable(id: $0.id, name: $0.name, icon: $0.icon, colorHex: $0.colorHex, kind: $0.kind.rawValue) },
             tags: tags.map { FullBackupData.TagCodable(id: $0.id, name: $0.name) },
@@ -237,7 +243,11 @@ class BackupManager: NSObject, ObservableObject {
                     updatedAt: $0.updatedAt,
                     accountID: $0.account?.id,
                     categoryID: $0.category?.id,
-                    tagIDs: $0.tags.map { $0.id }
+                    tagIDs: $0.tags.map { $0.id },
+                    advanceCaseID: $0.advanceCaseID,
+                    advanceParticipantID: $0.advanceParticipantID,
+                    advanceRepaymentID: $0.advanceRepaymentID,
+                    advanceEntryRole: $0.advanceEntryRoleRaw
                 )
             },
             shortcuts: shortcuts.map { FullBackupData.ShortcutCodable(id: $0.id, name: $0.name, icon: $0.icon, amount: $0.amount, type: $0.type.rawValue, note: $0.note, currencyCode: $0.currencyCode, accountID: $0.account?.id, categoryID: $0.category?.id, tagIDs: $0.tags.map { $0.id }) },
@@ -320,7 +330,9 @@ class BackupManager: NSObject, ObservableObject {
                     payerAccountID: $0.payerAccount?.id,
                     expenseCategoryID: $0.expenseCategory?.id,
                     createdAt: $0.createdAt,
-                    updatedAt: $0.updatedAt
+                    updatedAt: $0.updatedAt,
+                    direction: $0.directionRaw,
+                    tagIDs: $0.tagIDs
                 )
             },
             advanceParticipants: advanceParticipants.map {
@@ -455,6 +467,10 @@ class BackupManager: NSObject, ObservableObject {
                 linkedTransactionID: txDTO.linkedTransactionID,
                 transferGroupID: txDTO.transferGroupID,
                 transferSide: TransferSide(rawValue: txDTO.transferSide ?? ""),
+                advanceCaseID: txDTO.advanceCaseID,
+                advanceParticipantID: txDTO.advanceParticipantID,
+                advanceRepaymentID: txDTO.advanceRepaymentID,
+                advanceEntryRole: txDTO.advanceEntryRole.flatMap(AdvanceEntryRole.init(rawValue:)),
                 account: txDTO.accountID.flatMap { accountByID[$0] },
                 category: txDTO.categoryID.flatMap { categoryByID[$0] },
                 tags: tagByID.values.filter { tagIDs.contains($0.id) },
@@ -635,6 +651,8 @@ class BackupManager: NSObject, ObservableObject {
                     myShareAmount: caseDTO.myShareAmount ?? 0,
                     note: caseDTO.note ?? "",
                     selfExpenseTransactionID: caseDTO.selfExpenseTransactionID,
+                    direction: caseDTO.direction.flatMap(AdvanceDirection.init(rawValue:)),
+                    tagIDs: caseDTO.tagIDs ?? [],
                     createdAt: caseDTO.createdAt ?? caseDTO.date,
                     updatedAt: caseDTO.updatedAt ?? (caseDTO.createdAt ?? caseDTO.date),
                     payerAccount: caseDTO.payerAccountID.flatMap { accountByID[$0] },
@@ -684,6 +702,7 @@ class BackupManager: NSObject, ObservableObject {
         }
 
         try modelContext.save()
+        _ = try AdvanceService.backfillExplicitLinks(modelContext: modelContext)
         _ = try AdvanceService.reconcileUnderstatedRepaymentTotals(modelContext: modelContext)
         try BudgetHistoryService.shared.syncAll(modelContext: modelContext, currencyService: CurrencyService.shared)
         try modelContext.save()

--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -396,6 +396,7 @@ struct SettingsView: View {
     private func repairLegacyAdvanceLinksAfterImport() {
         do {
             let result = try AdvanceService.repairLegacyLinks(modelContext: modelContext)
+            _ = try AdvanceService.backfillExplicitLinks(modelContext: modelContext)
             alertMessage = """
             匯入成功並完成修復。
             已更新 \(result.totalUpdated) 筆連結。

--- a/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
+++ b/AI 記帳/Views/Transactions/EditAdvanceTransferView.swift
@@ -551,6 +551,8 @@ struct EditAdvanceTransferView: View {
                     draft: .init(
                         payerAccount: selectedAccount,
                         owedAmount: amount,
+                        paymentAmount: amount,
+                        paymentCurrencyCode: currencyCode,
                         date: date,
                         note: note,
                         category: selectedCategory,

--- a/AI 記帳Tests/AdvanceEditingTests.swift
+++ b/AI 記帳Tests/AdvanceEditingTests.swift
@@ -4,6 +4,54 @@ import SwiftData
 
 @MainActor
 final class AdvanceEditingTests: XCTestCase {
+    func testInitialEntrySupportsActualPaymentCurrencySeparateFromDebtCurrency() throws {
+        let context = try makeContext()
+        let bank = Account(name: "HSBC HKD", currency: "HKD", type: .bank, baseBalance: 0)
+        let friend = Account(name: "TKL", currency: "JPY", type: .debt, baseBalance: 0)
+        [bank, friend].forEach(context.insert)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "LUUP",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: bank,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 710)],
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+
+        try AdvanceService.updateInitialEntry(
+            advanceCase: advanceCase,
+            participant: participant,
+            draft: .init(
+                payerAccount: bank,
+                owedAmount: 710,
+                paymentAmount: Decimal(string: "34.86"),
+                paymentCurrencyCode: "HKD",
+                date: Date(timeIntervalSince1970: 20),
+                note: "LUUP",
+                category: nil,
+                tags: []
+            ),
+            modelContext: context
+        )
+
+        let groupID = try XCTUnwrap(participant.initialTransferGroupID)
+        let group = try fetchGroup(groupID, context: context)
+        let asset = try XCTUnwrap(group.first { $0.advanceEntryRole == .initialAsset })
+        let debt = try XCTUnwrap(group.first { $0.advanceEntryRole == .initialDebt })
+        XCTAssertEqual(Decimal(string: "-34.86"), asset.amount)
+        XCTAssertEqual("HKD", asset.currencyCode)
+        XCTAssertEqual(Decimal(710), debt.amount)
+        XCTAssertEqual("JPY", debt.currencyCode)
+        XCTAssertEqual(advanceCase.id, asset.advanceCaseID)
+        XCTAssertEqual(participant.id, debt.advanceParticipantID)
+    }
+
     func testCrossCurrencyRepaymentEditPreservesExplicitNormalizedAmountAndIncomingMetadata() throws {
         let context = try makeContext()
         let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
@@ -261,6 +309,8 @@ final class AdvanceEditingTests: XCTestCase {
             draft: .init(
                 payerAccount: bank,
                 owedAmount: 120,
+                paymentAmount: 120,
+                paymentCurrencyCode: "HKD",
                 date: editedDate,
                 note: "Edited",
                 category: nil,
@@ -442,6 +492,102 @@ final class AdvanceEditingTests: XCTestCase {
         }
         XCTAssertEqual(Decimal(40), repayment.amount)
         XCTAssertEqual(Decimal(40), participant.repaidAmount)
+    }
+
+    func testExplicitLinkBackfillUsesExistingCaseAndGroupIdentifiers() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "JPY", type: .debt, baseBalance: 0)
+        [wallet, friend].forEach(context.insert)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "LUUP",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 710)],
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        let entries = try fetchGroup(
+            try XCTUnwrap(participant.initialTransferGroupID),
+            context: context
+        )
+        for entry in entries {
+            entry.advanceCaseID = nil
+            entry.advanceParticipantID = nil
+            entry.advanceEntryRole = nil
+        }
+        advanceCase.direction = nil
+        try context.save()
+
+        let result = try AdvanceService.backfillExplicitLinks(modelContext: context)
+
+        XCTAssertEqual(2, result.linkedTransactionCount)
+        XCTAssertEqual(.iAdvancedOthers, advanceCase.direction)
+        XCTAssertTrue(entries.allSatisfy { $0.advanceCaseID == advanceCase.id })
+        XCTAssertTrue(entries.allSatisfy { $0.advanceParticipantID == participant.id })
+        XCTAssertEqual(
+            Set([AdvanceEntryRole.initialAsset, AdvanceEntryRole.initialDebt]),
+            Set(entries.compactMap(\.advanceEntryRole))
+        )
+    }
+
+    func testCaseEditingRejectsDirectionChangeBeforeMutatingCase() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        [wallet, friend].forEach(context.insert)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Dinner",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 100)],
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        let draft = AdvanceCaseEditDraft(
+            advanceCase: advanceCase,
+            title: "Changed",
+            date: advanceCase.date,
+            direction: .othersAdvancedMe,
+            currencyCode: advanceCase.currencyCode,
+            note: advanceCase.note,
+            category: nil,
+            tags: [],
+            share: nil,
+            participants: [
+                AdvanceParticipantDraft(
+                    participant: participant,
+                    name: participant.name,
+                    debtAccount: friend,
+                    owedAmount: participant.owedAmount,
+                    paymentLegs: []
+                )
+            ],
+            repayments: []
+        )
+
+        XCTAssertThrowsError(
+            try AdvanceCaseEditingService.apply(draft, modelContext: context)
+        ) { error in
+            XCTAssertEqual(
+                AdvanceCaseEditingError.unsupportedDirectionChange.localizedDescription,
+                error.localizedDescription
+            )
+        }
+        XCTAssertEqual("Dinner", advanceCase.title)
+        XCTAssertEqual(.iAdvancedOthers, advanceCase.direction)
     }
 
     private func makeContext() throws -> ModelContext {

--- a/AI 記帳Tests/ReportAggregationServiceTests.swift
+++ b/AI 記帳Tests/ReportAggregationServiceTests.swift
@@ -351,6 +351,16 @@ private struct FixedReportCurrencyConverter: ReportCurrencyConverting {
     let ratesToMain: [String: Decimal]
     let source: ReportEstimateStatus
 
+    init(
+        mainCurrency: String,
+        ratesToMain: [String: Decimal] = [:],
+        source: ReportEstimateStatus = .exact
+    ) {
+        self.mainCurrency = mainCurrency
+        self.ratesToMain = ratesToMain
+        self.source = source
+    }
+
     func estimateInMainCurrency(amount: Decimal, from currencyCode: String) -> ReportConversion? {
         if currencyCode.uppercased() == mainCurrency.uppercased() {
             return ReportConversion(amount: amount, status: .exact)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/AppContainer.kt
@@ -17,6 +17,7 @@ class AppContainer(context: Context) {
             .addMigrations(AIAccountingDatabase.MIGRATION_2_3)
             .addMigrations(AIAccountingDatabase.MIGRATION_3_4)
             .addMigrations(AIAccountingDatabase.MIGRATION_4_5)
+            .addMigrations(AIAccountingDatabase.MIGRATION_5_6)
             .addCallback(SeedData.callback(appContext))
             .build()
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/backup/BackupModels.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/backup/BackupModels.kt
@@ -59,7 +59,11 @@ data class FullBackupData(
         val updatedAt: Instant?,
         val accountID: UUID?,
         val categoryID: UUID?,
-        val tagIDs: List<UUID>
+        val tagIDs: List<UUID>,
+        val advanceCaseID: UUID? = null,
+        val advanceParticipantID: UUID? = null,
+        val advanceRepaymentID: UUID? = null,
+        val advanceEntryRole: String? = null
     )
 
     data class ShortcutCodable(
@@ -148,7 +152,9 @@ data class FullBackupData(
         val payerAccountID: UUID?,
         val expenseCategoryID: UUID?,
         val createdAt: Instant?,
-        val updatedAt: Instant?
+        val updatedAt: Instant?,
+        val direction: String? = null,
+        val tagIDs: List<UUID>? = null
     )
 
     data class AdvanceParticipantCodable(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/AIAccountingDatabase.kt
@@ -22,10 +22,11 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         BudgetMonthlyHistoryEntity::class,
         BudgetSettingsEntity::class,
         AdvanceCaseEntity::class,
+        AdvanceCaseTagCrossRef::class,
         AdvanceParticipantEntity::class,
         AdvanceRepaymentEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -142,6 +143,29 @@ abstract class AIAccountingDatabase : RoomDatabase() {
                     """.trimIndent()
                 )
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_recurring_rule_tag_cross_ref_tagId` ON `recurring_rule_tag_cross_ref` (`tagId`)")
+            }
+        }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `transactions` ADD COLUMN `advanceCaseId` TEXT")
+                db.execSQL("ALTER TABLE `transactions` ADD COLUMN `advanceParticipantId` TEXT")
+                db.execSQL("ALTER TABLE `transactions` ADD COLUMN `advanceRepaymentId` TEXT")
+                db.execSQL("ALTER TABLE `transactions` ADD COLUMN `advanceEntryRole` TEXT")
+                db.execSQL("ALTER TABLE `advance_cases` ADD COLUMN `direction` TEXT")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transactions_advanceCaseId` ON `transactions` (`advanceCaseId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transactions_advanceParticipantId` ON `transactions` (`advanceParticipantId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transactions_advanceRepaymentId` ON `transactions` (`advanceRepaymentId`)")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `advance_case_tag_cross_ref` (
+                        `advanceCaseId` TEXT NOT NULL,
+                        `tagId` TEXT NOT NULL,
+                        PRIMARY KEY(`advanceCaseId`, `tagId`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_advance_case_tag_cross_ref_tagId` ON `advance_case_tag_cross_ref` (`tagId`)")
             }
         }
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Daos.kt
@@ -301,6 +301,15 @@ interface AdvanceDao {
     suspend fun upsertCase(advanceCase: AdvanceCaseEntity)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCaseTags(tags: List<AdvanceCaseTagCrossRef>)
+
+    @Query("SELECT * FROM advance_case_tag_cross_ref")
+    suspend fun getCaseTags(): List<AdvanceCaseTagCrossRef>
+
+    @Query("DELETE FROM advance_case_tag_cross_ref WHERE advanceCaseId = :caseId")
+    suspend fun clearCaseTags(caseId: UUID)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertParticipants(participants: List<AdvanceParticipantEntity>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -323,4 +332,7 @@ interface AdvanceDao {
 
     @Query("DELETE FROM advance_cases")
     suspend fun deleteAllCases()
+
+    @Query("DELETE FROM advance_case_tag_cross_ref")
+    suspend fun deleteAllCaseTags()
 }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/db/Entities.kt
@@ -42,7 +42,10 @@ data class TagEntity(
     indices = [
         Index("accountId"),
         Index("categoryId"),
-        Index("transferGroupId")
+        Index("transferGroupId"),
+        Index("advanceCaseId"),
+        Index("advanceParticipantId"),
+        Index("advanceRepaymentId")
     ]
 )
 data class TransactionEntity(
@@ -59,7 +62,11 @@ data class TransactionEntity(
     val createdAt: Instant,
     val updatedAt: Instant,
     val accountId: UUID?,
-    val categoryId: UUID?
+    val categoryId: UUID?,
+    val advanceCaseId: UUID? = null,
+    val advanceParticipantId: UUID? = null,
+    val advanceRepaymentId: UUID? = null,
+    val advanceEntryRole: String? = null
 )
 
 @Entity(
@@ -209,7 +216,18 @@ data class AdvanceCaseEntity(
     val createdAt: Instant,
     val updatedAt: Instant,
     val payerAccountId: UUID?,
-    val expenseCategoryId: UUID?
+    val expenseCategoryId: UUID?,
+    val direction: String? = null
+)
+
+@Entity(
+    tableName = "advance_case_tag_cross_ref",
+    primaryKeys = ["advanceCaseId", "tagId"],
+    indices = [Index("tagId")]
+)
+data class AdvanceCaseTagCrossRef(
+    val advanceCaseId: UUID,
+    val tagId: UUID
 )
 
 @Entity(

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -19,6 +19,7 @@ import org.duckdns.lhfser.aiaccounting.core.model.TransferSide
 import org.duckdns.lhfser.aiaccounting.core.transactions.TransactionSemantics
 import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseTagCrossRef
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceParticipantEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AdvanceRepaymentEntity
 import org.duckdns.lhfser.aiaccounting.data.db.AIAccountingDatabase
@@ -118,6 +119,14 @@ data class TransferGroupReplacementDraft(
 enum class AdvanceSettlementDirection {
     IAdvancedOthers,
     OthersAdvancedMe
+}
+
+enum class AdvanceEntryRole {
+    SelfExpense,
+    InitialAsset,
+    InitialDebt,
+    RepaymentAsset,
+    RepaymentDebt
 }
 
 data class AdvanceRepaymentEditDraft(
@@ -1369,7 +1378,9 @@ class AccountingRepository(
                     createdAt = now,
                     updatedAt = now,
                     accountId = payerAccount.id,
-                    categoryId = expenseCategory?.id
+                    categoryId = expenseCategory?.id,
+                    advanceCaseId = caseId,
+                    advanceEntryRole = AdvanceEntryRole.SelfExpense.name
                 )
                 transactionDao.upsert(expenseTx)
                 if (tagIds.isNotEmpty()) {
@@ -1391,9 +1402,19 @@ class AccountingRepository(
                 createdAt = now,
                 updatedAt = now,
                 payerAccountId = payerAccount?.id,
-                expenseCategoryId = expenseCategory?.id
+                expenseCategoryId = expenseCategory?.id,
+                direction = if (isBorrowedByMe) {
+                    AdvanceSettlementDirection.OthersAdvancedMe.name
+                } else {
+                    AdvanceSettlementDirection.IAdvancedOthers.name
+                }
             )
             advanceDao.upsertCase(advanceCase)
+            if (tagIds.isNotEmpty()) {
+                advanceDao.insertCaseTags(
+                    tagIds.distinct().map { tagId -> AdvanceCaseTagCrossRef(caseId, tagId) }
+                )
+            }
 
             val transferMemo = if (finalNote.isBlank()) finalTitle else finalNote
             val participantEntities = mutableListOf<AdvanceParticipantEntity>()
@@ -1404,10 +1425,11 @@ class AccountingRepository(
                 val transferGroupId = UUID.randomUUID()
                 val outId = UUID.randomUUID()
                 val inId = UUID.randomUUID()
+                val participantId = UUID.randomUUID()
 
                 participantEntities.add(
                     AdvanceParticipantEntity(
-                        id = UUID.randomUUID(),
+                        id = participantId,
                         name = input.debtAccount.name,
                         owedAmount = input.owedAmount.abs(),
                         repaidAmount = BigDecimal.ZERO,
@@ -1434,7 +1456,10 @@ class AccountingRepository(
                         createdAt = now,
                         updatedAt = now,
                         accountId = input.debtAccount.id,
-                        categoryId = expenseCategory?.id
+                        categoryId = expenseCategory?.id,
+                        advanceCaseId = caseId,
+                        advanceParticipantId = participantId,
+                        advanceEntryRole = AdvanceEntryRole.InitialDebt.name
                     )
                     transferEntities.add(expenseTx)
                     if (tagIds.isNotEmpty()) {
@@ -1456,7 +1481,10 @@ class AccountingRepository(
                         createdAt = now,
                         updatedAt = now,
                         accountId = payer.id,
-                        categoryId = null
+                        categoryId = null,
+                        advanceCaseId = caseId,
+                        advanceParticipantId = participantId,
+                        advanceEntryRole = AdvanceEntryRole.InitialAsset.name
                     )
                     val inTx = TransactionEntity(
                         id = inId,
@@ -1472,7 +1500,10 @@ class AccountingRepository(
                         createdAt = now,
                         updatedAt = now,
                         accountId = input.debtAccount.id,
-                        categoryId = null
+                        categoryId = null,
+                        advanceCaseId = caseId,
+                        advanceParticipantId = participantId,
+                        advanceEntryRole = AdvanceEntryRole.InitialDebt.name
                     )
                     transferEntities.add(outTx)
                     transferEntities.add(inTx)
@@ -1581,6 +1612,7 @@ class AccountingRepository(
         val transferGroupId = UUID.randomUUID()
         val outId = UUID.randomUUID()
         val inId = UUID.randomUUID()
+        val repaymentId = UUID.randomUUID()
         val amount = draft.amount.abs()
         val currency = draft.currencyCode.trim().uppercase()
         val transferMemo = draft.note.trim().ifBlank { currentCase.title }
@@ -1603,7 +1635,11 @@ class AccountingRepository(
                 createdAt = now,
                 updatedAt = now,
                 accountId = currentReceiveAccount.id,
-                categoryId = currentCategory?.id
+                categoryId = currentCategory?.id,
+                advanceCaseId = currentCase.id,
+                advanceParticipantId = currentParticipant.id,
+                advanceRepaymentId = repaymentId,
+                advanceEntryRole = AdvanceEntryRole.RepaymentAsset.name
             )
             inTx = TransactionEntity(
                 id = inId,
@@ -1619,7 +1655,11 @@ class AccountingRepository(
                 createdAt = now,
                 updatedAt = now,
                 accountId = currentParticipant.debtAccountId,
-                categoryId = null
+                categoryId = null,
+                advanceCaseId = currentCase.id,
+                advanceParticipantId = currentParticipant.id,
+                advanceRepaymentId = repaymentId,
+                advanceEntryRole = AdvanceEntryRole.RepaymentDebt.name
             )
             taggedTxId = outId
         } else {
@@ -1637,7 +1677,11 @@ class AccountingRepository(
                 createdAt = now,
                 updatedAt = now,
                 accountId = currentParticipant.debtAccountId,
-                categoryId = null
+                categoryId = null,
+                advanceCaseId = currentCase.id,
+                advanceParticipantId = currentParticipant.id,
+                advanceRepaymentId = repaymentId,
+                advanceEntryRole = AdvanceEntryRole.RepaymentDebt.name
             )
             inTx = TransactionEntity(
                 id = inId,
@@ -1653,7 +1697,11 @@ class AccountingRepository(
                 createdAt = now,
                 updatedAt = now,
                 accountId = currentReceiveAccount.id,
-                categoryId = currentCategory?.id
+                categoryId = currentCategory?.id,
+                advanceCaseId = currentCase.id,
+                advanceParticipantId = currentParticipant.id,
+                advanceRepaymentId = repaymentId,
+                advanceEntryRole = AdvanceEntryRole.RepaymentAsset.name
             )
             taggedTxId = inId
         }
@@ -1676,7 +1724,7 @@ class AccountingRepository(
         advanceDao.upsertCase(currentCase.copy(updatedAt = now))
         advanceDao.upsertRepayment(
             AdvanceRepaymentEntity(
-                id = UUID.randomUUID(),
+                id = repaymentId,
                 amount = amount,
                 currencyCode = currency,
                 normalizedAmount = normalized,
@@ -1927,7 +1975,12 @@ class AccountingRepository(
         }
     }
 
-    suspend fun updateAdvanceParticipantOwedAmount(participantId: UUID, newOwedAmount: BigDecimal) {
+    suspend fun updateAdvanceParticipantOwedAmount(
+        participantId: UUID,
+        newOwedAmount: BigDecimal,
+        paymentAmount: BigDecimal? = null,
+        paymentCurrencyCode: String? = null
+    ) {
         require(newOwedAmount > BigDecimal.ZERO) { "欠款金額必須大於 0。" }
 
         database.withTransaction {
@@ -1971,12 +2024,31 @@ class AccountingRepository(
                     require(group.size == 2) { "我代墊他人的初始轉帳結構不完整。" }
                     group.map { item ->
                         val side = effectiveTransferSide(item.transaction)
+                        val isAssetLeg = side == TransferSide.Outgoing
+                        val actualAmount = if (isAssetLeg) {
+                            paymentAmount?.abs() ?: item.transaction.amount.abs()
+                        } else {
+                            amount
+                        }
                         item.transaction.copy(
-                            amount = if (side == TransferSide.Outgoing) amount.negate() else amount,
-                            currencyCode = advanceCase.currencyCode,
+                            amount = if (isAssetLeg) actualAmount.negate() else actualAmount,
+                            currencyCode = if (isAssetLeg) {
+                                paymentCurrencyCode?.trim()?.uppercase()
+                                    ?.takeIf(String::isNotBlank)
+                                    ?: item.transaction.currencyCode
+                            } else {
+                                advanceCase.currencyCode
+                            },
                             date = advanceCase.date,
                             transferSide = side,
-                            updatedAt = now
+                            updatedAt = now,
+                            advanceCaseId = advanceCase.id,
+                            advanceParticipantId = participant.id,
+                            advanceEntryRole = if (isAssetLeg) {
+                                AdvanceEntryRole.InitialAsset.name
+                            } else {
+                                AdvanceEntryRole.InitialDebt.name
+                            }
                         )
                     }
                 }
@@ -2073,7 +2145,10 @@ class AccountingRepository(
                                     transferSide = TransferSide.Outgoing,
                                     updatedAt = now,
                                     accountId = requireNotNull(payerAccount).id,
-                                    categoryId = null
+                                    categoryId = null,
+                                    advanceCaseId = advanceCase.id,
+                                    advanceParticipantId = participant.id,
+                                    advanceEntryRole = AdvanceEntryRole.InitialAsset.name
                                 ),
                                 incoming.copy(
                                     amount = amount,
@@ -2084,7 +2159,10 @@ class AccountingRepository(
                                     transferSide = TransferSide.Incoming,
                                     updatedAt = now,
                                     accountId = participant.debtAccountId,
-                                    categoryId = null
+                                    categoryId = null,
+                                    advanceCaseId = advanceCase.id,
+                                    advanceParticipantId = participant.id,
+                                    advanceEntryRole = AdvanceEntryRole.InitialDebt.name
                                 )
                             )
                         )
@@ -2103,7 +2181,10 @@ class AccountingRepository(
                                 transferSide = TransferSide.Outgoing,
                                 updatedAt = now,
                                 accountId = participant.debtAccountId,
-                                categoryId = category?.id
+                                categoryId = category?.id,
+                                advanceCaseId = advanceCase.id,
+                                advanceParticipantId = participant.id,
+                                advanceEntryRole = AdvanceEntryRole.InitialDebt.name
                             )
                         )
                         transactionDao.clearTransactionTags(expense.id)
@@ -2126,9 +2207,18 @@ class AccountingRepository(
                         if (direction == AdvanceSettlementDirection.IAdvancedOthers) payerAccount?.id else null,
                     expenseCategoryId =
                         if (direction == AdvanceSettlementDirection.OthersAdvancedMe) category?.id
-                        else advanceCase.expenseCategoryId
+                        else advanceCase.expenseCategoryId,
+                    direction = direction.name
                 )
             )
+            advanceDao.clearCaseTags(advanceCase.id)
+            if (draft.tagIds.isNotEmpty()) {
+                advanceDao.insertCaseTags(
+                    draft.tagIds.distinct().map { tagId ->
+                        AdvanceCaseTagCrossRef(advanceCase.id, tagId)
+                    }
+                )
+            }
             syncAllBudgetHistory()
         }
     }
@@ -2148,15 +2238,17 @@ class AccountingRepository(
         val budgetHistories = budgetDao.getAllHistory()
         val budgetSettings = budgetDao.getSettings()
         val advanceCases = advanceDao.getAllCases()
+        val advanceCaseTags = advanceDao.getCaseTags()
         val advanceParticipants = advanceDao.getAllParticipants()
         val advanceRepayments = advanceDao.getAllRepayments()
 
         val transactionTagMap = transactionTags.groupBy { it.transactionId }
         val shortcutTagMap = shortcutTags.groupBy { it.shortcutId }
         val recurringRuleTagMap = recurringRuleTags.groupBy { it.ruleId }
+        val advanceCaseTagMap = advanceCaseTags.groupBy { it.advanceCaseId }
 
         return FullBackupData(
-            version = "1.8",
+            version = "1.9",
             timestamp = Instant.now(),
             accounts = accounts.map {
                 FullBackupData.AccountCodable(
@@ -2195,7 +2287,11 @@ class AccountingRepository(
                     updatedAt = tx.updatedAt,
                     accountID = tx.accountId,
                     categoryID = tx.categoryId,
-                    tagIDs = transactionTagMap[tx.id]?.map { it.tagId } ?: emptyList()
+                    tagIDs = transactionTagMap[tx.id]?.map { it.tagId } ?: emptyList(),
+                    advanceCaseID = tx.advanceCaseId,
+                    advanceParticipantID = tx.advanceParticipantId,
+                    advanceRepaymentID = tx.advanceRepaymentId,
+                    advanceEntryRole = tx.advanceEntryRole
                 )
             },
             shortcuts = shortcuts.map { shortcut ->
@@ -2291,7 +2387,9 @@ class AccountingRepository(
                     payerAccountID = case.payerAccountId,
                     expenseCategoryID = case.expenseCategoryId,
                     createdAt = case.createdAt,
-                    updatedAt = case.updatedAt
+                    updatedAt = case.updatedAt,
+                    direction = case.direction,
+                    tagIDs = advanceCaseTagMap[case.id]?.map { it.tagId } ?: emptyList()
                 )
             },
             advanceParticipants = advanceParticipants.map { participant ->
@@ -2378,7 +2476,11 @@ class AccountingRepository(
                 createdAt = tx.createdAt ?: Instant.now(),
                 updatedAt = tx.updatedAt ?: Instant.now(),
                 accountId = tx.accountID,
-                categoryId = tx.categoryID
+                categoryId = tx.categoryID,
+                advanceCaseId = tx.advanceCaseID,
+                advanceParticipantId = tx.advanceParticipantID,
+                advanceRepaymentId = tx.advanceRepaymentID,
+                advanceEntryRole = tx.advanceEntryRole
             )
         }
         val transactionTags = data.transactions.flatMap { tx ->
@@ -2495,8 +2597,12 @@ class AccountingRepository(
                 createdAt = case.createdAt ?: Instant.now(),
                 updatedAt = case.updatedAt ?: Instant.now(),
                 payerAccountId = case.payerAccountID,
-                expenseCategoryId = case.expenseCategoryID
+                expenseCategoryId = case.expenseCategoryID,
+                direction = case.direction
             )
+        }.orEmpty()
+        val caseTags = data.advanceCases?.flatMap { case ->
+            case.tagIDs.orEmpty().map { tagId -> AdvanceCaseTagCrossRef(case.id, tagId) }
         }.orEmpty()
 
         val participantEntities = data.advanceParticipants?.map { participant ->
@@ -2564,11 +2670,94 @@ class AccountingRepository(
             }
             settingsEntities.forEach { budgetDao.upsertSettings(it) }
             caseEntities.forEach { advanceDao.upsertCase(it) }
+            if (caseTags.isNotEmpty()) {
+                advanceDao.insertCaseTags(caseTags)
+            }
             if (participantEntities.isNotEmpty()) {
                 advanceDao.upsertParticipants(participantEntities)
             }
             repaymentEntities.forEach { advanceDao.upsertRepayment(it) }
+            backfillAdvanceLinksLocked()
             syncAllBudgetHistory()
+        }
+    }
+
+    suspend fun backfillAdvanceLinks() {
+        database.withTransaction {
+            backfillAdvanceLinksLocked()
+        }
+    }
+
+    private suspend fun backfillAdvanceLinksLocked() {
+        val cases = advanceDao.getAllCases()
+        val participants = advanceDao.getAllParticipants()
+        val repayments = advanceDao.getAllRepayments()
+        val participantsByCase = participants.groupBy { it.advanceCaseId }
+        val repaymentsByCase = repayments.groupBy { it.advanceCaseId }
+
+        cases.forEach { advanceCase ->
+            val caseParticipants = participantsByCase[advanceCase.id].orEmpty()
+            if (advanceCase.direction == null && caseParticipants.isNotEmpty()) {
+                val direction = advanceSettlementDirectionLocked(caseParticipants.first())
+                advanceDao.upsertCase(advanceCase.copy(direction = direction.name))
+            }
+
+            advanceCase.selfExpenseTransactionId?.let { transactionId ->
+                transactionDao.getTransaction(transactionId)?.transaction?.let { transaction ->
+                    if (transaction.advanceCaseId == null) {
+                        transactionDao.upsert(
+                            transaction.copy(
+                                advanceCaseId = advanceCase.id,
+                                advanceEntryRole = AdvanceEntryRole.SelfExpense.name
+                            )
+                        )
+                    }
+                }
+            }
+
+            caseParticipants.forEach { participant ->
+                participant.initialTransferGroupId?.let { groupId ->
+                    transactionDao.getTransferGroup(groupId).forEach { details ->
+                        val transaction = details.transaction
+                        if (transaction.advanceCaseId == null) {
+                            transactionDao.upsert(
+                                transaction.copy(
+                                    advanceCaseId = advanceCase.id,
+                                    advanceParticipantId = participant.id,
+                                    advanceEntryRole = if (transaction.accountId == participant.debtAccountId) {
+                                        AdvanceEntryRole.InitialDebt.name
+                                    } else {
+                                        AdvanceEntryRole.InitialAsset.name
+                                    }
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            repaymentsByCase[advanceCase.id].orEmpty().forEach { repayment ->
+                repayment.linkedTransferGroupId?.let { groupId ->
+                    val participant = participants.firstOrNull { it.id == repayment.participantId }
+                    transactionDao.getTransferGroup(groupId).forEach { details ->
+                        val transaction = details.transaction
+                        if (transaction.advanceCaseId == null) {
+                            transactionDao.upsert(
+                                transaction.copy(
+                                    advanceCaseId = advanceCase.id,
+                                    advanceParticipantId = participant?.id,
+                                    advanceRepaymentId = repayment.id,
+                                    advanceEntryRole = if (transaction.accountId == participant?.debtAccountId) {
+                                        AdvanceEntryRole.RepaymentDebt.name
+                                    } else {
+                                        AdvanceEntryRole.RepaymentAsset.name
+                                    }
+                                )
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -2649,6 +2838,7 @@ class AccountingRepository(
         shortcutDao.deleteAllShortcutTags()
         advanceDao.deleteAllRepayments()
         advanceDao.deleteAllParticipants()
+        advanceDao.deleteAllCaseTags()
         advanceDao.deleteAllCases()
         budgetDao.deleteAllSettings()
         budgetDao.deleteAllHistory()

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
@@ -78,6 +78,41 @@ class AdvanceEditingTest {
     }
 
     @Test
+    fun initialEntry_supportsActualPaymentCurrencySeparateFromDebtCurrency() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "LUUP",
+            date = Instant.parse("2026-06-10T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = bank,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("710")))
+        )
+        val participant = requireNotNull(repository.getAdvanceCase(caseId)).participants.single()
+
+        repository.updateAdvanceParticipantOwedAmount(
+            participantId = participant.id,
+            newOwedAmount = BigDecimal("710"),
+            paymentAmount = BigDecimal("34.86"),
+            paymentCurrencyCode = "HKD"
+        )
+
+        val group = database.transactionDao().getTransferGroup(
+            requireNotNull(participant.initialTransferGroupId)
+        ).map { it.transaction }
+        val asset = group.single { it.advanceEntryRole == "InitialAsset" }
+        val debt = group.single { it.advanceEntryRole == "InitialDebt" }
+        assertEquals("-34.86", asset.amount.toPlainString())
+        assertEquals("HKD", asset.currencyCode)
+        assertEquals("710", debt.amount.toPlainString())
+        assertEquals("JPY", debt.currencyCode)
+        assertEquals(caseId, asset.advanceCaseId)
+        assertEquals(participant.id, debt.advanceParticipantId)
+    }
+
+    @Test
     fun crossCurrencyRepaymentEdit_preservesExplicitSettlementAndMovesMetadataToIncomingOwnLeg() = runBlocking {
         val caseId = repository.createAdvanceCase(
             title = "Japan trip",

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -84,6 +84,13 @@ class BackupRoundTripTest {
                 ?.myShareAmount
                 ?.toPlainString()
         )
+        assertTrue(exported.advanceCases.orEmpty().all { !it.direction.isNullOrBlank() })
+        assertTrue(exported.transactions.any { it.advanceCaseID != null })
+        assertTrue(
+            exported.transactions
+                .filter { it.advanceCaseID != null }
+                .all { !it.advanceEntryRole.isNullOrBlank() }
+        )
 
         val secondDatabase = buildDatabase()
         try {
@@ -844,7 +851,7 @@ class BackupRoundTripTest {
 
         val exportedJson = repository.exportBackupJson()
         val exported = BackupJsonAdapter.gson.fromJson(exportedJson, FullBackupData::class.java)
-        assertEquals("1.8", exported.version)
+        assertEquals("1.9", exported.version)
         assertEquals(1, exported.recurringRules?.size)
         assertEquals(1, exported.recurringOccurrences?.size)
 


### PR DESCRIPTION
## Summary
- add explicit advance case, participant, repayment and entry-role links on iOS and Android
- migrate/backfill legacy records conservatively and preserve links in backup v1.9
- support actual payment currency differing from the debt currency
- add safe editing drafts and cross-platform regression coverage

## Validation
- iOS simulator app build succeeded
- iOS test bundle build succeeded
- Android `testDebugUnitTest assembleDebug --rerun-tasks` succeeded
- Simulator runtime test launch is currently blocked by a local CoreSimulator boot timeout; compilation and CI provide independent validation

Local `.xcscheme` and `Localizable.xcstrings` changes are intentionally excluded.