### PR TITLE
Add case-based advance ledger editing

### DIFF
--- a/AI 記帳/Services/AdvanceService.swift
+++ b/AI 記帳/Services/AdvanceService.swift
@@ -107,6 +107,9 @@ enum AdvanceService {
     }
 
     struct InitialEntryEditDraft {
+        let caseTitle: String?
+        let participantName: String?
+        let debtAccount: Account?
         let payerAccount: Account?
         let owedAmount: Decimal
         let paymentAmount: Decimal?
@@ -115,6 +118,32 @@ enum AdvanceService {
         let note: String
         let category: Category?
         let tags: [Tag]
+
+        init(
+            caseTitle: String? = nil,
+            participantName: String? = nil,
+            debtAccount: Account? = nil,
+            payerAccount: Account?,
+            owedAmount: Decimal,
+            paymentAmount: Decimal?,
+            paymentCurrencyCode: String?,
+            date: Date,
+            note: String,
+            category: Category?,
+            tags: [Tag]
+        ) {
+            self.caseTitle = caseTitle
+            self.participantName = participantName
+            self.debtAccount = debtAccount
+            self.payerAccount = payerAccount
+            self.owedAmount = owedAmount
+            self.paymentAmount = paymentAmount
+            self.paymentCurrencyCode = paymentCurrencyCode
+            self.date = date
+            self.note = note
+            self.category = category
+            self.tags = tags
+        }
     }
     
     struct DeleteAdvanceResult {
@@ -1035,6 +1064,15 @@ enum AdvanceService {
         guard draft.owedAmount + roundingTolerance >= participant.repaidAmount else {
             throw AdvanceServiceError.adjustedOwedLowerThanRepaid
         }
+        let trimmedParticipantName = draft.participantName?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let targetName = (trimmedParticipantName?.isEmpty == false)
+            ? trimmedParticipantName!
+            : participant.name
+        let targetDebtAccount = draft.debtAccount ?? participant.debtAccount
+        guard let targetDebtAccount, targetDebtAccount.type == .debt, !targetDebtAccount.isArchived else {
+            throw AdvanceServiceError.invalidPayerAccount
+        }
 
         let direction = inferSettlementDirection(for: participant, modelContext: modelContext)
         if direction == .iAdvancedOthers {
@@ -1085,26 +1123,40 @@ enum AdvanceService {
         let originalBudgetKeys = entries
             .flatMap(\.1)
             .compactMap(BudgetHistoryService.affectedKey(for:))
+        let targetTitle = draft.caseTitle?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalTitle = (targetTitle?.isEmpty == false) ? targetTitle! : advanceCase.title
         let memo = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
-        let baseMemo = memo.isEmpty ? advanceCase.title : memo
+        let baseMemo = memo.isEmpty ? finalTitle : memo
         let now = Date()
 
         for (caseParticipant, transactions) in entries {
             let amount = caseParticipant.id == participant.id
                 ? abs(draft.owedAmount)
                 : abs(caseParticipant.owedAmount)
+            let participantName = caseParticipant.id == participant.id
+                ? targetName
+                : caseParticipant.name
+            let debtAccount = caseParticipant.id == participant.id
+                ? targetDebtAccount
+                : caseParticipant.debtAccount
             switch direction {
             case .iAdvancedOthers:
-                guard let payerAccount = draft.payerAccount,
-                      let debtAccount = caseParticipant.debtAccount,
+                guard let debtAccount,
                       let outgoing = transactions.first(where: {
                           $0.transferSide == .outgoing || $0.amount < 0
                       }),
                       let incoming = transactions.first(where: {
                           $0.transferSide == .incoming || $0.amount > 0
-                      })
+                      }),
+                      let payerAccount = caseParticipant.id == participant.id
+                        ? draft.payerAccount
+                        : outgoing.account
                 else {
                     throw AdvanceServiceError.invalidRepaymentStructure
+                }
+                guard payerAccount.type != .debt, !payerAccount.isArchived else {
+                    throw AdvanceServiceError.invalidPayerAccount
                 }
                 let paymentAmount = caseParticipant.id == participant.id
                     ? abs(draft.paymentAmount ?? draft.owedAmount)
@@ -1116,7 +1168,7 @@ enum AdvanceService {
                 outgoing.amount = -paymentAmount
                 outgoing.currencyCode = paymentCurrency
                 outgoing.date = draft.date
-                outgoing.note = "\(baseMemo) (代墊給 \(caseParticipant.name))"
+                outgoing.note = "\(baseMemo) (代墊給 \(participantName))"
                 outgoing.account = payerAccount
                 outgoing.category = nil
                 outgoing.tags = []
@@ -1143,7 +1195,7 @@ enum AdvanceService {
                 incoming.updatedAt = now
             case .othersAdvancedMe:
                 guard let expense = transactions.first,
-                      let debtAccount = caseParticipant.debtAccount
+                      let debtAccount
                 else {
                     throw AdvanceServiceError.invalidRepaymentStructure
                 }
@@ -1151,7 +1203,7 @@ enum AdvanceService {
                 expense.amount = -amount
                 expense.currencyCode = advanceCase.currencyCode
                 expense.date = draft.date
-                expense.note = "\(baseMemo) (他人代墊我：\(caseParticipant.name))"
+                expense.note = "\(baseMemo) (他人代墊我：\(participantName))"
                 expense.account = debtAccount
                 expense.category = draft.category
                 expense.tags = draft.tags
@@ -1166,8 +1218,21 @@ enum AdvanceService {
 
         participant.owedAmount = abs(draft.owedAmount)
         participant.repaidAmount = min(participant.repaidAmount, participant.owedAmount)
+        participant.name = targetName
+        participant.debtAccount = targetDebtAccount
         participant.updatedAt = now
-        advanceCase.payerAccount = direction == .iAdvancedOthers ? draft.payerAccount : nil
+        advanceCase.title = finalTitle
+        if direction == .iAdvancedOthers {
+            let paymentAccounts = entries.compactMap { _, transactions in
+                transactions.first(where: {
+                    $0.transferSide == .outgoing || $0.amount < 0
+                })?.account
+            }
+            let uniqueAccountIDs = Set(paymentAccounts.map(\.id))
+            advanceCase.payerAccount = uniqueAccountIDs.count == 1 ? paymentAccounts.first : nil
+        } else {
+            advanceCase.payerAccount = nil
+        }
         advanceCase.direction = direction == .iAdvancedOthers ? .iAdvancedOthers : .othersAdvancedMe
         advanceCase.tagIDs = draft.tags.map(\.id)
         if direction == .othersAdvancedMe {

--- a/AI 記帳/Views/Accounts/AccountDetailView.swift
+++ b/AI 記帳/Views/Accounts/AccountDetailView.swift
@@ -134,7 +134,13 @@ struct AccountDetailView: View {
             advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
         ) {
         case .advanceSelfExpense, .advanceInitial, .advanceRepayment:
-            EditAdvanceTransferView(originalTransaction: tx)
+            if let advanceCase = advanceCase(for: tx) {
+                NavigationStack {
+                    AdvanceCaseDetailView(advanceCase: advanceCase)
+                }
+            } else {
+                EditAdvanceTransferView(originalTransaction: tx)
+            }
         case .debtForgiveness:
             AddDebtView(existingForgivenessTransaction: tx)
         case .debt:
@@ -146,6 +152,26 @@ struct AccountDetailView: View {
                 EditTransactionView(transaction: tx)
             }
         }
+    }
+
+    private func advanceCase(for transaction: FinancialTransaction) -> AdvanceCase? {
+        if let caseID = transaction.advanceCaseID,
+           let match = advanceCases.first(where: { $0.id == caseID }) {
+            return match
+        }
+        if let participantID = transaction.advanceParticipantID,
+           let match = advanceCases.first(where: {
+               $0.participants.contains { $0.id == participantID }
+           }) {
+            return match
+        }
+        guard let groupID = transaction.transferGroupID else {
+            return advanceCases.first(where: { $0.selfExpenseTransactionID == transaction.id })
+        }
+        return advanceCases.first(where: { advanceCase in
+            advanceCase.participants.contains { $0.initialTransferGroupID == groupID }
+                || advanceCase.repayments.contains { $0.linkedTransferGroupID == groupID }
+        })
     }
 
     private func deleteTransaction(_ transaction: FinancialTransaction) {

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -224,11 +224,14 @@ struct AdvanceCaseDetailView: View {
     
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @Query(sort: \FinancialTransaction.date, order: .reverse)
+    private var transactions: [FinancialTransaction]
     
     let advanceCase: AdvanceCase
     @State private var selectedParticipantForRepayment: AdvanceParticipant?
     @State private var selectedParticipantForEdit: AdvanceParticipant?
     @State private var selectedRepaymentForEdit: AdvanceRepayment?
+    @State private var showingCaseEditor = false
     @State private var repaymentToRollback: AdvanceRepayment?
     @State private var selectedDeleteMode: DeleteMode?
     @State private var showingDeleteModeDialog = false
@@ -249,6 +252,44 @@ struct AdvanceCaseDetailView: View {
     
     private var sortedRepayments: [AdvanceRepayment] {
         advanceCase.repayments.sorted { $0.date > $1.date }
+    }
+
+    private var linkedAssetTransactionCount: Int {
+        linkedTransactions.filter { $0.account?.type != .debt }.count
+    }
+
+    private var linkedDebtTransactionCount: Int {
+        linkedTransactions.filter { $0.account?.type == .debt }.count
+    }
+
+    private var linkedTransactions: [FinancialTransaction] {
+        let participantIDs = Set(advanceCase.participants.map(\.id))
+        let groupIDs = Set(
+            advanceCase.participants.compactMap(\.initialTransferGroupID)
+                + advanceCase.repayments.compactMap(\.linkedTransferGroupID)
+        )
+        return transactions.filter { transaction in
+            transaction.advanceCaseID == advanceCase.id
+                || transaction.advanceParticipantID.map(participantIDs.contains) == true
+                || transaction.transferGroupID.map(groupIDs.contains) == true
+                || transaction.id == advanceCase.selfExpenseTransactionID
+        }
+    }
+
+    private var initialPaymentTransactions: [FinancialTransaction] {
+        linkedTransactions
+            .filter { transaction in
+                transaction.advanceEntryRole == .initialAsset
+                    || (
+                        transaction.advanceEntryRole == nil
+                            && transaction.type == .transfer
+                            && (transaction.transferSide == .outgoing || transaction.amount < 0)
+                            && advanceCase.participants.contains { participant in
+                                participant.initialTransferGroupID == transaction.transferGroupID
+                            }
+                    )
+            }
+            .sorted { $0.date < $1.date }
     }
     
     var body: some View {
@@ -274,6 +315,44 @@ struct AdvanceCaseDetailView: View {
                     title: "帳務儲存",
                     value: settlementDirection == .iAdvancedOthers ? "借貸帳戶轉帳" : "借貸帳戶支出"
                 )
+            }
+
+            Section("實際付款") {
+                if initialPaymentTransactions.isEmpty {
+                    Text(settlementDirection == .othersAdvancedMe
+                         ? "由他人代付，自己的資產帳戶沒有變動。"
+                         : "找不到可唯一識別的實際付款分錄，請執行資料健康檢查。")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(initialPaymentTransactions) { transaction in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(transaction.account?.name ?? "未指定帳戶")
+                                if let participant = advanceCase.participants.first(where: {
+                                    $0.id == transaction.advanceParticipantID
+                                }) {
+                                    Text(participant.name)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Text(abs(transaction.amount).formatted(.currency(code: transaction.currencyCode)))
+                                .fontWeight(.semibold)
+                        }
+                    }
+                }
+            }
+
+            Section("帳務影響") {
+                summaryRow(
+                    title: "收入／支出報表",
+                    value: settlementDirection == .iAdvancedOthers
+                        ? (advanceCase.myShareAmount > 0 ? "只計自己的份額" : "不計入")
+                        : "代付當日計為支出"
+                )
+                summaryRow(title: "資產帳戶", value: "\(linkedAssetTransactionCount) 筆流水")
+                summaryRow(title: "借貸帳戶", value: "\(linkedDebtTransactionCount) 筆流水")
             }
             
             Section {
@@ -336,6 +415,16 @@ struct AdvanceCaseDetailView: View {
             }
         }
         .navigationTitle(advanceCase.title)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("編輯") {
+                    showingCaseEditor = true
+                }
+            }
+        }
+        .sheet(isPresented: $showingCaseEditor) {
+            EditAdvanceCaseView(advanceCase: advanceCase)
+        }
         .sheet(item: $selectedParticipantForRepayment) { participant in
             AddAdvanceRepaymentView(advanceCase: advanceCase, participant: participant)
         }
@@ -579,6 +668,170 @@ struct AdvanceCaseDetailView: View {
             errorMessage = error.localizedDescription
             showingError = true
         }
+    }
+}
+
+struct EditAdvanceCaseView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Category.name) private var categories: [Category]
+    @Query(sort: \Tag.name) private var tags: [Tag]
+
+    let advanceCase: AdvanceCase
+
+    @State private var title = ""
+    @State private var date = Date()
+    @State private var note = ""
+    @State private var selectedCategory: Category?
+    @State private var selectedTags: Set<Tag> = []
+    @State private var direction: AdvanceService.SettlementDirection = .iAdvancedOthers
+    @State private var showingError = false
+    @State private var errorMessage = ""
+
+    private var availableCategories: [Category] {
+        direction == .othersAdvancedMe
+            ? categories.filter { $0.kind.supports(.expense) }
+            : []
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("案件") {
+                    TextField("案件名稱", text: $title)
+                    DatePicker("日期", selection: $date)
+                    LabeledContent("方向", value: direction == .iAdvancedOthers ? "我代墊他人" : "他人代墊我")
+                    LabeledContent("案件幣種", value: advanceCase.currencyCode)
+                    Text("方向與案件幣種會改變所有底層分錄；請先逐筆確認參與人及還款，再使用重建流程。")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if direction == .othersAdvancedMe {
+                    Section("支出分類") {
+                        Picker("分類", selection: $selectedCategory) {
+                            Text("無分類").tag(nil as Category?)
+                            ForEach(availableCategories) { category in
+                                Text(category.name).tag(category as Category?)
+                            }
+                        }
+                    }
+                }
+
+                Section("標籤") {
+                    ForEach(tags) { tag in
+                        Toggle(tag.name, isOn: Binding(
+                            get: { selectedTags.contains(tag) },
+                            set: { selected in
+                                if selected {
+                                    selectedTags.insert(tag)
+                                } else {
+                                    selectedTags.remove(tag)
+                                }
+                            }
+                        ))
+                    }
+                }
+
+                Section("備註") {
+                    TextEditor(text: $note)
+                        .frame(minHeight: 100)
+                }
+
+                Section("完整金額編輯") {
+                    Text("返回案件詳情後，可逐位修改債務帳戶、欠款、實際付款帳戶、金額與幣種；每筆普通還款亦可獨立修改。")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("編輯代墊案件")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("儲存") { save() }
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完成") { hideKeyboard() }
+                }
+            }
+            .alert("無法儲存", isPresented: $showingError) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .onAppear {
+                title = advanceCase.title
+                date = advanceCase.date
+                note = advanceCase.note
+                selectedCategory = advanceCase.expenseCategory
+                selectedTags = Set(tags.filter { advanceCase.tagIDs.contains($0.id) })
+                if let participant = advanceCase.participants.first {
+                    direction = AdvanceService.inferSettlementDirection(
+                        for: participant,
+                        modelContext: modelContext
+                    )
+                }
+            }
+        }
+    }
+
+    private func save() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            showError("請輸入案件名稱。")
+            return
+        }
+        guard let participant = advanceCase.participants.first else {
+            showError("案件沒有可編輯的參與人。")
+            return
+        }
+
+        let payment = initialPayment(for: participant)
+        do {
+            try AdvanceService.updateInitialEntry(
+                advanceCase: advanceCase,
+                participant: participant,
+                draft: .init(
+                    caseTitle: trimmedTitle,
+                    participantName: participant.name,
+                    debtAccount: participant.debtAccount,
+                    payerAccount: direction == .iAdvancedOthers
+                        ? (payment?.account ?? advanceCase.payerAccount)
+                        : nil,
+                    owedAmount: participant.owedAmount,
+                    paymentAmount: payment.map { abs($0.amount) },
+                    paymentCurrencyCode: payment?.currencyCode,
+                    date: date,
+                    note: note,
+                    category: direction == .othersAdvancedMe ? selectedCategory : nil,
+                    tags: Array(selectedTags)
+                ),
+                modelContext: modelContext
+            )
+            dismiss()
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+
+    private func initialPayment(for participant: AdvanceParticipant) -> FinancialTransaction? {
+        guard let groupID = participant.initialTransferGroupID else { return nil }
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        return try? modelContext.fetch(descriptor).first(where: {
+            $0.advanceEntryRole == .initialAsset
+                || $0.transferSide == .outgoing
+                || $0.amount < 0
+        })
+    }
+
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
     }
 }
 
@@ -1653,24 +1906,48 @@ struct AddAdvanceRepaymentView: View {
 struct EditAdvanceParticipantView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Account.sortOrder) private var accounts: [Account]
+    @Query(sort: \Tag.name) private var tags: [Tag]
     
     let advanceCase: AdvanceCase
     let participant: AdvanceParticipant
     
+    @State private var name = ""
+    @State private var selectedDebtAccount: Account?
     @State private var owedAmountString = ""
+    @State private var selectedPaymentAccount: Account?
+    @State private var paymentAmountString = ""
+    @State private var paymentCurrency = "HKD"
+    @State private var direction: AdvanceService.SettlementDirection = .iAdvancedOthers
     @State private var showingError = false
     @State private var errorMessage = ""
+
+    private var ownAccounts: [Account] {
+        accounts.filter { !$0.isArchived && $0.type != .debt }
+    }
+
+    private var debtAccounts: [Account] {
+        accounts.filter { !$0.isArchived && $0.type == .debt }
+    }
+
+    private var availableCurrencies: [String] {
+        Array(Set(accounts.map(\.currency) + [advanceCase.currencyCode, "HKD", "JPY", "USD", "CNY"]))
+            .sorted()
+    }
     
     var body: some View {
         NavigationStack {
             Form {
                 Section("對象") {
-                    HStack {
-                        Text("姓名")
-                        Spacer()
-                        Text(participant.name)
-                            .foregroundStyle(.secondary)
+                    TextField("姓名", text: $name)
+
+                    Picker("債務帳戶", selection: $selectedDebtAccount) {
+                        Text("請選擇").tag(nil as Account?)
+                        ForEach(debtAccounts) { account in
+                            Text(account.name).tag(account as Account?)
+                        }
                     }
+
                     HStack {
                         Text("已還")
                         Spacer()
@@ -1679,19 +1956,46 @@ struct EditAdvanceParticipantView: View {
                     }
                 }
                 
-                Section("更正欠款") {
+                Section(direction == .iAdvancedOthers ? "對方欠款" : "我欠對方") {
                     TextField("欠款金額", text: Binding(
                         get: { owedAmountString },
                         set: { owedAmountString = sanitizePositiveDecimalInput($0) }
                     ))
                     .keyboardType(.decimalPad)
                     
-                    Text("此值用於代墊追蹤；借貸實際帳務仍以轉帳紀錄為準。")
+                    Text("此金額使用案件幣種 \(advanceCase.currencyCode)，不可低於已還金額。")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                if direction == .iAdvancedOthers {
+                    Section("實際付款") {
+                        Picker("付款帳戶", selection: $selectedPaymentAccount) {
+                            Text("請選擇").tag(nil as Account?)
+                            ForEach(ownAccounts) { account in
+                                Text(account.name).tag(account as Account?)
+                            }
+                        }
+
+                        TextField("實際付款金額", text: Binding(
+                            get: { paymentAmountString },
+                            set: { paymentAmountString = sanitizePositiveDecimalInput($0) }
+                        ))
+                        .keyboardType(.decimalPad)
+
+                        Picker("付款幣種", selection: $paymentCurrency) {
+                            ForEach(availableCurrencies, id: \.self) { currency in
+                                Text(currency).tag(currency)
+                            }
+                        }
+
+                        Text("付款金額可與欠款金額及案件幣種不同，例如實付 34.86 HKD、朋友欠 710 JPY。")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
-            .navigationTitle("更正欠款")
+            .navigationTitle("編輯代墊對象")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("取消") { dismiss() }
@@ -1712,28 +2016,86 @@ struct EditAdvanceParticipantView: View {
                 Text(errorMessage)
             }
             .onAppear {
+                name = participant.name
+                selectedDebtAccount = participant.debtAccount
                 owedAmountString = NSDecimalNumber(decimal: participant.owedAmount).stringValue
+                direction = AdvanceService.inferSettlementDirection(
+                    for: participant,
+                    modelContext: modelContext
+                )
+                loadPaymentLeg()
             }
         }
     }
     
     private func save() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            showError("請輸入對象名稱。")
+            return
+        }
+        guard let debtAccount = selectedDebtAccount else {
+            showError("請選擇債務帳戶。")
+            return
+        }
         guard let newOwed = Decimal(string: owedAmountString), newOwed > 0 else {
             showError("請輸入大於 0 的欠款金額。")
             return
         }
+
+        var paymentAmount: Decimal?
+        if direction == .iAdvancedOthers {
+            guard selectedPaymentAccount != nil,
+                  let parsedPayment = Decimal(string: paymentAmountString),
+                  parsedPayment > 0 else {
+                showError("請選擇付款帳戶並輸入實際付款金額。")
+                return
+            }
+            paymentAmount = parsedPayment
+        }
         
         do {
-            try AdvanceService.updateParticipantOwedAmount(
+            try AdvanceService.updateInitialEntry(
                 advanceCase: advanceCase,
                 participant: participant,
-                newOwedAmount: newOwed,
+                draft: .init(
+                    participantName: trimmedName,
+                    debtAccount: debtAccount,
+                    payerAccount: direction == .iAdvancedOthers ? selectedPaymentAccount : nil,
+                    owedAmount: newOwed,
+                    paymentAmount: paymentAmount,
+                    paymentCurrencyCode: direction == .iAdvancedOthers ? paymentCurrency : nil,
+                    date: advanceCase.date,
+                    note: advanceCase.note,
+                    category: advanceCase.expenseCategory,
+                    tags: tags.filter { advanceCase.tagIDs.contains($0.id) }
+                ),
                 modelContext: modelContext
             )
             dismiss()
         } catch {
             showError(error.localizedDescription)
         }
+    }
+
+    private func loadPaymentLeg() {
+        guard direction == .iAdvancedOthers,
+              let groupID = participant.initialTransferGroupID else {
+            return
+        }
+        let descriptor = FetchDescriptor<FinancialTransaction>(
+            predicate: #Predicate { $0.transferGroupID == groupID }
+        )
+        guard let outgoing = try? modelContext.fetch(descriptor).first(where: {
+            $0.advanceEntryRole == .initialAsset
+                || $0.transferSide == .outgoing
+                || $0.amount < 0
+        }) else {
+            return
+        }
+        selectedPaymentAccount = outgoing.account ?? advanceCase.payerAccount
+        paymentAmountString = NSDecimalNumber(decimal: abs(outgoing.amount)).stringValue
+        paymentCurrency = outgoing.currencyCode
     }
     
     private func sanitizePositiveDecimalInput(_ value: String) -> String {

--- a/AI 記帳/Views/Charts/ChartsView.swift
+++ b/AI 記帳/Views/Charts/ChartsView.swift
@@ -652,7 +652,13 @@ private struct ReportTransactionListView: View {
             advanceRepaymentGroupIDs: renderState.repaymentAdvanceGroupIDs
         ) {
         case .advanceSelfExpense, .advanceInitial, .advanceRepayment:
-            EditAdvanceTransferView(originalTransaction: tx)
+            if let advanceCase = advanceCase(for: tx) {
+                NavigationStack {
+                    AdvanceCaseDetailView(advanceCase: advanceCase)
+                }
+            } else {
+                EditAdvanceTransferView(originalTransaction: tx)
+            }
         case .debtForgiveness:
             AddDebtView(existingForgivenessTransaction: tx)
         case .debt:
@@ -664,6 +670,26 @@ private struct ReportTransactionListView: View {
                 EditTransactionView(transaction: tx)
             }
         }
+    }
+
+    private func advanceCase(for transaction: FinancialTransaction) -> AdvanceCase? {
+        if let caseID = transaction.advanceCaseID,
+           let match = advanceCases.first(where: { $0.id == caseID }) {
+            return match
+        }
+        if let participantID = transaction.advanceParticipantID,
+           let match = advanceCases.first(where: {
+               $0.participants.contains { $0.id == participantID }
+           }) {
+            return match
+        }
+        guard let groupID = transaction.transferGroupID else {
+            return advanceCases.first(where: { $0.selfExpenseTransactionID == transaction.id })
+        }
+        return advanceCases.first(where: { advanceCase in
+            advanceCase.participants.contains { $0.initialTransferGroupID == groupID }
+                || advanceCase.repayments.contains { $0.linkedTransferGroupID == groupID }
+        })
     }
 
     private func deleteTransaction(_ tx: FinancialTransaction) {

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -8,6 +8,7 @@ struct TransactionsListView: View {
     @Query(sort: \AdvanceCase.date, order: .reverse) private var advanceCases: [AdvanceCase]
     @Query private var advanceParticipants: [AdvanceParticipant]
     @Query private var advanceRepayments: [AdvanceRepayment]
+    @Query(sort: \Tag.name) private var tags: [Tag]
     
     @AppStorage(DateFilterPreferenceKeys.filterType) private var filterTypeRaw: String = FilterType.month.rawValue
     @AppStorage(DateFilterPreferenceKeys.selectedDate) private var selectedDateTimeInterval: Double = Date().timeIntervalSince1970
@@ -29,14 +30,14 @@ struct TransactionsListView: View {
 
     enum LedgerItem: Identifiable {
         case transaction(FinancialTransaction)
-        case advanceCaseSummary(AdvanceCase)
+        case advanceCaseSummary(AdvanceCaseLedgerSummary)
 
         var id: String {
             switch self {
             case .transaction(let transaction):
                 return "transaction-\(transaction.id.uuidString)"
-            case .advanceCaseSummary(let advanceCase):
-                return "advance-\(advanceCase.id.uuidString)"
+            case .advanceCaseSummary(let summary):
+                return "advance-\(summary.advanceCase.id.uuidString)"
             }
         }
 
@@ -44,8 +45,8 @@ struct TransactionsListView: View {
             switch self {
             case .transaction(let transaction):
                 return transaction.date
-            case .advanceCaseSummary(let advanceCase):
-                return advanceCase.date
+            case .advanceCaseSummary(let summary):
+                return summary.activityDate
             }
         }
     }
@@ -210,9 +211,9 @@ struct TransactionsListView: View {
                                     transactionToEdit = transaction
                                 } label: { Label("編輯", systemImage: "pencil") }.tint(.blue)
                             }
-                        case .advanceCaseSummary(let advanceCase):
-                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: advanceCase)) {
-                                AdvanceCaseSummaryRow(advanceCase: advanceCase)
+                        case .advanceCaseSummary(let summary):
+                            NavigationLink(destination: AdvanceCaseDetailView(advanceCase: summary.advanceCase)) {
+                                AdvanceCaseSummaryRow(summary: summary)
                             }
                         }
                     }
@@ -329,6 +330,7 @@ struct TransactionsListView: View {
             advanceCases: advanceCases,
             advanceParticipants: advanceParticipants,
             advanceRepayments: advanceRepayments,
+            tags: tags,
             filterType: filterType,
             selectedDate: selectedDate,
             customStartDate: customStartDate,
@@ -447,7 +449,7 @@ struct TransactionsListView: View {
 private struct TransactionsRenderState {
     let allTransactions: [FinancialTransaction]
     let filteredTransactions: [FinancialTransaction]
-    let filteredAdvanceCases: [AdvanceCase]
+    let filteredAdvanceCases: [AdvanceCaseLedgerSummary]
     let ledgerItems: [TransactionsListView.LedgerItem]
     let groupedTransactions: [TransactionsListView.TransactionGroup]
     let transferCounterpartByID: [UUID: TransferCounterpartInfo]
@@ -459,6 +461,7 @@ private struct TransactionsRenderState {
         advanceCases: [AdvanceCase],
         advanceParticipants: [AdvanceParticipant],
         advanceRepayments: [AdvanceRepayment],
+        tags: [Tag],
         filterType: FilterType,
         selectedDate: Date,
         customStartDate: Date,
@@ -467,10 +470,13 @@ private struct TransactionsRenderState {
     ) {
         let initialAdvanceGroupIDs = Set(advanceParticipants.compactMap(\.initialTransferGroupID))
         let repaymentAdvanceGroupIDs = Set(advanceRepayments.compactMap(\.linkedTransferGroupID))
+        let advanceSelfExpenseTransactionIDs = Set(advanceCases.compactMap(\.selfExpenseTransactionID))
 
         let filteredTransactions = Self.filteredTransactions(
             from: transactions,
             initialAdvanceGroupIDs: initialAdvanceGroupIDs,
+            repaymentAdvanceGroupIDs: repaymentAdvanceGroupIDs,
+            advanceSelfExpenseTransactionIDs: advanceSelfExpenseTransactionIDs,
             filterType: filterType,
             selectedDate: selectedDate,
             customStartDate: customStartDate,
@@ -479,6 +485,8 @@ private struct TransactionsRenderState {
         )
         let filteredAdvanceCases = Self.filteredAdvanceCases(
             from: advanceCases,
+            transactions: transactions,
+            tags: tags,
             filterType: filterType,
             selectedDate: selectedDate,
             customStartDate: customStartDate,
@@ -503,6 +511,8 @@ private struct TransactionsRenderState {
     private static func filteredTransactions(
         from transactions: [FinancialTransaction],
         initialAdvanceGroupIDs: Set<UUID>,
+        repaymentAdvanceGroupIDs: Set<UUID>,
+        advanceSelfExpenseTransactionIDs: Set<UUID>,
         filterType: FilterType,
         selectedDate: Date,
         customStartDate: Date,
@@ -510,6 +520,9 @@ private struct TransactionsRenderState {
         searchText: String
     ) -> [FinancialTransaction] {
         let timeFiltered = transactions.filter { tx in
+            if tx.advanceCaseID != nil || advanceSelfExpenseTransactionIDs.contains(tx.id) {
+                return false
+            }
             if tx.type == .transfer && tx.amount > 0 && !TransactionSemantics.isDebtForgiveness(note: tx.note) { return false }
             if tx.type == .transfer,
                tx.transferGroupID == nil,
@@ -517,7 +530,8 @@ private struct TransactionsRenderState {
                isAssetAdjustment(note: tx.note) {
                 return false
             }
-            if let groupID = tx.transferGroupID, initialAdvanceGroupIDs.contains(groupID) {
+            if let groupID = tx.transferGroupID,
+               initialAdvanceGroupIDs.contains(groupID) || repaymentAdvanceGroupIDs.contains(groupID) {
                 return false
             }
             return filterType.matches(
@@ -538,38 +552,92 @@ private struct TransactionsRenderState {
 
     private static func filteredAdvanceCases(
         from advanceCases: [AdvanceCase],
+        transactions: [FinancialTransaction],
+        tags: [Tag],
         filterType: FilterType,
         selectedDate: Date,
         customStartDate: Date,
         customEndDate: Date,
         searchText: String
-    ) -> [AdvanceCase] {
-        let timeFiltered = advanceCases.filter { advanceCase in
-            filterType.matches(
-                date: advanceCase.date,
-                selectedDate: selectedDate,
-                customStartDate: customStartDate,
-                customEndDate: customEndDate
+    ) -> [AdvanceCaseLedgerSummary] {
+        let transactionsByCaseID = Dictionary(
+            grouping: transactions.compactMap { transaction in
+                transaction.advanceCaseID.map { ($0, transaction) }
+            },
+            by: \.0
+        ).mapValues { $0.map(\.1) }
+        let transactionsByGroupID = Dictionary(
+            grouping: transactions.compactMap { transaction in
+                transaction.transferGroupID.map { ($0, transaction) }
+            },
+            by: \.0
+        ).mapValues { $0.map(\.1) }
+        let transactionByID = Dictionary(uniqueKeysWithValues: transactions.map { ($0.id, $0) })
+        let tagNameByID = Dictionary(uniqueKeysWithValues: tags.map { ($0.id, $0.name) })
+
+        return advanceCases.compactMap { advanceCase in
+            var caseTransactions = transactionsByCaseID[advanceCase.id] ?? []
+            let legacyGroupIDs = Set(
+                advanceCase.participants.compactMap(\.initialTransferGroupID)
+                    + advanceCase.repayments.compactMap(\.linkedTransferGroupID)
             )
-        }
+            caseTransactions += legacyGroupIDs.flatMap {
+                transactionsByGroupID[$0] ?? []
+            }
+            if let selfExpenseID = advanceCase.selfExpenseTransactionID,
+               let selfExpense = transactionByID[selfExpenseID] {
+                caseTransactions.append(selfExpense)
+            }
+            caseTransactions = Array(
+                Dictionary(uniqueKeysWithValues: caseTransactions.map { ($0.id, $0) }).values
+            )
+            let activityDates = [advanceCase.date]
+                + advanceCase.repayments.map(\.date)
+                + caseTransactions.map(\.date)
+            let matchingDates = activityDates.filter {
+                filterType.matches(
+                    date: $0,
+                    selectedDate: selectedDate,
+                    customStartDate: customStartDate,
+                    customEndDate: customEndDate
+                )
+            }
+            guard let activityDate = matchingDates.max() else { return nil }
 
-        guard !searchText.isEmpty else {
-            return timeFiltered
-        }
+            if !searchText.isEmpty {
+                let searchableValues = [
+                    advanceCase.title,
+                    advanceCase.note,
+                    advanceCase.payerAccount?.name ?? "",
+                    advanceCase.expenseCategory?.name ?? "",
+                    advanceCase.participants.map(\.name).joined(separator: " "),
+                    advanceCase.participants.compactMap(\.debtAccount?.name).joined(separator: " "),
+                    advanceCase.repayments.map(\.note).joined(separator: " "),
+                    advanceCase.repayments.compactMap(\.receivedAccount?.name).joined(separator: " "),
+                    advanceCase.tagIDs.compactMap { tagNameByID[$0] }.joined(separator: " "),
+                    caseTransactions.compactMap(\.account?.name).joined(separator: " "),
+                ]
+                guard searchableValues.contains(where: {
+                    $0.localizedCaseInsensitiveContains(searchText)
+                }) else {
+                    return nil
+                }
+            }
 
-        return timeFiltered.filter { advanceCase in
-            advanceCase.title.localizedCaseInsensitiveContains(searchText)
-                || advanceCase.note.localizedCaseInsensitiveContains(searchText)
-                || (advanceCase.payerAccount?.name.localizedCaseInsensitiveContains(searchText) ?? false)
-                || advanceCase.participants.contains { $0.name.localizedCaseInsensitiveContains(searchText) }
+            return AdvanceCaseLedgerSummary(
+                advanceCase: advanceCase,
+                activityDate: activityDate,
+                caseTransactions: caseTransactions
+            )
         }
     }
 
     private static func ledgerItems(
         transactions: [FinancialTransaction],
-        advanceCases: [AdvanceCase]
+        advanceCases: [AdvanceCaseLedgerSummary]
     ) -> [TransactionsListView.LedgerItem] {
-        (transactions.map(TransactionsListView.LedgerItem.transaction) + advanceCases.map(TransactionsListView.LedgerItem.advanceCaseSummary))
+        (transactions.map(TransactionsListView.LedgerItem.transaction)
+            + advanceCases.map(TransactionsListView.LedgerItem.advanceCaseSummary))
             .sorted { lhs, rhs in
                 if lhs.date == rhs.date {
                     return lhs.id > rhs.id
@@ -651,27 +719,92 @@ private struct LedgerSearchModifier: ViewModifier {
     }
 }
 
-private struct AdvanceCaseSummaryRow: View {
-    let advanceCase: AdvanceCase
-
-    private var totalAmount: Decimal {
-        AdvanceService.totalAdvanced(for: advanceCase)
+struct AdvanceCaseLedgerSummary {
+    struct CurrencyTotal: Identifiable {
+        let currencyCode: String
+        let amount: Decimal
+        var id: String { currencyCode }
     }
 
-    private var outstandingAmount: Decimal {
+    let advanceCase: AdvanceCase
+    let activityDate: Date
+    let paymentTotals: [CurrencyTotal]
+
+    init(
+        advanceCase: AdvanceCase,
+        activityDate: Date,
+        caseTransactions: [FinancialTransaction]
+    ) {
+        self.advanceCase = advanceCase
+        self.activityDate = activityDate
+
+        let initialGroupIDs = Set(advanceCase.participants.compactMap(\.initialTransferGroupID))
+        let assetPayments = caseTransactions.filter {
+            ($0.advanceEntryRole == .initialAsset
+                || (
+                    $0.advanceEntryRole == nil
+                        && $0.transferGroupID.map(initialGroupIDs.contains) == true
+                        && ($0.transferSide == .outgoing || $0.amount < 0)
+                ))
+                && $0.amount < 0
+        }
+        let grouped = Dictionary(grouping: assetPayments, by: \.currencyCode)
+        self.paymentTotals = grouped.map { currencyCode, transactions in
+            CurrencyTotal(
+                currencyCode: currencyCode,
+                amount: transactions.reduce(Decimal.zero) { $0 + abs($1.amount) }
+            )
+        }.sorted { $0.currencyCode < $1.currencyCode }
+    }
+
+    var outstandingAmount: Decimal {
         AdvanceService.outstandingAmount(for: advanceCase)
     }
+
+    var isSettled: Bool {
+        outstandingAmount <= Decimal(string: "0.0001")!
+    }
+
+    var directionLabel: String {
+        advanceCase.direction == .othersAdvancedMe ? "他人代墊我" : "我代墊他人"
+    }
+
+    var paymentSummary: String {
+        if paymentTotals.isEmpty {
+            return advanceCase.direction == .othersAdvancedMe
+                ? "\(AdvanceService.totalAdvanced(for: advanceCase).formatted(.currency(code: advanceCase.currencyCode)))（他人代付）"
+                : AdvanceService.totalAdvanced(for: advanceCase)
+                    .formatted(.currency(code: advanceCase.currencyCode))
+        }
+        return paymentTotals.map {
+            $0.amount.formatted(.currency(code: $0.currencyCode))
+        }.joined(separator: " + ")
+    }
+}
+
+private struct AdvanceCaseSummaryRow: View {
+    let summary: AdvanceCaseLedgerSummary
 
     var body: some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 6) {
-                Text(advanceCase.title)
+                HStack(spacing: 6) {
+                    Text(summary.advanceCase.title)
+                    Text(summary.directionLabel)
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.12))
+                        .foregroundStyle(.orange)
+                        .clipShape(Capsule())
+                }
                     .font(.headline)
                     .foregroundStyle(.primary)
                 Text(summaryLine)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text(advanceCase.date.formatted(date: .abbreviated, time: .shortened))
+                Text("最近活動 \(summary.activityDate.formatted(date: .abbreviated, time: .shortened))")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -679,19 +812,32 @@ private struct AdvanceCaseSummaryRow: View {
             Spacer()
 
             VStack(alignment: .trailing, spacing: 4) {
-                Text(totalAmount.formatted(.currency(code: advanceCase.currencyCode)))
+                Text(summary.paymentSummary)
                     .font(.headline)
                     .foregroundStyle(.orange)
-                Text("未清 \(outstandingAmount.formatted(.currency(code: advanceCase.currencyCode)))")
+                    .multilineTextAlignment(.trailing)
+                Text(statusText)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(summary.isSettled ? .green : .secondary)
             }
         }
         .padding(.vertical, 4)
+        .opacity(summary.isSettled ? 0.72 : 1)
     }
 
     private var summaryLine: String {
-        let payer = advanceCase.payerAccount?.name ?? "他人代付（不影響自己帳戶）"
-        return "\(advanceCase.participants.count) 人 · \(payer)"
+        let payer = summary.advanceCase.payerAccount?.name ?? "不影響自己帳戶"
+        let ownShare = summary.advanceCase.myShareAmount.formatted(
+            .currency(code: summary.advanceCase.currencyCode)
+        )
+        return "\(summary.advanceCase.participants.count) 人 · 自己份額 \(ownShare) · \(payer)"
+    }
+
+    private var statusText: String {
+        if summary.isSettled {
+            return "已結清"
+        }
+        let label = summary.advanceCase.direction == .othersAdvancedMe ? "待還" : "待收"
+        return "\(label) \(summary.outstandingAmount.formatted(.currency(code: summary.advanceCase.currencyCode)))"
     }
 }

--- a/AI 記帳Tests/AdvanceEditingTests.swift
+++ b/AI 記帳Tests/AdvanceEditingTests.swift
@@ -8,7 +8,8 @@ final class AdvanceEditingTests: XCTestCase {
         let context = try makeContext()
         let bank = Account(name: "HSBC HKD", currency: "HKD", type: .bank, baseBalance: 0)
         let friend = Account(name: "TKL", currency: "JPY", type: .debt, baseBalance: 0)
-        [bank, friend].forEach(context.insert)
+        let replacementDebt = Account(name: "TKL Travel", currency: "JPY", type: .debt, baseBalance: 0)
+        [bank, friend, replacementDebt].forEach(context.insert)
 
         let advanceCase = try AdvanceService.createAdvanceCase(
             title: "LUUP",
@@ -28,6 +29,8 @@ final class AdvanceEditingTests: XCTestCase {
             advanceCase: advanceCase,
             participant: participant,
             draft: .init(
+                participantName: "TKL Travel",
+                debtAccount: replacementDebt,
                 payerAccount: bank,
                 owedAmount: 710,
                 paymentAmount: Decimal(string: "34.86"),
@@ -48,6 +51,9 @@ final class AdvanceEditingTests: XCTestCase {
         XCTAssertEqual("HKD", asset.currencyCode)
         XCTAssertEqual(Decimal(710), debt.amount)
         XCTAssertEqual("JPY", debt.currencyCode)
+        XCTAssertEqual("TKL Travel", participant.name)
+        XCTAssertEqual(replacementDebt.id, participant.debtAccount?.id)
+        XCTAssertEqual(replacementDebt.id, debt.account?.id)
         XCTAssertEqual(advanceCase.id, asset.advanceCaseID)
         XCTAssertEqual(participant.id, debt.advanceParticipantID)
     }
@@ -321,7 +327,7 @@ final class AdvanceEditingTests: XCTestCase {
 
         XCTAssertEqual(Decimal(120), participantA.owedAmount)
         XCTAssertEqual(Decimal(200), participantB.owedAmount)
-        XCTAssertEqual(bank.id, advanceCase.payerAccount?.id)
+        XCTAssertNil(advanceCase.payerAccount)
         XCTAssertEqual(editedDate, advanceCase.date)
         XCTAssertEqual("Edited", advanceCase.note)
 
@@ -334,10 +340,11 @@ final class AdvanceEditingTests: XCTestCase {
             let incoming = try XCTUnwrap(
                 transactions.first { $0.transferSide == .incoming }
             )
-            XCTAssertEqual(bank.id, outgoing.account?.id)
+            let expectedPaymentAccount = participant.id == participantA.id ? bank : wallet
+            XCTAssertEqual(expectedPaymentAccount.id, outgoing.account?.id)
             XCTAssertEqual(editedDate, outgoing.date)
             XCTAssertEqual(editedDate, incoming.date)
-            XCTAssertTrue(incoming.note.contains(bank.name))
+            XCTAssertTrue(incoming.note.contains(expectedPaymentAccount.name))
             XCTAssertEqual(participant.owedAmount, abs(outgoing.amount))
             XCTAssertEqual(participant.owedAmount, incoming.amount)
         }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -166,6 +166,7 @@ data class AdvanceSelfExpenseEditDraft(
 
 data class AdvanceInitialMetadataEditDraft(
     val caseId: UUID,
+    val title: String,
     val payerAccountId: UUID?,
     val date: Instant,
     val note: String,
@@ -1978,6 +1979,9 @@ class AccountingRepository(
     suspend fun updateAdvanceParticipantOwedAmount(
         participantId: UUID,
         newOwedAmount: BigDecimal,
+        participantName: String? = null,
+        debtAccountId: UUID? = null,
+        paymentAccountId: UUID? = null,
         paymentAmount: BigDecimal? = null,
         paymentCurrencyCode: String? = null
     ) {
@@ -1995,6 +1999,16 @@ class AccountingRepository(
                     advanceDao.getAllCases().firstOrNull { it.id == caseId }
                 }
             ) { "找不到代墊案件。" }
+            val finalName = participantName?.trim()
+                ?.takeIf(String::isNotBlank)
+                ?: participant.name
+            val finalDebtAccountId = debtAccountId ?: participant.debtAccountId
+            val debtAccount = requireNotNull(
+                finalDebtAccountId?.let { accountDao.getAccount(it) }
+            ) { "請選擇債務帳戶。" }
+            require(debtAccount.type == AccountType.Debt && !debtAccount.isArchived) {
+                "請選擇未歸檔的借貸帳戶。"
+            }
             val groupId = requireNotNull(participant.initialTransferGroupId) { "找不到初始代墊分錄。" }
             val group = transactionDao.getTransferGroup(groupId)
             require(group.isNotEmpty()) { "找不到初始代墊分錄。" }
@@ -2015,13 +2029,25 @@ class AccountingRepository(
                             transferGroupId = groupId,
                             transferSide = TransferSide.Outgoing,
                             updatedAt = now,
-                            accountId = participant.debtAccountId,
+                            accountId = debtAccount.id,
                             categoryId = advanceCase.expenseCategoryId
                         )
                     )
                 }
                 AdvanceSettlementDirection.IAdvancedOthers -> {
                     require(group.size == 2) { "我代墊他人的初始轉帳結構不完整。" }
+                    val existingAssetLeg = requireNotNull(
+                        group.firstOrNull {
+                            effectiveTransferSide(it.transaction) == TransferSide.Outgoing
+                        }
+                    ) { "找不到實際付款分錄。" }
+                    val paymentAccount = paymentAccountId?.let { accountDao.getAccount(it) }
+                        ?: existingAssetLeg.account
+                    require(
+                        paymentAccount != null &&
+                            paymentAccount.type != AccountType.Debt &&
+                            !paymentAccount.isArchived
+                    ) { "請選擇未歸檔的非借貸付款帳戶。" }
                     group.map { item ->
                         val side = effectiveTransferSide(item.transaction)
                         val isAssetLeg = side == TransferSide.Outgoing
@@ -2042,6 +2068,12 @@ class AccountingRepository(
                             date = advanceCase.date,
                             transferSide = side,
                             updatedAt = now,
+                            accountId = if (isAssetLeg) paymentAccount.id else debtAccount.id,
+                            note = if (isAssetLeg) {
+                                "${advanceCase.note.ifBlank { advanceCase.title }} (代墊給 $finalName)"
+                            } else {
+                                "${advanceCase.note.ifBlank { advanceCase.title }} (來自 ${paymentAccount.name})"
+                            },
                             advanceCaseId = advanceCase.id,
                             advanceParticipantId = participant.id,
                             advanceEntryRole = if (isAssetLeg) {
@@ -2058,13 +2090,37 @@ class AccountingRepository(
             advanceDao.upsertParticipants(
                 listOf(
                     participant.copy(
+                        name = finalName,
+                        debtAccountId = debtAccount.id,
                         owedAmount = amount,
                         repaidAmount = participant.repaidAmount.min(amount),
                         updatedAt = now
                     )
                 )
             )
-            advanceDao.upsertCase(advanceCase.copy(updatedAt = now))
+            val payerAccountId = if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                val paymentAccountIds = advanceDao.getAllParticipants()
+                    .filter { it.advanceCaseId == advanceCase.id }
+                    .mapNotNull { caseParticipant ->
+                        caseParticipant.initialTransferGroupId
+                            ?.let { transactionDao.getTransferGroup(it) }
+                            ?.firstOrNull {
+                                effectiveTransferSide(it.transaction) == TransferSide.Outgoing
+                            }
+                            ?.transaction
+                            ?.accountId
+                    }
+                    .distinct()
+                paymentAccountIds.singleOrNull()
+            } else {
+                null
+            }
+            advanceDao.upsertCase(
+                advanceCase.copy(
+                    updatedAt = now,
+                    payerAccountId = payerAccountId
+                )
+            )
             syncAllBudgetHistory()
         }
     }
@@ -2077,16 +2133,11 @@ class AccountingRepository(
             val participants = advanceDao.getAllParticipants()
                 .filter { it.advanceCaseId == advanceCase.id }
             require(participants.isNotEmpty()) { "代墊案件沒有可更新的對象。" }
+            val title = draft.title.trim()
+            require(title.isNotEmpty()) { "請輸入案件名稱。" }
 
             val direction = advanceSettlementDirectionLocked(participants.first())
-            val payerAccount = draft.payerAccountId?.let { accountId ->
-                requireNotNull(accountDao.getAccount(accountId)) { "找不到所選付款帳戶。" }
-            }
-            if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
-                require(payerAccount != null && payerAccount.type != AccountType.Debt && !payerAccount.isArchived) {
-                    "請選擇未歸檔的非借貸付款帳戶。"
-                }
-            }
+            val payerAccount = advanceCase.payerAccountId?.let { accountDao.getAccount(it) }
             val category = draft.categoryId?.let { categoryId ->
                 requireNotNull(categoryDao.getCategory(categoryId)) { "找不到所選分類。" }
             }
@@ -2118,17 +2169,18 @@ class AccountingRepository(
             }
 
             val memo = draft.note.trim()
-            val baseMemo = memo.ifBlank { advanceCase.title }
+            val baseMemo = memo.ifBlank { title }
             val now = Instant.now()
             entries.forEach { (participant, group) ->
                 val amount = participant.owedAmount.abs()
                 when (direction) {
                     AdvanceSettlementDirection.IAdvancedOthers -> {
-                        val outgoing = requireNotNull(
+                        val outgoingItem = requireNotNull(
                             group.firstOrNull {
                                 effectiveTransferSide(it.transaction) == TransferSide.Outgoing
-                            }?.transaction
+                            }
                         )
+                        val outgoing = outgoingItem.transaction
                         val incoming = requireNotNull(
                             group.firstOrNull {
                                 effectiveTransferSide(it.transaction) == TransferSide.Incoming
@@ -2137,14 +2189,11 @@ class AccountingRepository(
                         transactionDao.upsertAll(
                             listOf(
                                 outgoing.copy(
-                                    amount = amount.negate(),
-                                    currencyCode = advanceCase.currencyCode,
                                     date = draft.date,
                                     note = "$baseMemo (代墊給 ${participant.name})",
                                     linkedTransactionId = incoming.id,
                                     transferSide = TransferSide.Outgoing,
                                     updatedAt = now,
-                                    accountId = requireNotNull(payerAccount).id,
                                     categoryId = null,
                                     advanceCaseId = advanceCase.id,
                                     advanceParticipantId = participant.id,
@@ -2154,7 +2203,7 @@ class AccountingRepository(
                                     amount = amount,
                                     currencyCode = advanceCase.currencyCode,
                                     date = draft.date,
-                                    note = "$baseMemo (來自 ${payerAccount.name})",
+                                    note = "$baseMemo (來自 ${outgoingItem.account?.name ?: payerAccount?.name.orEmpty()})",
                                     linkedTransactionId = outgoing.id,
                                     transferSide = TransferSide.Incoming,
                                     updatedAt = now,
@@ -2200,11 +2249,13 @@ class AccountingRepository(
             }
             advanceDao.upsertCase(
                 advanceCase.copy(
+                    title = title,
                     date = draft.date,
                     note = memo,
                     updatedAt = now,
                     payerAccountId =
-                        if (direction == AdvanceSettlementDirection.IAdvancedOthers) payerAccount?.id else null,
+                        if (direction == AdvanceSettlementDirection.IAdvancedOthers) advanceCase.payerAccountId
+                        else null,
                     expenseCategoryId =
                         if (direction == AdvanceSettlementDirection.OthersAdvancedMe) category?.id
                         else advanceCase.expenseCategoryId,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/routing/TransactionEditRouting.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/routing/TransactionEditRouting.kt
@@ -22,6 +22,10 @@ suspend fun resolveTransactionEditDestination(
         return TransactionEditDestination.Debt(transaction.id.toString())
     }
 
+    transaction.advanceCaseId?.let { caseId ->
+        return TransactionEditDestination.Advance(caseId.toString())
+    }
+
     repository.findAdvanceCaseIdBySelfExpense(transaction.id)?.let { caseId ->
         return TransactionEditDestination.Advance(caseId.toString())
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
@@ -97,6 +97,7 @@ fun AdvanceDetailScreen(caseId: String?) {
     }
 
     val receiveAccounts = accounts.filter { it.type != AccountType.Debt && !it.isArchived }
+    val debtAccounts = accounts.filter { it.type == AccountType.Debt && !it.isArchived }
 
     var selectedParticipant by remember { mutableStateOf<AdvanceParticipantEntity?>(null) }
     var selectedReceiveAccount by remember { mutableStateOf<AccountEntity?>(null) }
@@ -116,7 +117,12 @@ fun AdvanceDetailScreen(caseId: String?) {
     var editingRepayment by remember { mutableStateOf<AdvanceRepaymentEntity?>(null) }
     var repaymentToRollback by remember { mutableStateOf<AdvanceRepaymentEntity?>(null) }
     var participantToEdit by remember { mutableStateOf<AdvanceParticipantEntity?>(null) }
+    var editedParticipantName by remember { mutableStateOf("") }
+    var editedParticipantDebtAccount by remember { mutableStateOf<AccountEntity?>(null) }
     var editedParticipantAmount by remember { mutableStateOf("") }
+    var editedParticipantPaymentAccount by remember { mutableStateOf<AccountEntity?>(null) }
+    var editedParticipantPaymentAmount by remember { mutableStateOf("") }
+    var editedParticipantPaymentCurrency by remember { mutableStateOf("HKD") }
     var selfExpense by remember { mutableStateOf<TransactionWithDetails?>(null) }
     var isEditingSelfExpense by remember { mutableStateOf(false) }
     var selfExpenseAccount by remember { mutableStateOf<AccountEntity?>(null) }
@@ -128,6 +134,7 @@ fun AdvanceDetailScreen(caseId: String?) {
     var selfExpenseDate by remember { mutableStateOf(Instant.now()) }
     var selfExpenseNote by remember { mutableStateOf("") }
     var isEditingInitialMetadata by remember { mutableStateOf(false) }
+    var initialTitle by remember { mutableStateOf("") }
     var initialPayerAccount by remember { mutableStateOf<AccountEntity?>(null) }
     var initialCategory by remember { mutableStateOf<CategoryEntity?>(null) }
     var initialTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
@@ -153,6 +160,7 @@ fun AdvanceDetailScreen(caseId: String?) {
 
     LaunchedEffect(caseData.advanceCase.id, receiveAccounts, categories) {
         if (!isEditingInitialMetadata) {
+            initialTitle = caseData.advanceCase.title
             initialPayerAccount = receiveAccounts.firstOrNull {
                 it.id == caseData.advanceCase.payerAccountId
             }
@@ -287,6 +295,7 @@ fun AdvanceDetailScreen(caseId: String?) {
                     Text("備註：${caseData.advanceCase.note.ifBlank { "-" }}")
                     if (!isEditingInitialMetadata) {
                         TextButton(onClick = {
+                            initialTitle = caseData.advanceCase.title
                             initialPayerAccount = receiveAccounts.firstOrNull {
                                 it.id == caseData.advanceCase.payerAccountId
                             }
@@ -309,6 +318,17 @@ fun AdvanceDetailScreen(caseId: String?) {
                             Text("編輯案件記帳資料")
                         }
                     } else {
+                        OutlinedTextField(
+                            value = initialTitle,
+                            onValueChange = { initialTitle = it },
+                            label = { Text("案件名稱") },
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                            ),
+                            keyboardActions =
+                                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+                        )
                         if (isBorrowedByMe) {
                             CategoryPicker(
                                 categories = selfExpenseCategories,
@@ -326,11 +346,10 @@ fun AdvanceDetailScreen(caseId: String?) {
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         } else {
-                            AccountPicker(
-                                label = "付款帳戶",
-                                accounts = receiveAccounts,
-                                selected = initialPayerAccount,
-                                onSelect = { initialPayerAccount = it }
+                            Text(
+                                "每位對象的實際付款帳戶、金額與幣種請在下方「代墊對象」逐筆編輯。",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                         TextButton(onClick = {
@@ -359,6 +378,7 @@ fun AdvanceDetailScreen(caseId: String?) {
                                             repository.updateAdvanceInitialMetadata(
                                                 AdvanceInitialMetadataEditDraft(
                                                     caseId = caseData.advanceCase.id,
+                                                    title = initialTitle,
                                                     payerAccountId =
                                                         if (isBorrowedByMe) null else initialPayerAccount?.id,
                                                     date = initialDate,
@@ -379,7 +399,7 @@ fun AdvanceDetailScreen(caseId: String?) {
                                         }
                                     }
                                 },
-                                enabled = isBorrowedByMe || initialPayerAccount != null
+                                enabled = initialTitle.isNotBlank()
                             ) {
                                 Text("儲存")
                             }
@@ -540,7 +560,31 @@ fun AdvanceDetailScreen(caseId: String?) {
                         currency = caseCurrency,
                         onEdit = {
                             participantToEdit = participant
+                            editedParticipantName = participant.name
+                            editedParticipantDebtAccount = debtAccounts.firstOrNull {
+                                it.id == participant.debtAccountId
+                            }
                             editedParticipantAmount = participant.owedAmount.stripTrailingZeros().toPlainString()
+                            editedParticipantPaymentAccount = null
+                            editedParticipantPaymentAmount = ""
+                            editedParticipantPaymentCurrency = caseCurrency
+                            scope.launch {
+                                val group = participant.initialTransferGroupId
+                                    ?.let { repository.getTransferGroup(it) }
+                                    .orEmpty()
+                                val assetLeg = group.firstOrNull {
+                                    it.transaction.advanceEntryRole == "InitialAsset" ||
+                                        it.transaction.transferSide ==
+                                        org.duckdns.lhfser.aiaccounting.core.model.TransferSide.Outgoing
+                                }
+                                if (!isBorrowedByMe && assetLeg != null) {
+                                    editedParticipantPaymentAccount = assetLeg.account
+                                    editedParticipantPaymentAmount =
+                                        assetLeg.transaction.amount.abs().stripTrailingZeros().toPlainString()
+                                    editedParticipantPaymentCurrency =
+                                        assetLeg.transaction.currencyCode
+                                }
+                            }
                         }
                     )
                 }
@@ -966,23 +1010,97 @@ fun AdvanceDetailScreen(caseId: String?) {
     participantToEdit?.let { participant ->
         AlertDialog(
             onDismissRequest = { participantToEdit = null },
-            title = { Text("更正欠款") },
+            title = { Text("編輯代墊對象") },
             text = {
-                OutlinedTextField(
-                    value = editedParticipantAmount,
-                    onValueChange = { editedParticipantAmount = sanitizeAmount(it) },
-                    label = { Text("欠款金額 ($caseCurrency)") }
-                )
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    item {
+                        OutlinedTextField(
+                            value = editedParticipantName,
+                            onValueChange = { editedParticipantName = it },
+                            label = { Text("姓名") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    item {
+                        AccountPicker(
+                            label = "債務帳戶",
+                            accounts = debtAccounts,
+                            selected = editedParticipantDebtAccount,
+                            onSelect = { editedParticipantDebtAccount = it }
+                        )
+                    }
+                    item {
+                        OutlinedTextField(
+                            value = editedParticipantAmount,
+                            onValueChange = { editedParticipantAmount = sanitizeAmount(it) },
+                            label = { Text("欠款金額 ($caseCurrency)") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    if (!isBorrowedByMe) {
+                        item {
+                            AccountPicker(
+                                label = "實際付款帳戶",
+                                accounts = receiveAccounts,
+                                selected = editedParticipantPaymentAccount,
+                                onSelect = { editedParticipantPaymentAccount = it }
+                            )
+                        }
+                        item {
+                            AmountRow(
+                                label = "實際付款",
+                                amount = editedParticipantPaymentAmount,
+                                onAmountChange = {
+                                    editedParticipantPaymentAmount = sanitizeAmount(it)
+                                },
+                                currency = editedParticipantPaymentCurrency,
+                                onCurrencyChange = {
+                                    editedParticipantPaymentCurrency = it
+                                }
+                            )
+                        }
+                        item {
+                            Text(
+                                "實際付款可與欠款使用不同幣種，例如實付 34.86 HKD、對方欠 710 JPY。",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
             },
             confirmButton = {
                 TextButton(onClick = {
                     val amount = parsePositive(editedParticipantAmount)
-                    if (amount == null) {
+                    val paymentAmount = if (!isBorrowedByMe) {
+                        parsePositive(editedParticipantPaymentAmount)
+                    } else {
+                        null
+                    }
+                    if (editedParticipantName.isBlank()) {
+                        errorMessage = "請輸入對象名稱。"
+                    } else if (editedParticipantDebtAccount == null) {
+                        errorMessage = "請選擇債務帳戶。"
+                    } else if (amount == null) {
                         errorMessage = "請輸入大於 0 的欠款金額。"
+                    } else if (!isBorrowedByMe &&
+                        (editedParticipantPaymentAccount == null || paymentAmount == null)
+                    ) {
+                        errorMessage = "請選擇付款帳戶並輸入實際付款金額。"
                     } else {
                         scope.launch {
                             runCatching {
-                                repository.updateAdvanceParticipantOwedAmount(participant.id, amount)
+                                repository.updateAdvanceParticipantOwedAmount(
+                                    participantId = participant.id,
+                                    newOwedAmount = amount,
+                                    participantName = editedParticipantName,
+                                    debtAccountId = editedParticipantDebtAccount?.id,
+                                    paymentAccountId =
+                                        if (!isBorrowedByMe) editedParticipantPaymentAccount?.id else null,
+                                    paymentAmount = paymentAmount,
+                                    paymentCurrencyCode =
+                                        if (!isBorrowedByMe) editedParticipantPaymentCurrency else null
+                                )
                             }.onSuccess {
                                 advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
                             }.onFailure {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/TransactionsScreen.kt
@@ -83,11 +83,22 @@ private sealed interface LedgerItem {
         override val date: Instant = item.transaction.date
     }
 
-    data class AdvanceSummary(val item: AdvanceCaseWithDetails) : LedgerItem {
-        override val stableId: String = "advance-${item.advanceCase.id}"
-        override val date: Instant = item.advanceCase.date
+    data class AdvanceSummary(val summary: AdvanceLedgerSummary) : LedgerItem {
+        override val stableId: String = "advance-${summary.item.advanceCase.id}"
+        override val date: Instant = summary.activityDate
     }
 }
+
+private data class AdvanceCurrencyTotal(
+    val currencyCode: String,
+    val amount: BigDecimal
+)
+
+private data class AdvanceLedgerSummary(
+    val item: AdvanceCaseWithDetails,
+    val activityDate: Instant,
+    val paymentTotals: List<AdvanceCurrencyTotal>
+)
 
 private data class DailySection(val date: LocalDate, val items: List<LedgerItem>)
 
@@ -131,11 +142,32 @@ fun TransactionsScreen(
     val initialAdvanceGroupIds = remember(advanceCases) {
         advanceCases.flatMap { it.participants.mapNotNull { participant -> participant.initialTransferGroupId } }.toSet()
     }
-    val filteredTransactions = remember(transactions, rangeStart, rangeEnd, searchText, initialAdvanceGroupIds) {
-        filterTransactions(transactions, rangeStart, rangeEnd, searchText, initialAdvanceGroupIds)
+    val repaymentAdvanceGroupIds = remember(advanceCases) {
+        advanceCases.flatMap { it.repayments.mapNotNull { repayment -> repayment.linkedTransferGroupId } }.toSet()
     }
-    val filteredAdvanceCases = remember(advanceCases, rangeStart, rangeEnd, searchText) {
-        filterAdvanceCases(advanceCases, rangeStart, rangeEnd, searchText)
+    val advanceSelfExpenseIds = remember(advanceCases) {
+        advanceCases.mapNotNull { it.advanceCase.selfExpenseTransactionId }.toSet()
+    }
+    val filteredTransactions = remember(
+        transactions,
+        rangeStart,
+        rangeEnd,
+        searchText,
+        initialAdvanceGroupIds,
+        repaymentAdvanceGroupIds,
+        advanceSelfExpenseIds
+    ) {
+        filterTransactions(
+            transactions = transactions,
+            rangeStart = rangeStart,
+            rangeEnd = rangeEnd,
+            query = searchText,
+            excludedAdvanceGroupIds = initialAdvanceGroupIds + repaymentAdvanceGroupIds,
+            advanceSelfExpenseIds = advanceSelfExpenseIds
+        )
+    }
+    val filteredAdvanceCases = remember(advanceCases, transactions, rangeStart, rangeEnd, searchText) {
+        filterAdvanceCases(advanceCases, transactions, rangeStart, rangeEnd, searchText)
     }
     val ledgerItems = remember(filteredTransactions, filteredAdvanceCases) {
         buildLedgerItems(filteredTransactions, filteredAdvanceCases)
@@ -276,8 +308,10 @@ fun TransactionsScreen(
                             }
                             is LedgerItem.AdvanceSummary -> {
                                 AdvanceSummaryRow(
-                                    item = item.item,
-                                    onClick = { onOpenAdvanceCase(item.item.advanceCase.id.toString()) }
+                                    summary = item.summary,
+                                    onClick = {
+                                        onOpenAdvanceCase(item.summary.item.advanceCase.id.toString())
+                                    }
                                 )
                             }
                         }
@@ -528,9 +562,10 @@ private fun TransactionRow(
 
 @Composable
 private fun AdvanceSummaryRow(
-    item: AdvanceCaseWithDetails,
+    summary: AdvanceLedgerSummary,
     onClick: () -> Unit
 ) {
+    val item = summary.item
     val totalAdvanced = item.advanceCase.myShareAmount + item.participants.fold(BigDecimal.ZERO) { acc, participant ->
         acc + participant.owedAmount
     }
@@ -538,6 +573,23 @@ private fun AdvanceSummaryRow(
         acc + (participant.owedAmount - participant.repaidAmount).max(BigDecimal.ZERO)
     }
     val payerText = item.payerAccount?.name ?: "他人代付（不影響自己帳戶）"
+    val isSettled = outstanding <= BigDecimal("0.0001")
+    val directionLabel = if (item.advanceCase.direction == "OthersAdvancedMe") {
+        "他人代墊我"
+    } else {
+        "我代墊他人"
+    }
+    val paymentText = if (summary.paymentTotals.isEmpty()) {
+        if (item.advanceCase.direction == "OthersAdvancedMe") {
+            "${totalAdvanced.asCurrencyText(item.advanceCase.currencyCode)}（他人代付）"
+        } else {
+            totalAdvanced.asCurrencyText(item.advanceCase.currencyCode)
+        }
+    } else {
+        summary.paymentTotals.joinToString(" + ") {
+            it.amount.asCurrencyText(it.currencyCode)
+        }
+    }
 
     PressableCard(
         modifier = Modifier.fillMaxWidth(),
@@ -559,7 +611,7 @@ private fun AdvanceSummaryRow(
                         fontWeight = FontWeight.SemiBold
                     )
                     ParityStatusPill(
-                        text = "代墊",
+                        text = directionLabel,
                         tint = Color(0xFFEF6C00)
                     )
                 }
@@ -569,22 +621,27 @@ private fun AdvanceSummaryRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    item.advanceCase.date.toDateText(),
+                    "最近活動 ${summary.activityDate.toDateText()}",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             Column(horizontalAlignment = Alignment.End) {
                 Text(
-                    totalAdvanced.asCurrencyText(item.advanceCase.currencyCode),
+                    paymentText,
                     color = Color(0xFFEF6C00),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    "未清 ${outstanding.asCurrencyText(item.advanceCase.currencyCode)}",
+                    if (isSettled) {
+                        "已結清"
+                    } else {
+                        val label = if (item.advanceCase.direction == "OthersAdvancedMe") "待還" else "待收"
+                        "$label ${outstanding.asCurrencyText(item.advanceCase.currencyCode)}"
+                    },
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = if (isSettled) Color(0xFF2E7D32) else MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
@@ -731,7 +788,8 @@ private fun filterTransactions(
     rangeStart: Instant?,
     rangeEnd: Instant?,
     query: String,
-    excludedAdvanceGroupIds: Set<UUID>
+    excludedAdvanceGroupIds: Set<UUID>,
+    advanceSelfExpenseIds: Set<UUID>
 ): List<TransactionWithDetails> {
     val normalized = query.trim().lowercase()
     return transactions.filter { tx ->
@@ -739,6 +797,9 @@ private fun filterTransactions(
             tx.transaction.date >= rangeStart && tx.transaction.date < rangeEnd
         } else true
         if (!dateOk) return@filter false
+        if (tx.transaction.advanceCaseId != null || tx.transaction.id in advanceSelfExpenseIds) {
+            return@filter false
+        }
         if (tx.transaction.transferGroupId in excludedAdvanceGroupIds) return@filter false
         if (normalized.isBlank()) return@filter true
         val note = tx.transaction.note.lowercase()
@@ -753,31 +814,109 @@ private fun filterTransactions(
 
 private fun filterAdvanceCases(
     advanceCases: List<AdvanceCaseWithDetails>,
+    transactions: List<TransactionWithDetails>,
     rangeStart: Instant?,
     rangeEnd: Instant?,
     query: String
-): List<AdvanceCaseWithDetails> {
+): List<AdvanceLedgerSummary> {
     val normalized = query.trim().lowercase()
-    return advanceCases.filter { advanceCase ->
-        val dateOk = if (rangeStart != null && rangeEnd != null) {
-            advanceCase.advanceCase.date >= rangeStart && advanceCase.advanceCase.date < rangeEnd
-        } else true
-        if (!dateOk) return@filter false
-        if (normalized.isBlank()) return@filter true
+    val transactionsByCaseId = transactions
+        .mapNotNull { transaction ->
+            transaction.transaction.advanceCaseId?.let { it to transaction }
+        }
+        .groupBy({ it.first }, { it.second })
+    val transactionsByGroupId = transactions
+        .mapNotNull { transaction ->
+            transaction.transaction.transferGroupId?.let { it to transaction }
+        }
+        .groupBy({ it.first }, { it.second })
+    val transactionById = transactions.associateBy { it.transaction.id }
 
-        val title = advanceCase.advanceCase.title.lowercase()
-        val note = advanceCase.advanceCase.note.lowercase()
-        val payer = advanceCase.payerAccount?.name?.lowercase().orEmpty()
-        val participants = advanceCase.participants.joinToString(" ") { it.name.lowercase() }
-        listOf(title, note, payer, participants).any { it.contains(normalized) }
+    return advanceCases.mapNotNull { advanceCase ->
+        var caseTransactions = transactionsByCaseId[advanceCase.advanceCase.id].orEmpty()
+        val groupIds = advanceCase.participants.mapNotNull { it.initialTransferGroupId } +
+            advanceCase.repayments.mapNotNull { it.linkedTransferGroupId }
+        caseTransactions = (
+            caseTransactions +
+                groupIds.distinct().flatMap { transactionsByGroupId[it].orEmpty() } +
+                listOfNotNull(
+                    advanceCase.advanceCase.selfExpenseTransactionId?.let(transactionById::get)
+                )
+            ).distinctBy { it.transaction.id }
+
+        val activityDates = listOf(advanceCase.advanceCase.date) +
+            advanceCase.repayments.map { it.date } +
+            caseTransactions.map { it.transaction.date }
+        val matchingDates = activityDates.filter {
+            rangeStart == null || rangeEnd == null || (it >= rangeStart && it < rangeEnd)
+        }
+        val activityDate = matchingDates.maxOrNull() ?: return@mapNotNull null
+
+        if (normalized.isNotBlank()) {
+            val searchable = listOf(
+                advanceCase.advanceCase.title,
+                advanceCase.advanceCase.note,
+                advanceCase.payerAccount?.name.orEmpty(),
+                advanceCase.expenseCategory?.name.orEmpty(),
+                advanceCase.participants.joinToString(" ") { it.name },
+                advanceCase.repayments.joinToString(" ") { it.note },
+                caseTransactions.joinToString(" ") {
+                    listOfNotNull(it.account?.name, it.category?.name)
+                        .plus(it.tags.map { tag -> tag.name })
+                        .joinToString(" ")
+                }
+            )
+            if (searchable.none { it.lowercase().contains(normalized) }) {
+                return@mapNotNull null
+            }
+        }
+
+        val initialGroupIds = advanceCase.participants
+            .mapNotNull { it.initialTransferGroupId }
+            .toSet()
+        val paymentTotals = caseTransactions
+            .filter {
+                (
+                    it.transaction.advanceEntryRole == "InitialAsset" ||
+                        (
+                            it.transaction.advanceEntryRole == null &&
+                                it.transaction.transferGroupId in initialGroupIds &&
+                                (
+                                    it.transaction.transferSide ==
+                                        org.duckdns.lhfser.aiaccounting.core.model.TransferSide.Outgoing ||
+                                        it.transaction.amount < BigDecimal.ZERO
+                                    )
+                            )
+                    ) &&
+                    it.transaction.amount < BigDecimal.ZERO
+            }
+            .groupBy { it.transaction.currencyCode }
+            .map { (currency, entries) ->
+                AdvanceCurrencyTotal(
+                    currencyCode = currency,
+                    amount = entries.fold(BigDecimal.ZERO) { acc, entry ->
+                        acc + entry.transaction.amount.abs()
+                    }
+                )
+            }
+            .sortedBy { it.currencyCode }
+
+        AdvanceLedgerSummary(
+            item = advanceCase,
+            activityDate = activityDate,
+            paymentTotals = paymentTotals
+        )
     }
 }
 
 private fun buildLedgerItems(
     transactions: List<TransactionWithDetails>,
-    advanceCases: List<AdvanceCaseWithDetails>
+    advanceCases: List<AdvanceLedgerSummary>
 ): List<LedgerItem> {
-    return (transactions.map { LedgerItem.TransactionEntry(it) } + advanceCases.map { LedgerItem.AdvanceSummary(it) })
+    return (
+        transactions.map { LedgerItem.TransactionEntry(it) } +
+            advanceCases.map { LedgerItem.AdvanceSummary(it) }
+        )
         .sortedByDescending { it.date }
 }
 

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
@@ -79,6 +79,8 @@ class AdvanceEditingTest {
 
     @Test
     fun initialEntry_supportsActualPaymentCurrencySeparateFromDebtCurrency() = runBlocking {
+        val renamedDebtAccount = account("TKL", AccountType.Debt, 3)
+        repository.upsertAccount(renamedDebtAccount)
         val caseId = repository.createAdvanceCase(
             title = "LUUP",
             date = Instant.parse("2026-06-10T10:00:00Z"),
@@ -95,6 +97,9 @@ class AdvanceEditingTest {
         repository.updateAdvanceParticipantOwedAmount(
             participantId = participant.id,
             newOwedAmount = BigDecimal("710"),
+            participantName = "TKL",
+            debtAccountId = renamedDebtAccount.id,
+            paymentAccountId = bank.id,
             paymentAmount = BigDecimal("34.86"),
             paymentCurrencyCode = "HKD"
         )
@@ -108,8 +113,13 @@ class AdvanceEditingTest {
         assertEquals("HKD", asset.currencyCode)
         assertEquals("710", debt.amount.toPlainString())
         assertEquals("JPY", debt.currencyCode)
+        assertEquals(bank.id, asset.accountId)
+        assertEquals(renamedDebtAccount.id, debt.accountId)
         assertEquals(caseId, asset.advanceCaseId)
         assertEquals(participant.id, debt.advanceParticipantId)
+        val updatedParticipant = requireNotNull(repository.getAdvanceCase(caseId)).participants.single()
+        assertEquals("TKL", updatedParticipant.name)
+        assertEquals(renamedDebtAccount.id, updatedParticipant.debtAccountId)
     }
 
     @Test
@@ -323,6 +333,7 @@ class AdvanceEditingTest {
         repository.updateAdvanceInitialMetadata(
             AdvanceInitialMetadataEditDraft(
                 caseId = caseId,
+                title = "Japan trip updated",
                 payerAccountId = bank.id,
                 date = editedDate,
                 note = "Edited",
@@ -332,17 +343,18 @@ class AdvanceEditingTest {
         )
 
         val updated = requireNotNull(repository.getAdvanceCase(caseId))
-        assertEquals(bank.id, updated.advanceCase.payerAccountId)
+        assertEquals("Japan trip updated", updated.advanceCase.title)
+        assertEquals(wallet.id, updated.advanceCase.payerAccountId)
         assertEquals(editedDate, updated.advanceCase.date)
         assertEquals("Edited", updated.advanceCase.note)
         updated.participants.forEach { participant ->
             val group = repository.getTransferGroup(requireNotNull(participant.initialTransferGroupId))
             val outgoing = group.single { it.transaction.transferSide == TransferSide.Outgoing }
             val incoming = group.single { it.transaction.transferSide == TransferSide.Incoming }
-            assertEquals(bank.id, outgoing.transaction.accountId)
+            assertEquals(wallet.id, outgoing.transaction.accountId)
             assertEquals(editedDate, outgoing.transaction.date)
             assertEquals(editedDate, incoming.transaction.date)
-            assertTrue(incoming.transaction.note.contains(bank.name))
+            assertTrue(incoming.transaction.note.contains(wallet.name))
             assertEquals(participant.owedAmount.negate(), outgoing.transaction.amount)
             assertEquals(participant.owedAmount, incoming.transaction.amount)
         }


### PR DESCRIPTION
## Summary
- collapse advance bookkeeping into one case summary on the main ledger
- add richer advance detail and safe editing for metadata, participants, actual payments, and repayments
- route account/report advance entries back to the case detail
- preserve actual payment currency independently from settlement currency on iOS and Android

## Validation
- iOS simulator build twice
- Android `testDebugUnitTest assembleDebug` twice, including rerun-tasks
- iOS test bundles compile; local simulator runtime could not bind launchd_sim

## Safety
- no local scheme or localisation changes included
- destructive direction/currency rebuild remains blocked rather than partially applying changes