### PR TITLE
Standardize keyboard dismissal across app

### DIFF
--- a/AI 記帳/Views/Budgets/BudgetsView.swift
+++ b/AI 記帳/Views/Budgets/BudgetsView.swift
@@ -411,7 +411,7 @@ struct BudgetEditorView: View {
                     Toggle("啟用", isOn: $isEnabled)
                 }
             }
-            .interactiveKeyboardDismiss()
+            .standardKeyboardBehavior()
             .navigationTitle(existingBudget == nil ? "新增預算" : "編輯預算")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -421,7 +421,6 @@ struct BudgetEditorView: View {
                     Button("儲存") { save() }
                 }
             }
-            .keyboardDoneToolbar()
             .alert("無法儲存", isPresented: $showingError) {
                 Button("好", role: .cancel) {}
             } message: {

--- a/AI 記帳/Views/Categories/AddCategoryView.swift
+++ b/AI 記帳/Views/Categories/AddCategoryView.swift
@@ -141,7 +141,7 @@ struct AddCategoryView: View {
                     }
                 }
             }
-            .interactiveKeyboardDismiss()
+            .standardKeyboardBehavior()
             .navigationTitle("新增分類")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -158,7 +158,6 @@ struct AddCategoryView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
-            .keyboardDoneToolbar()
         }
     }
     

--- a/AI 記帳/Views/Categories/EditCategoryView.swift
+++ b/AI 記帳/Views/Categories/EditCategoryView.swift
@@ -133,7 +133,7 @@ struct EditCategoryView: View {
                     }
                 }
             }
-            .interactiveKeyboardDismiss()
+            .standardKeyboardBehavior()
             .navigationTitle("編輯分類")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -147,7 +147,6 @@ struct EditCategoryView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
-            .keyboardDoneToolbar()
             .onAppear {
                 // 初始化暫存數據
                 name = category.name

--- a/AI 記帳/Views/Common/ProminentInlineTitle.swift
+++ b/AI 記帳/Views/Common/ProminentInlineTitle.swift
@@ -44,4 +44,11 @@ extension View {
     func interactiveKeyboardDismiss() -> some View {
         scrollDismissesKeyboard(.interactively)
     }
+
+    /// Applies the app-wide keyboard contract: scroll to dismiss and an
+    /// explicit Done action for keyboards that do not provide one.
+    func standardKeyboardBehavior(doneTitle: String = "完成") -> some View {
+        scrollDismissesKeyboard(.interactively)
+            .keyboardDoneToolbar(title: doneTitle)
+    }
 }

--- a/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
+++ b/AI 記帳/Views/Recurring/RecurringTransactionsView.swift
@@ -263,7 +263,7 @@ struct AddRecurringRuleView: View {
                     TextField("備註（可選）", text: $note, axis: .vertical)
                 }
             }
-            .interactiveKeyboardDismiss()
+            .standardKeyboardBehavior()
             .navigationTitle(rule == nil ? "新增定期記帳" : "編輯定期記帳")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -273,7 +273,6 @@ struct AddRecurringRuleView: View {
                     Button("儲存") { save() }
                 }
             }
-            .keyboardDoneToolbar()
             .alert("無法儲存", isPresented: Binding(
                 get: { validationMessage != nil },
                 set: { if !$0 { validationMessage = nil } }

--- a/AI 記帳/Views/Settings/RemoteBackupView.swift
+++ b/AI 記帳/Views/Settings/RemoteBackupView.swift
@@ -129,8 +129,7 @@ struct RemoteBackupView: View {
                 }
             }
         }
-        .interactiveKeyboardDismiss()
-        .keyboardDoneToolbar()
+        .standardKeyboardBehavior()
         .navigationTitle("WebDAV 遠端備份")
         .onAppear(perform: loadSecrets)
         .alert("還原遠端備份？", isPresented: $showingRestoreConfirm) {

--- a/AI 記帳/Views/Settings/SettingsView.swift
+++ b/AI 記帳/Views/Settings/SettingsView.swift
@@ -303,6 +303,7 @@ struct SettingsView: View {
                 }
             }
             .prominentInlineTitle("設定")
+            .standardKeyboardBehavior()
             .alert("提示", isPresented: $showingAlert) {
                 Button("好") {}
             } message: {

--- a/AI 記帳/Views/Settlements/SettlementCenterView.swift
+++ b/AI 記帳/Views/Settlements/SettlementCenterView.swift
@@ -785,6 +785,7 @@ private struct ManualDebtSettlementSheet: View {
             }
             .navigationTitle("跨幣種平賬")
             .navigationBarTitleDisplayMode(.inline)
+            .standardKeyboardBehavior()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("取消") { dismiss() }

--- a/AI 記帳/Views/Tags/EditTagView.swift
+++ b/AI 記帳/Views/Tags/EditTagView.swift
@@ -14,7 +14,7 @@ struct EditTagView: View {
                     TextField("例如: 旅行、報銷", text: $name)
                 }
             }
-            .interactiveKeyboardDismiss()
+            .standardKeyboardBehavior()
             .navigationTitle("編輯標籤")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -29,7 +29,6 @@ struct EditTagView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
-            .keyboardDoneToolbar()
             .onAppear {
                 name = tag.name
             }

--- a/AI 記帳/Views/Tags/TagsView.swift
+++ b/AI 記帳/Views/Tags/TagsView.swift
@@ -35,6 +35,7 @@ struct TagsView: View {
             }
         }
         .navigationTitle("標籤管理")
+        .standardKeyboardBehavior()
         .overlay {
             if tags.isEmpty {
                 ContentUnavailableView("尚無標籤", systemImage: "tag", description: Text("標籤可幫助您更靈活地標記交易"))
@@ -48,8 +49,12 @@ struct TagsView: View {
         // 新增標籤 Alert
         .alert("新增標籤", isPresented: $showingAddTag) {
             TextField("標籤名稱", text: $newTagName)
-            Button("取消", role: .cancel) { newTagName = "" }
+            Button("取消", role: .cancel) {
+                hideKeyboard()
+                newTagName = ""
+            }
             Button("儲存") {
+                hideKeyboard()
                 if !newTagName.isEmpty {
                     let tag = Tag(name: newTagName)
                     modelContext.insert(tag)

--- a/AI 記帳/Views/Transactions/ScanReceiptView.swift
+++ b/AI 記帳/Views/Transactions/ScanReceiptView.swift
@@ -93,6 +93,7 @@ struct ScanReceiptView: View {
                     .foregroundStyle(.secondary)
             }
             .navigationTitle("掃描單據")
+            .standardKeyboardBehavior()
             .onChange(of: selectedItem) { _, newItem in
                 Task {
                     if let data = try? await newItem?.loadTransferable(type: Data.self),

--- a/AI 記帳/Views/Transactions/ScannedResultView.swift
+++ b/AI 記帳/Views/Transactions/ScannedResultView.swift
@@ -67,7 +67,7 @@ struct ScannedResultView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
         }
-        .interactiveKeyboardDismiss()
+        .standardKeyboardBehavior()
         .navigationTitle("確認資料")
         .toolbar {
             Button("儲存") {
@@ -75,7 +75,6 @@ struct ScannedResultView: View {
             }
             .disabled(selectedAccount == nil || amountString.isEmpty)
         }
-        .keyboardDoneToolbar()
         .onAppear {
             // 填充 AI 資料
             amountString = "\(info.amount)"

--- a/AI 記帳/Views/Transactions/TransactionsListView.swift
+++ b/AI 記帳/Views/Transactions/TransactionsListView.swift
@@ -62,6 +62,7 @@ struct TransactionsListView: View {
         NavigationStack {
             ledgerContent(renderState: renderState)
         }
+        .standardKeyboardBehavior()
         .sheet(isPresented: $showingFilterSheet) {
             DateFilterView(
                 filterType: filterTypeBinding,

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
@@ -282,7 +283,9 @@ fun AdvanceDetailScreen(caseId: String?) {
     }
 
     LazyColumn(
-        modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        modifier = Modifier
+            .imePadding()
+            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         item {
@@ -1012,13 +1015,21 @@ fun AdvanceDetailScreen(caseId: String?) {
             onDismissRequest = { participantToEdit = null },
             title = { Text("編輯代墊對象") },
             text = {
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                LazyColumn(
+                    modifier = Modifier.imePadding(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     item {
                         OutlinedTextField(
                             value = editedParticipantName,
                             onValueChange = { editedParticipantName = it },
                             label = { Text("姓名") },
-                            modifier = Modifier.fillMaxWidth()
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                            ),
+                            keyboardActions =
+                                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
                         )
                     }
                     item {
@@ -1034,7 +1045,13 @@ fun AdvanceDetailScreen(caseId: String?) {
                             value = editedParticipantAmount,
                             onValueChange = { editedParticipantAmount = sanitizeAmount(it) },
                             label = { Text("欠款金額 ($caseCurrency)") },
-                            modifier = Modifier.fillMaxWidth()
+                            modifier = Modifier.fillMaxWidth(),
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                keyboardType = androidx.compose.ui.text.input.KeyboardType.Decimal,
+                                imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                            ),
+                            keyboardActions =
+                                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
                         )
                     }
                     if (!isBorrowedByMe) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/BudgetsScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/BudgetsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -191,7 +192,9 @@ fun BudgetsScreen() {
     }
 
     LazyColumn(
-        modifier = Modifier.padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
+        modifier = Modifier
+            .imePadding()
+            .padding(horizontal = AppSpacing.screenHorizontal, vertical = AppSpacing.screenVertical),
         verticalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = PaddingValues(bottom = 20.dp)
     ) {

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/SettlementCenterScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -29,7 +30,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.KeyboardOptions
@@ -149,7 +152,9 @@ fun SettlementCenterScreen(
     }
 
     LazyColumn(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .imePadding(),
         contentPadding = androidx.compose.foundation.layout.PaddingValues(
             start = AppSpacing.screenHorizontal,
             end = AppSpacing.screenHorizontal,
@@ -380,6 +385,7 @@ private fun ManualDebtSettlementDialog(
     onDismiss: () -> Unit,
     onConfirm: (BigDecimal, String) -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     var amountText by remember(draft.id) { mutableStateOf(draft.suggestedAmount.stripTrailingZeros().toPlainString()) }
     var note by remember(draft.id) { mutableStateOf("") }
     var errorText by remember(draft.id) { mutableStateOf<String?>(null) }
@@ -388,7 +394,10 @@ private fun ManualDebtSettlementDialog(
         onDismissRequest = onDismiss,
         title = { Text("跨幣種平賬") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Column(
+                modifier = Modifier.imePadding(),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
                 Text("對象：${draft.account.name}", style = MaterialTheme.typography.bodyMedium)
                 Text("方向：${manualSettlementLabel(draft.direction, draft.currencyCode)}", style = MaterialTheme.typography.bodyMedium)
                 Text(
@@ -410,7 +419,12 @@ private fun ManualDebtSettlementDialog(
                     value = amountText,
                     onValueChange = { amountText = it },
                     label = { Text("平賬金額") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Decimal,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions =
+                        org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions(),
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -420,6 +434,9 @@ private fun ManualDebtSettlementDialog(
                     label = { Text("備註（可選）") },
                     modifier = Modifier.fillMaxWidth()
                 )
+                TextButton(onClick = { focusManager.clearFocus() }) {
+                    Text("完成輸入")
+                }
                 errorText?.let {
                     Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 }
@@ -427,6 +444,7 @@ private fun ManualDebtSettlementDialog(
         },
         confirmButton = {
             TextButton(onClick = {
+                focusManager.clearFocus()
                 val amount = runCatching { BigDecimal(amountText.trim()) }.getOrNull()
                 when {
                     amount == null || amount <= BigDecimal.ZERO -> errorText = "請輸入有效金額。"
@@ -438,7 +456,10 @@ private fun ManualDebtSettlementDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("取消") }
+            TextButton(onClick = {
+                focusManager.clearFocus()
+                onDismiss()
+            }) { Text("取消") }
         }
     )
 }

--- a/scripts/audit-keyboard-inputs.sh
+++ b/scripts/audit-keyboard-inputs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+status=0
+
+echo "iOS files with input controls but no standard keyboard exit:"
+while IFS= read -r file; do
+    if ! rg -q \
+        'standardKeyboardBehavior|keyboardDoneToolbar|ToolbarItemGroup\(placement: \.keyboard\)' \
+        "$file"; then
+        echo "  $file"
+        status=1
+    fi
+done < <(
+    rg -l 'TextField\(|TextEditor\(|SecureField\(|\.searchable\(' \
+        'AI 記帳' --glob '*.swift' | sort
+)
+
+echo "Android input screens without IME avoidance:"
+while IFS= read -r file; do
+    if [[ "$file" == *"/ui/components/"* ]]; then
+        continue
+    fi
+    if ! rg -q 'imePadding\(' "$file"; then
+        echo "  $file"
+        status=1
+    fi
+done < <(
+    rg -l 'OutlinedTextField\(|BasicTextField\(|TextField\(' \
+        android/app/src/main/java --glob '*.kt' | sort
+)
+
+echo "Android input screens without a Done/focus-clear action:"
+while IFS= read -r file; do
+    if [[ "$file" == *"/ui/components/"* ]]; then
+        continue
+    fi
+    if ! rg -q 'keyboardDoneActions|clearFocus\(|ImeAction\.Done' "$file"; then
+        echo "  $file"
+        status=1
+    fi
+done < <(
+    rg -l 'OutlinedTextField\(|BasicTextField\(|TextField\(' \
+        android/app/src/main/java --glob '*.kt' | sort
+)
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add one shared iOS keyboard behaviour with interactive dismissal and a Done toolbar
- apply it to every iOS input screen and close alert input explicitly
- add missing Android Done/focus clearing and IME padding to settlement, budget, and advance flows
- add a reusable keyboard input inventory script

## Validation
- `scripts/audit-keyboard-inputs.sh` reports no missing screen-level behaviour
- iOS simulator build passed twice
- Android `testDebugUnitTest assembleDebug` passed twice, including `--rerun-tasks`

## Safety
- local Xcode scheme and localisation diffs are excluded