### PR TITLE
Add atomic advance structural editing core

### DIFF
--- a/AI 記帳/Services/AdvanceCaseEditingService.swift
+++ b/AI 記帳/Services/AdvanceCaseEditingService.swift
@@ -17,11 +17,25 @@ struct AdvanceShareDraft {
 }
 
 struct AdvanceParticipantDraft {
-    let participant: AdvanceParticipant
+    let participant: AdvanceParticipant?
     let name: String
     let debtAccount: Account
     let owedAmount: Decimal
     let paymentLegs: [AdvancePaymentLegDraft]
+
+    init(
+        participant: AdvanceParticipant? = nil,
+        name: String,
+        debtAccount: Account,
+        owedAmount: Decimal,
+        paymentLegs: [AdvancePaymentLegDraft]
+    ) {
+        self.participant = participant
+        self.name = name
+        self.debtAccount = debtAccount
+        self.owedAmount = owedAmount
+        self.paymentLegs = paymentLegs
+    }
 }
 
 struct AdvanceRepaymentDraft {
@@ -56,6 +70,8 @@ struct AdvanceCaseImpactPreview {
     let affectedTransactionCount: Int
     let affectedParticipantCount: Int
     let affectedRepaymentCount: Int
+    let removedParticipantCount: Int
+    let removedRepaymentCount: Int
     let warnings: [String]
 }
 
@@ -64,149 +80,696 @@ enum AdvanceCaseEditingError: LocalizedError {
     case invalidCurrency
     case noParticipants
     case duplicateParticipant
+    case invalidDebtAccount
     case invalidPaymentLeg
-    case unsupportedDirectionChange
-    case unsupportedSplitPaymentEdit
+    case invalidShare
     case currencyChangeRequiresExplicitAmounts
+    case participantNotInCase
+    case repaymentNotInCase
+    case duplicateRepayment
+    case missingLinkedEntry
+    case transactionNotInCase
+    case specialRepaymentRequiresGroupRollback
 
     var errorDescription: String? {
         switch self {
-        case .emptyTitle: return "請輸入案件名稱。"
-        case .invalidCurrency: return "請選擇案件幣種。"
-        case .noParticipants: return "請至少保留一位代墊對象。"
-        case .duplicateParticipant: return "同一債務對象不可重複。"
-        case .invalidPaymentLeg: return "實際付款帳戶、金額或幣種無效。"
-        case .unsupportedDirectionChange:
-            return "改變代墊方向需要重建底層分錄，請使用案件完整編輯流程。"
-        case .unsupportedSplitPaymentEdit:
-            return "多付款來源需要使用案件完整編輯流程。"
+        case .emptyTitle:
+            return "請輸入案件名稱。"
+        case .invalidCurrency:
+            return "請選擇案件幣種。"
+        case .noParticipants:
+            return "請至少保留一位代墊對象。"
+        case .duplicateParticipant:
+            return "同一債務對象不可重複。"
+        case .invalidDebtAccount:
+            return "請選擇未歸檔的借貸帳戶。"
+        case .invalidPaymentLeg:
+            return "實際付款帳戶、金額或幣種無效。"
+        case .invalidShare:
+            return "自己的份額、付款帳戶或幣種無效。"
         case .currencyChangeRequiresExplicitAmounts:
-            return "改變案件幣種前，必須重新確認每位對象與每筆還款的沖銷金額。"
+            return "改變案件幣種前，必須重新確認自己份額、每位對象與每筆還款的沖銷金額。"
+        case .participantNotInCase:
+            return "編輯草稿包含不屬於此案件的參與人。"
+        case .repaymentNotInCase:
+            return "編輯草稿包含不屬於此案件的還款。"
+        case .duplicateRepayment:
+            return "同一筆還款不可重複。"
+        case .missingLinkedEntry:
+            return "案件底層分錄連結不完整，無法安全重建。"
+        case .transactionNotInCase:
+            return "付款分錄識別碼已屬於其他交易，無法安全重建。"
+        case .specialRepaymentRequiresGroupRollback:
+            return "債務抵銷或跨幣種平賬必須先整組撤銷，不能在案件編輯中拆開修改。"
         }
     }
 }
 
 enum AdvanceCaseEditingService {
+    private struct TransactionSpec {
+        let id: UUID
+        let amount: Decimal
+        let currencyCode: String
+        let date: Date
+        let note: String
+        let type: TransactionType
+        let linkedTransactionID: UUID?
+        let transferGroupID: UUID?
+        let transferSide: TransferSide?
+        let advanceCaseID: UUID
+        let advanceParticipantID: UUID?
+        let advanceRepaymentID: UUID?
+        let advanceEntryRole: AdvanceEntryRole
+        let account: Account
+        let category: Category?
+        let tags: [Tag]
+    }
+
+    private struct PreparedParticipant {
+        let draft: AdvanceParticipantDraft
+        let participant: AdvanceParticipant
+        let isNew: Bool
+        let groupID: UUID
+        let repaidAmount: Decimal
+    }
+
     @MainActor
-    static func preview(_ draft: AdvanceCaseEditDraft, modelContext: ModelContext) throws -> AdvanceCaseImpactPreview {
-        try validate(draft)
-        let transactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
-        let affected = transactions.filter { $0.advanceCaseID == draft.advanceCase.id }
+    static func preview(
+        _ draft: AdvanceCaseEditDraft,
+        modelContext: ModelContext
+    ) throws -> AdvanceCaseImpactPreview {
+        try validate(draft, modelContext: modelContext)
+        let transactions = try linkedTransactions(for: draft.advanceCase, modelContext: modelContext)
+        let retainedParticipantIDs = Set(draft.participants.compactMap { $0.participant?.id })
+        let retainedRepaymentIDs = Set(draft.repayments.map(\.repayment.id))
+        let removedParticipants = draft.advanceCase.participants.filter {
+            !retainedParticipantIDs.contains($0.id)
+        }
+        let removedRepayments = draft.advanceCase.repayments.filter {
+            !retainedRepaymentIDs.contains($0.id)
+        }
+
         var warnings: [String] = []
         if draft.direction != draft.advanceCase.direction {
-            warnings.append("改變方向會重建案件的初始帳務分錄。")
+            warnings.append("改變方向會原子重建案件的初始分錄與普通還款分錄。")
         }
-        if draft.currencyCode != draft.advanceCase.currencyCode {
-            warnings.append("案件幣種改變後，舊金額不會自動換算。")
+        if normalizedCurrency(draft.currencyCode) != normalizedCurrency(draft.advanceCase.currencyCode) {
+            warnings.append("案件幣種改變後，所有沖銷金額均以輸入值為準，不會自動換算。")
         }
+        if !removedParticipants.isEmpty {
+            warnings.append("刪除參與人會一併刪除其普通還款及相關底層分錄。")
+        } else if !removedRepayments.isEmpty {
+            warnings.append("未保留的普通還款會連同底層分錄刪除。")
+        }
+
         return AdvanceCaseImpactPreview(
             changesDirection: draft.direction != draft.advanceCase.direction,
-            changesCurrency: draft.currencyCode != draft.advanceCase.currencyCode,
-            affectedTransactionCount: affected.count,
+            changesCurrency: normalizedCurrency(draft.currencyCode) != normalizedCurrency(draft.advanceCase.currencyCode),
+            affectedTransactionCount: transactions.count,
             affectedParticipantCount: draft.participants.count,
             affectedRepaymentCount: draft.repayments.count,
+            removedParticipantCount: removedParticipants.count,
+            removedRepaymentCount: removedRepayments.count,
             warnings: warnings
         )
     }
 
     @MainActor
-    static func apply(_ draft: AdvanceCaseEditDraft, modelContext: ModelContext) throws {
-        try validate(draft)
-        if draft.direction != draft.advanceCase.direction {
-            throw AdvanceCaseEditingError.unsupportedDirectionChange
+    static func apply(
+        _ draft: AdvanceCaseEditDraft,
+        modelContext: ModelContext
+    ) throws {
+        try validate(draft, modelContext: modelContext)
+
+        let existingTransactions = try linkedTransactions(
+            for: draft.advanceCase,
+            modelContext: modelContext
+        )
+        let existingByID = Dictionary(uniqueKeysWithValues: existingTransactions.map { ($0.id, $0) })
+        let preparedParticipants = try prepareParticipants(draft)
+        let participantByID = Dictionary(
+            uniqueKeysWithValues: preparedParticipants.map { ($0.participant.id, $0) }
+        )
+        let specs = try buildTransactionSpecs(
+            draft,
+            preparedParticipants: preparedParticipants,
+            existingTransactions: existingTransactions
+        )
+        guard Set(specs.map(\.id)).count == specs.count else {
+            throw AdvanceCaseEditingError.missingLinkedEntry
         }
 
-        let now = Date()
-        draft.advanceCase.title = draft.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        draft.advanceCase.date = draft.date
-        draft.advanceCase.direction = draft.direction
-        draft.advanceCase.currencyCode = draft.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        draft.advanceCase.note = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
-        draft.advanceCase.expenseCategory = draft.category
-        draft.advanceCase.tagIDs = draft.tags.map(\.id)
-        draft.advanceCase.updatedAt = now
+        do {
+            let now = Date()
+            let title = draft.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let note = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+            let currencyCode = normalizedCurrency(draft.currencyCode)
+            let desiredParticipantIDs = Set(preparedParticipants.map(\.participant.id))
+            let desiredRepaymentIDs = Set(draft.repayments.map(\.repayment.id))
 
-        for participantDraft in draft.participants {
-            if participantDraft.paymentLegs.count > 1 {
-                throw AdvanceCaseEditingError.unsupportedSplitPaymentEdit
+            for repayment in draft.advanceCase.repayments where !desiredRepaymentIDs.contains(repayment.id) {
+                modelContext.delete(repayment)
             }
-            let payment = participantDraft.paymentLegs.first
-            if draft.direction == .iAdvancedOthers, payment == nil {
-                throw AdvanceCaseEditingError.invalidPaymentLeg
+            for participant in draft.advanceCase.participants where !desiredParticipantIDs.contains(participant.id) {
+                modelContext.delete(participant)
             }
-            participantDraft.participant.name = participantDraft.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            participantDraft.participant.debtAccount = participantDraft.debtAccount
-            try AdvanceService.updateInitialEntry(
-                advanceCase: draft.advanceCase,
-                participant: participantDraft.participant,
-                draft: .init(
-                    payerAccount: draft.direction == .iAdvancedOthers ? payment?.account : nil,
-                    owedAmount: participantDraft.owedAmount,
-                    paymentAmount: payment?.amount,
-                    paymentCurrencyCode: payment?.currencyCode,
-                    date: draft.date,
-                    note: draft.note,
-                    category: draft.category,
-                    tags: draft.tags
-                ),
-                modelContext: modelContext
-            )
-        }
 
-        for repaymentDraft in draft.repayments {
-            try AdvanceService.updateRepayment(
-                advanceCase: draft.advanceCase,
-                repayment: repaymentDraft.repayment,
-                draft: .init(
-                    receiveAccount: repaymentDraft.account,
-                    amount: repaymentDraft.amount,
-                    currencyCode: repaymentDraft.currencyCode,
-                    normalizedAmount: repaymentDraft.normalizedAmount,
-                    date: repaymentDraft.date,
-                    note: repaymentDraft.note,
-                    category: repaymentDraft.category,
-                    tags: repaymentDraft.tags
-                ),
-                modelContext: modelContext
+            for prepared in preparedParticipants {
+                let participantDraft = prepared.draft
+                let participant = prepared.participant
+                if prepared.isNew {
+                    modelContext.insert(participant)
+                }
+                participant.name = participantDraft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                participant.owedAmount = abs(participantDraft.owedAmount)
+                participant.repaidAmount = prepared.repaidAmount
+                participant.initialTransferGroupID = prepared.groupID
+                participant.advanceCase = draft.advanceCase
+                participant.debtAccount = participantDraft.debtAccount
+                participant.updatedAt = now
+            }
+
+            for repaymentDraft in draft.repayments {
+                guard let prepared = participantByID[repaymentDraft.repayment.participant?.id ?? UUID()] else {
+                    throw AdvanceCaseEditingError.repaymentNotInCase
+                }
+                let repayment = repaymentDraft.repayment
+                repayment.amount = abs(repaymentDraft.amount)
+                repayment.currencyCode = normalizedCurrency(repaymentDraft.currencyCode)
+                repayment.normalizedAmount = abs(repaymentDraft.normalizedAmount)
+                repayment.date = repaymentDraft.date
+                repayment.note = repaymentDraft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+                repayment.linkedTransferGroupID = specs.first(where: {
+                    $0.advanceRepaymentID == repayment.id
+                })?.transferGroupID
+                repayment.advanceCase = draft.advanceCase
+                repayment.participant = prepared.participant
+                repayment.receivedAccount = repaymentDraft.account
+            }
+
+            let desiredTransactionIDs = Set(specs.map(\.id))
+            for transaction in existingTransactions where !desiredTransactionIDs.contains(transaction.id) {
+                modelContext.delete(transaction)
+            }
+            for spec in specs {
+                let transaction: FinancialTransaction
+                if let existing = existingByID[spec.id] {
+                    transaction = existing
+                } else {
+                    transaction = FinancialTransaction(
+                        id: spec.id,
+                        amount: spec.amount,
+                        currencyCode: spec.currencyCode,
+                        date: spec.date,
+                        note: spec.note,
+                        type: spec.type
+                    )
+                    modelContext.insert(transaction)
+                }
+                apply(spec, to: transaction, updatedAt: now)
+            }
+
+            let paymentAccounts = draft.participants.flatMap(\.paymentLegs).map(\.account)
+            let uniquePaymentAccountIDs = Set(paymentAccounts.map(\.id))
+            draft.advanceCase.title = title
+            draft.advanceCase.date = draft.date
+            draft.advanceCase.direction = draft.direction
+            draft.advanceCase.currencyCode = currencyCode
+            draft.advanceCase.myShareAmount = draft.share.map { abs($0.normalizedAmount) } ?? 0
+            draft.advanceCase.note = note
+            draft.advanceCase.selfExpenseTransactionID = draft.share?.transactionID
+                ?? specs.first(where: { $0.advanceEntryRole == .selfExpense })?.id
+            draft.advanceCase.payerAccount = draft.direction == .iAdvancedOthers &&
+                uniquePaymentAccountIDs.count == 1 ? paymentAccounts.first : nil
+            draft.advanceCase.expenseCategory = draft.category
+            draft.advanceCase.tagIDs = draft.tags.map(\.id)
+            draft.advanceCase.updatedAt = now
+
+            try BudgetHistoryService.shared.syncAll(
+                modelContext: modelContext,
+                currencyService: CurrencyService.shared
             )
+        } catch {
+            modelContext.rollback()
+            throw error
         }
-        try modelContext.save()
     }
 
-    private static func validate(_ draft: AdvanceCaseEditDraft) throws {
+    @MainActor
+    private static func validate(
+        _ draft: AdvanceCaseEditDraft,
+        modelContext: ModelContext
+    ) throws {
         guard !draft.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AdvanceCaseEditingError.emptyTitle
         }
-        guard !draft.currencyCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let currencyCode = normalizedCurrency(draft.currencyCode)
+        guard !currencyCode.isEmpty else {
             throw AdvanceCaseEditingError.invalidCurrency
         }
         guard !draft.participants.isEmpty else {
             throw AdvanceCaseEditingError.noParticipants
         }
-        let accountIDs = draft.participants.map(\.debtAccount.id)
-        guard Set(accountIDs).count == accountIDs.count else {
+        if let category = draft.category,
+           draft.direction == .othersAdvancedMe,
+           !category.kind.supports(.expense) {
+            throw AdvanceServiceError.invalidSettlementCategory
+        }
+
+        let existingParticipantIDs = Set(draft.advanceCase.participants.map(\.id))
+        let participantIDs = draft.participants.compactMap { $0.participant?.id }
+        guard participantIDs.allSatisfy(existingParticipantIDs.contains) else {
+            throw AdvanceCaseEditingError.participantNotInCase
+        }
+        guard Set(participantIDs).count == participantIDs.count else {
             throw AdvanceCaseEditingError.duplicateParticipant
         }
-        for participant in draft.participants {
-            guard participant.owedAmount > 0,
-                  participant.owedAmount >= participant.participant.repaidAmount
+        let debtAccountIDs = draft.participants.map(\.debtAccount.id)
+        guard Set(debtAccountIDs).count == debtAccountIDs.count else {
+            throw AdvanceCaseEditingError.duplicateParticipant
+        }
+
+        let repaymentIDs = draft.repayments.map(\.repayment.id)
+        guard Set(repaymentIDs).count == repaymentIDs.count else {
+            throw AdvanceCaseEditingError.duplicateRepayment
+        }
+        let existingRepaymentIDs = Set(draft.advanceCase.repayments.map(\.id))
+        guard repaymentIDs.allSatisfy(existingRepaymentIDs.contains) else {
+            throw AdvanceCaseEditingError.repaymentNotInCase
+        }
+
+        let requestedTransactionIDs = [
+            draft.share?.transactionID
+        ].compactMap { $0 } + draft.participants.flatMap(\.paymentLegs).compactMap(\.transactionID)
+        guard Set(requestedTransactionIDs).count == requestedTransactionIDs.count else {
+            throw AdvanceCaseEditingError.missingLinkedEntry
+        }
+        let caseID = draft.advanceCase.id
+        let selfExpenseID = draft.advanceCase.selfExpenseTransactionID
+        let conflictingTransaction = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+            .contains {
+                requestedTransactionIDs.contains($0.id) &&
+                    $0.advanceCaseID != caseID &&
+                    $0.id != selfExpenseID
+            }
+        guard !conflictingTransaction else {
+            throw AdvanceCaseEditingError.transactionNotInCase
+        }
+
+        let retainedParticipantIDs = Set(participantIDs)
+        for repaymentDraft in draft.repayments {
+            guard let participant = repaymentDraft.repayment.participant,
+                  retainedParticipantIDs.contains(participant.id),
+                  repaymentDraft.repayment.advanceCase?.id == draft.advanceCase.id
             else {
+                throw AdvanceCaseEditingError.repaymentNotInCase
+            }
+            guard AdvanceService.repaymentRecordKind(note: repaymentDraft.repayment.note) == .ordinary else {
+                throw AdvanceCaseEditingError.specialRepaymentRequiresGroupRollback
+            }
+            guard repaymentDraft.amount > 0,
+                  repaymentDraft.normalizedAmount > 0,
+                  !normalizedCurrency(repaymentDraft.currencyCode).isEmpty,
+                  repaymentDraft.account.type != .debt,
+                  !repaymentDraft.account.isArchived
+            else {
+                throw AdvanceServiceError.invalidRepaymentAmount
+            }
+            if let category = repaymentDraft.category {
+                let expectedType: TransactionType = draft.direction == .iAdvancedOthers ? .income : .expense
+                guard category.kind.supports(expectedType) else {
+                    throw AdvanceServiceError.invalidSettlementCategory
+                }
+            }
+        }
+
+        let omittedSpecialRepayments = draft.advanceCase.repayments.filter {
+            !repaymentIDs.contains($0.id) &&
+                AdvanceService.repaymentRecordKind(note: $0.note) != .ordinary
+        }
+        guard omittedSpecialRepayments.isEmpty else {
+            throw AdvanceCaseEditingError.specialRepaymentRequiresGroupRollback
+        }
+
+        let normalizedByParticipant = Dictionary(
+            grouping: draft.repayments,
+            by: { $0.repayment.participant?.id }
+        ).mapValues { repayments in
+            repayments.reduce(Decimal.zero) { $0 + abs($1.normalizedAmount) }
+        }
+
+        for participant in draft.participants {
+            guard participant.debtAccount.type == .debt,
+                  !participant.debtAccount.isArchived
+            else {
+                throw AdvanceCaseEditingError.invalidDebtAccount
+            }
+            guard participant.owedAmount > 0 else {
+                throw AdvanceServiceError.invalidAdjustedOwedAmount
+            }
+            let settled = normalizedByParticipant[participant.participant?.id] ?? 0
+            guard participant.owedAmount >= settled else {
                 throw AdvanceServiceError.adjustedOwedLowerThanRepaid
             }
-            guard draft.direction == .othersAdvancedMe || (
-                !participant.paymentLegs.isEmpty && participant.paymentLegs.allSatisfy({
-                $0.account.type != .debt &&
-                    !$0.account.isArchived &&
-                    $0.amount > 0 &&
-                    !$0.currencyCode.isEmpty
-                })
-            ) else {
+            if draft.direction == .iAdvancedOthers {
+                guard !participant.paymentLegs.isEmpty,
+                      participant.paymentLegs.allSatisfy({
+                          $0.account.type != .debt &&
+                              !$0.account.isArchived &&
+                              $0.amount > 0 &&
+                              !normalizedCurrency($0.currencyCode).isEmpty
+                      })
+                else {
+                    throw AdvanceCaseEditingError.invalidPaymentLeg
+                }
+            } else if !participant.paymentLegs.isEmpty {
                 throw AdvanceCaseEditingError.invalidPaymentLeg
             }
         }
-        if draft.currencyCode != draft.advanceCase.currencyCode,
-           draft.repayments.contains(where: { $0.normalizedAmount <= 0 }) {
-            throw AdvanceCaseEditingError.currencyChangeRequiresExplicitAmounts
+
+        if let share = draft.share {
+            guard draft.direction == .iAdvancedOthers,
+                  share.account.type != .debt,
+                  !share.account.isArchived,
+                  share.amount > 0,
+                  share.normalizedAmount > 0,
+                  !normalizedCurrency(share.currencyCode).isEmpty
+            else {
+                throw AdvanceCaseEditingError.invalidShare
+            }
         }
+
+        if normalizedCurrency(draft.advanceCase.currencyCode) != currencyCode {
+            guard draft.participants.allSatisfy({ $0.owedAmount > 0 }),
+                  draft.repayments.allSatisfy({ $0.normalizedAmount > 0 }),
+                  draft.share == nil || draft.share!.normalizedAmount > 0
+            else {
+                throw AdvanceCaseEditingError.currencyChangeRequiresExplicitAmounts
+            }
+        }
+    }
+
+    @MainActor
+    private static func prepareParticipants(
+        _ draft: AdvanceCaseEditDraft
+    ) throws -> [PreparedParticipant] {
+        let normalizedByParticipant = Dictionary(
+            grouping: draft.repayments,
+            by: { $0.repayment.participant?.id }
+        ).mapValues { repayments in
+            repayments.reduce(Decimal.zero) { $0 + abs($1.normalizedAmount) }
+        }
+        return draft.participants.map { participantDraft in
+            let participant = participantDraft.participant ?? AdvanceParticipant(
+                name: participantDraft.name,
+                owedAmount: abs(participantDraft.owedAmount),
+                advanceCase: draft.advanceCase,
+                debtAccount: participantDraft.debtAccount
+            )
+            return PreparedParticipant(
+                draft: participantDraft,
+                participant: participant,
+                isNew: participantDraft.participant == nil,
+                groupID: participant.initialTransferGroupID ?? UUID(),
+                repaidAmount: normalizedByParticipant[participant.id] ?? 0
+            )
+        }
+    }
+
+    @MainActor
+    private static func buildTransactionSpecs(
+        _ draft: AdvanceCaseEditDraft,
+        preparedParticipants: [PreparedParticipant],
+        existingTransactions: [FinancialTransaction]
+    ) throws -> [TransactionSpec] {
+        let title = draft.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let note = draft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let memo = note.isEmpty ? title : note
+        let currencyCode = normalizedCurrency(draft.currencyCode)
+        var specs: [TransactionSpec] = []
+
+        if let share = draft.share {
+            let transactionID = share.transactionID
+                ?? draft.advanceCase.selfExpenseTransactionID
+                ?? UUID()
+            specs.append(
+                TransactionSpec(
+                    id: transactionID,
+                    amount: -abs(share.amount),
+                    currencyCode: normalizedCurrency(share.currencyCode),
+                    date: draft.date,
+                    note: "\(memo) (自己份額)",
+                    type: .expense,
+                    linkedTransactionID: nil,
+                    transferGroupID: nil,
+                    transferSide: nil,
+                    advanceCaseID: draft.advanceCase.id,
+                    advanceParticipantID: nil,
+                    advanceRepaymentID: nil,
+                    advanceEntryRole: .selfExpense,
+                    account: share.account,
+                    category: draft.category,
+                    tags: draft.tags
+                )
+            )
+        }
+
+        for prepared in preparedParticipants {
+            let participant = prepared.participant
+            let participantDraft = prepared.draft
+            let existingGroup = existingTransactions.filter {
+                $0.transferGroupID == prepared.groupID &&
+                    $0.advanceRepaymentID == nil
+            }
+            let existingDebtID = existingGroup.first(where: {
+                $0.advanceEntryRole == .initialDebt ||
+                    $0.account?.id == participant.debtAccount?.id
+            })?.id
+
+            if draft.direction == .othersAdvancedMe {
+                specs.append(
+                    TransactionSpec(
+                        id: existingDebtID ?? UUID(),
+                        amount: -abs(participantDraft.owedAmount),
+                        currencyCode: currencyCode,
+                        date: draft.date,
+                        note: "\(memo) (他人代墊我：\(participantDraft.name))",
+                        type: .expense,
+                        linkedTransactionID: nil,
+                        transferGroupID: prepared.groupID,
+                        transferSide: .outgoing,
+                        advanceCaseID: draft.advanceCase.id,
+                        advanceParticipantID: participant.id,
+                        advanceRepaymentID: nil,
+                        advanceEntryRole: .initialDebt,
+                        account: participantDraft.debtAccount,
+                        category: draft.category,
+                        tags: draft.tags
+                    )
+                )
+                continue
+            }
+
+            let debtID = existingDebtID ?? UUID()
+            let assetIDs = participantDraft.paymentLegs.map { leg in
+                leg.transactionID ?? UUID()
+            }
+            for (leg, assetID) in zip(participantDraft.paymentLegs, assetIDs) {
+                specs.append(
+                    TransactionSpec(
+                        id: assetID,
+                        amount: -abs(leg.amount),
+                        currencyCode: normalizedCurrency(leg.currencyCode),
+                        date: draft.date,
+                        note: "\(memo) (代墊給 \(participantDraft.name))",
+                        type: .transfer,
+                        linkedTransactionID: debtID,
+                        transferGroupID: prepared.groupID,
+                        transferSide: .outgoing,
+                        advanceCaseID: draft.advanceCase.id,
+                        advanceParticipantID: participant.id,
+                        advanceRepaymentID: nil,
+                        advanceEntryRole: .initialAsset,
+                        account: leg.account,
+                        category: nil,
+                        tags: []
+                    )
+                )
+            }
+            specs.append(
+                TransactionSpec(
+                    id: debtID,
+                    amount: abs(participantDraft.owedAmount),
+                    currencyCode: currencyCode,
+                    date: draft.date,
+                    note: "\(memo) (來自多付款來源)",
+                    type: .transfer,
+                    linkedTransactionID: assetIDs.count == 1 ? assetIDs.first : nil,
+                    transferGroupID: prepared.groupID,
+                    transferSide: .incoming,
+                    advanceCaseID: draft.advanceCase.id,
+                    advanceParticipantID: participant.id,
+                    advanceRepaymentID: nil,
+                    advanceEntryRole: .initialDebt,
+                    account: participantDraft.debtAccount,
+                    category: nil,
+                    tags: []
+                )
+            )
+        }
+
+        for repaymentDraft in draft.repayments {
+            let repayment = repaymentDraft.repayment
+            guard let participant = repayment.participant,
+                  let debtAccount = preparedParticipants.first(where: {
+                      $0.participant.id == participant.id
+                  })?.draft.debtAccount
+            else {
+                throw AdvanceCaseEditingError.repaymentNotInCase
+            }
+            let groupID = repayment.linkedTransferGroupID ?? UUID()
+            let existingGroup = existingTransactions.filter { $0.transferGroupID == groupID }
+            let debtID = existingGroup.first(where: {
+                $0.advanceEntryRole == .repaymentDebt
+            })?.id ?? UUID()
+            let assetID = existingGroup.first(where: {
+                $0.advanceEntryRole == .repaymentAsset
+            })?.id ?? UUID()
+            let amount = abs(repaymentDraft.amount)
+            let repaymentCurrency = normalizedCurrency(repaymentDraft.currencyCode)
+            let repaymentNote = repaymentDraft.note.trimmingCharacters(in: .whitespacesAndNewlines)
+            let repaymentMemo = repaymentNote.isEmpty ? title : repaymentNote
+
+            if draft.direction == .iAdvancedOthers {
+                specs.append(
+                    TransactionSpec(
+                        id: debtID,
+                        amount: -amount,
+                        currencyCode: repaymentCurrency,
+                        date: repaymentDraft.date,
+                        note: "\(repaymentMemo) (還款至 \(repaymentDraft.account.name))",
+                        type: .transfer,
+                        linkedTransactionID: assetID,
+                        transferGroupID: groupID,
+                        transferSide: .outgoing,
+                        advanceCaseID: draft.advanceCase.id,
+                        advanceParticipantID: participant.id,
+                        advanceRepaymentID: repayment.id,
+                        advanceEntryRole: .repaymentDebt,
+                        account: debtAccount,
+                        category: nil,
+                        tags: []
+                    )
+                )
+                specs.append(
+                    TransactionSpec(
+                        id: assetID,
+                        amount: amount,
+                        currencyCode: repaymentCurrency,
+                        date: repaymentDraft.date,
+                        note: "\(repaymentMemo) (來自 \(participant.name))",
+                        type: .transfer,
+                        linkedTransactionID: debtID,
+                        transferGroupID: groupID,
+                        transferSide: .incoming,
+                        advanceCaseID: draft.advanceCase.id,
+                        advanceParticipantID: participant.id,
+                        advanceRepaymentID: repayment.id,
+                        advanceEntryRole: .repaymentAsset,
+                        account: repaymentDraft.account,
+                        category: repaymentDraft.category,
+                        tags: repaymentDraft.tags
+                    )
+                )
+            } else {
+                specs.append(
+                    TransactionSpec(
+                        id: assetID,
+                        amount: -amount,
+                        currencyCode: repaymentCurrency,
+                        date: repaymentDraft.date,
+                        note: "\(repaymentMemo) (還款給 \(participant.name))",
+                        type: .transfer,
+                        linkedTransactionID: debtID,
+                        transferGroupID: groupID,
+                        transferSide: .outgoing,
+                        advanceCaseID: draft.advanceCase.id,
+                        advanceParticipantID: participant.id,
+                        advanceRepaymentID: repayment.id,
+                        advanceEntryRole: .repaymentAsset,
+                        account: repaymentDraft.account,
+                        category: repaymentDraft.category,
+                        tags: repaymentDraft.tags
+                    )
+                )
+                specs.append(
+                    TransactionSpec(
+                        id: debtID,
+                        amount: amount,
+                        currencyCode: repaymentCurrency,
+                        date: repaymentDraft.date,
+                        note: "\(repaymentMemo) (來自 \(repaymentDraft.account.name))",
+                        type: .transfer,
+                        linkedTransactionID: assetID,
+                        transferGroupID: groupID,
+                        transferSide: .incoming,
+                        advanceCaseID: draft.advanceCase.id,
+                        advanceParticipantID: participant.id,
+                        advanceRepaymentID: repayment.id,
+                        advanceEntryRole: .repaymentDebt,
+                        account: debtAccount,
+                        category: nil,
+                        tags: []
+                    )
+                )
+            }
+        }
+        return specs
+    }
+
+    @MainActor
+    private static func linkedTransactions(
+        for advanceCase: AdvanceCase,
+        modelContext: ModelContext
+    ) throws -> [FinancialTransaction] {
+        let caseID = advanceCase.id
+        let allTransactions = try modelContext.fetch(FetchDescriptor<FinancialTransaction>())
+        let groupIDs = Set(
+            advanceCase.participants.compactMap(\.initialTransferGroupID) +
+                advanceCase.repayments.compactMap(\.linkedTransferGroupID)
+        )
+        return allTransactions.filter {
+            $0.advanceCaseID == caseID ||
+                $0.transferGroupID.map(groupIDs.contains) == true ||
+                $0.id == advanceCase.selfExpenseTransactionID
+        }
+    }
+
+    private static func apply(
+        _ spec: TransactionSpec,
+        to transaction: FinancialTransaction,
+        updatedAt: Date
+    ) {
+        transaction.amount = spec.amount
+        transaction.currencyCode = spec.currencyCode
+        transaction.date = spec.date
+        transaction.note = spec.note
+        transaction.photoPath = nil
+        transaction.type = spec.type
+        transaction.linkedTransactionID = spec.linkedTransactionID
+        transaction.transferGroupID = spec.transferGroupID
+        transaction.transferSide = spec.transferSide
+        transaction.advanceCaseID = spec.advanceCaseID
+        transaction.advanceParticipantID = spec.advanceParticipantID
+        transaction.advanceRepaymentID = spec.advanceRepaymentID
+        transaction.advanceEntryRole = spec.advanceEntryRole
+        transaction.account = spec.account
+        transaction.category = spec.category
+        transaction.tags = spec.tags
+        transaction.updatedAt = updatedAt
+    }
+
+    private static func normalizedCurrency(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
     }
 }

--- a/AI 記帳Tests/AdvanceEditingTests.swift
+++ b/AI 記帳Tests/AdvanceEditingTests.swift
@@ -544,11 +544,18 @@ final class AdvanceEditingTests: XCTestCase {
         )
     }
 
-    func testCaseEditingRejectsDirectionChangeBeforeMutatingCase() throws {
+    func testCaseEditingRebuildsDirectionAndRepaymentEntries() throws {
         let context = try makeContext()
         let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
         let friend = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        let expenseCategory = Category(
+            name: "Dining",
+            icon: "fork.knife",
+            colorHex: "#123456",
+            kind: .expense
+        )
         [wallet, friend].forEach(context.insert)
+        context.insert(expenseCategory)
 
         let advanceCase = try AdvanceService.createAdvanceCase(
             title: "Dinner",
@@ -563,6 +570,20 @@ final class AdvanceEditingTests: XCTestCase {
             modelContext: context
         )
         let participant = try XCTUnwrap(advanceCase.participants.first)
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 40,
+            currencyCode: "HKD",
+            date: Date(timeIntervalSince1970: 20),
+            note: "Paid",
+            receiveAccount: wallet,
+            category: nil,
+            tags: [],
+            currencyService: .shared,
+            normalizedAmountOverride: 40,
+            modelContext: context
+        )
         let draft = AdvanceCaseEditDraft(
             advanceCase: advanceCase,
             title: "Changed",
@@ -570,7 +591,7 @@ final class AdvanceEditingTests: XCTestCase {
             direction: .othersAdvancedMe,
             currencyCode: advanceCase.currencyCode,
             note: advanceCase.note,
-            category: nil,
+            category: expenseCategory,
             tags: [],
             share: nil,
             participants: [
@@ -582,19 +603,326 @@ final class AdvanceEditingTests: XCTestCase {
                     paymentLegs: []
                 )
             ],
+            repayments: [
+                AdvanceRepaymentDraft(
+                    repayment: repayment,
+                    account: wallet,
+                    amount: 40,
+                    currencyCode: "HKD",
+                    normalizedAmount: 40,
+                    date: repayment.date,
+                    note: repayment.note,
+                    category: expenseCategory,
+                    tags: []
+                )
+            ]
+        )
+
+        let preview = try AdvanceCaseEditingService.preview(draft, modelContext: context)
+        XCTAssertTrue(preview.changesDirection)
+        try AdvanceCaseEditingService.apply(draft, modelContext: context)
+
+        XCTAssertEqual("Changed", advanceCase.title)
+        XCTAssertEqual(.othersAdvancedMe, advanceCase.direction)
+        XCTAssertNil(advanceCase.payerAccount)
+        let initialGroup = try fetchGroup(
+            try XCTUnwrap(participant.initialTransferGroupID),
+            context: context
+        )
+        let initialExpense = try XCTUnwrap(initialGroup.first)
+        XCTAssertEqual(1, initialGroup.count)
+        XCTAssertEqual(.expense, initialExpense.type)
+        XCTAssertEqual(friend.id, initialExpense.account?.id)
+        XCTAssertEqual(.initialDebt, initialExpense.advanceEntryRole)
+        XCTAssertEqual(advanceCase.id, initialExpense.advanceCaseID)
+        XCTAssertEqual(participant.id, initialExpense.advanceParticipantID)
+
+        let repaymentGroup = try fetchGroup(
+            try XCTUnwrap(repayment.linkedTransferGroupID),
+            context: context
+        )
+        let outgoing = try XCTUnwrap(
+            repaymentGroup.first { $0.transferSide == .outgoing }
+        )
+        let incoming = try XCTUnwrap(
+            repaymentGroup.first { $0.transferSide == .incoming }
+        )
+        XCTAssertEqual(wallet.id, outgoing.account?.id)
+        XCTAssertEqual(.repaymentAsset, outgoing.advanceEntryRole)
+        XCTAssertEqual(friend.id, incoming.account?.id)
+        XCTAssertEqual(.repaymentDebt, incoming.advanceEntryRole)
+        XCTAssertTrue(repaymentGroup.allSatisfy { $0.advanceRepaymentID == repayment.id })
+    }
+
+    func testCaseEditingSupportsSplitPaymentLegsAndNewParticipant() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let card = Account(name: "Card", currency: "USD", type: .creditCard, baseBalance: 0)
+        let friendA = Account(name: "Friend A", currency: "JPY", type: .debt, baseBalance: 0)
+        let friendB = Account(name: "Friend B", currency: "JPY", type: .debt, baseBalance: 0)
+        [wallet, card, friendA, friendB].forEach(context.insert)
+
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Japan",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friendA, owedAmount: 1_000)],
+            modelContext: context
+        )
+        let participantA = try XCTUnwrap(advanceCase.participants.first)
+        let originalGroup = try fetchGroup(
+            try XCTUnwrap(participantA.initialTransferGroupID),
+            context: context
+        )
+        let originalAsset = try XCTUnwrap(
+            originalGroup.first { $0.advanceEntryRole == .initialAsset }
+        )
+
+        let draft = AdvanceCaseEditDraft(
+            advanceCase: advanceCase,
+            title: advanceCase.title,
+            date: advanceCase.date,
+            direction: .iAdvancedOthers,
+            currencyCode: "JPY",
+            note: "",
+            category: nil,
+            tags: [],
+            share: nil,
+            participants: [
+                AdvanceParticipantDraft(
+                    participant: participantA,
+                    name: "Friend A",
+                    debtAccount: friendA,
+                    owedAmount: 1_200,
+                    paymentLegs: [
+                        AdvancePaymentLegDraft(
+                            transactionID: originalAsset.id,
+                            account: wallet,
+                            amount: 500,
+                            currencyCode: "HKD"
+                        ),
+                        AdvancePaymentLegDraft(
+                            transactionID: nil,
+                            account: card,
+                            amount: 30,
+                            currencyCode: "USD"
+                        ),
+                    ]
+                ),
+                AdvanceParticipantDraft(
+                    name: "Friend B",
+                    debtAccount: friendB,
+                    owedAmount: 800,
+                    paymentLegs: [
+                        AdvancePaymentLegDraft(
+                            transactionID: nil,
+                            account: card,
+                            amount: 40,
+                            currencyCode: "USD"
+                        )
+                    ]
+                ),
+            ],
             repayments: []
         )
 
+        try AdvanceCaseEditingService.apply(draft, modelContext: context)
+
+        XCTAssertEqual(2, advanceCase.participants.count)
+        XCTAssertNil(advanceCase.payerAccount)
+        let updatedA = try XCTUnwrap(
+            advanceCase.participants.first { $0.debtAccount?.id == friendA.id }
+        )
+        let groupA = try fetchGroup(
+            try XCTUnwrap(updatedA.initialTransferGroupID),
+            context: context
+        )
+        XCTAssertEqual(3, groupA.count)
+        XCTAssertEqual(2, groupA.filter { $0.advanceEntryRole == .initialAsset }.count)
+        XCTAssertEqual(
+            Set(["HKD", "USD"]),
+            Set(groupA.filter { $0.advanceEntryRole == .initialAsset }.map(\.currencyCode))
+        )
+        XCTAssertTrue(groupA.allSatisfy {
+            $0.advanceCaseID == advanceCase.id &&
+                $0.advanceParticipantID == updatedA.id
+        })
+    }
+
+    func testCurrencyChangeUsesExplicitAmountsAndRejectsAmountBelowSettled() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "HKD", type: .debt, baseBalance: 0)
+        [wallet, friend].forEach(context.insert)
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Dinner",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 100)],
+            modelContext: context
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participant,
+            amount: 40,
+            currencyCode: "HKD",
+            date: Date(timeIntervalSince1970: 20),
+            note: "",
+            receiveAccount: wallet,
+            category: nil,
+            tags: [],
+            currencyService: .shared,
+            normalizedAmountOverride: 40,
+            modelContext: context
+        )
+        let originalGroupID = participant.initialTransferGroupID
+
+        let invalidDraft = AdvanceCaseEditDraft(
+            advanceCase: advanceCase,
+            title: advanceCase.title,
+            date: advanceCase.date,
+            direction: .iAdvancedOthers,
+            currencyCode: "JPY",
+            note: "",
+            category: nil,
+            tags: [],
+            share: nil,
+            participants: [
+                AdvanceParticipantDraft(
+                    participant: participant,
+                    name: participant.name,
+                    debtAccount: friend,
+                    owedAmount: 499,
+                    paymentLegs: [
+                        AdvancePaymentLegDraft(
+                            transactionID: nil,
+                            account: wallet,
+                            amount: 25,
+                            currencyCode: "HKD"
+                        )
+                    ]
+                )
+            ],
+            repayments: [
+                AdvanceRepaymentDraft(
+                    repayment: repayment,
+                    account: wallet,
+                    amount: 40,
+                    currencyCode: "HKD",
+                    normalizedAmount: 500,
+                    date: repayment.date,
+                    note: "",
+                    category: nil,
+                    tags: []
+                )
+            ]
+        )
+
         XCTAssertThrowsError(
-            try AdvanceCaseEditingService.apply(draft, modelContext: context)
-        ) { error in
-            XCTAssertEqual(
-                AdvanceCaseEditingError.unsupportedDirectionChange.localizedDescription,
-                error.localizedDescription
-            )
+            try AdvanceCaseEditingService.apply(invalidDraft, modelContext: context)
+        )
+        XCTAssertEqual("HKD", advanceCase.currencyCode)
+        XCTAssertEqual(Decimal(100), participant.owedAmount)
+        XCTAssertEqual(Decimal(40), participant.repaidAmount)
+        XCTAssertEqual(originalGroupID, participant.initialTransferGroupID)
+    }
+
+    func testRemovingParticipantDeletesOrdinaryRepaymentAndInitialEntries() throws {
+        let context = try makeContext()
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let friendA = Account(name: "Friend A", currency: "HKD", type: .debt, baseBalance: 0)
+        let friendB = Account(name: "Friend B", currency: "HKD", type: .debt, baseBalance: 0)
+        [wallet, friendA, friendB].forEach(context.insert)
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Dinner",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "HKD",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [
+                .init(debtAccount: friendA, owedAmount: 100),
+                .init(debtAccount: friendB, owedAmount: 200),
+            ],
+            modelContext: context
+        )
+        let participantA = try XCTUnwrap(
+            advanceCase.participants.first { $0.debtAccount?.id == friendA.id }
+        )
+        let participantB = try XCTUnwrap(
+            advanceCase.participants.first { $0.debtAccount?.id == friendB.id }
+        )
+        let repayment = try AdvanceService.recordRepayment(
+            advanceCase: advanceCase,
+            participant: participantB,
+            amount: 50,
+            currencyCode: "HKD",
+            date: Date(timeIntervalSince1970: 20),
+            note: "",
+            receiveAccount: wallet,
+            category: nil,
+            tags: [],
+            currencyService: .shared,
+            normalizedAmountOverride: 50,
+            modelContext: context
+        )
+        let removedGroupIDs = [
+            try XCTUnwrap(participantB.initialTransferGroupID),
+            try XCTUnwrap(repayment.linkedTransferGroupID),
+        ]
+
+        let draft = AdvanceCaseEditDraft(
+            advanceCase: advanceCase,
+            title: advanceCase.title,
+            date: advanceCase.date,
+            direction: .iAdvancedOthers,
+            currencyCode: advanceCase.currencyCode,
+            note: "",
+            category: nil,
+            tags: [],
+            share: nil,
+            participants: [
+                AdvanceParticipantDraft(
+                    participant: participantA,
+                    name: participantA.name,
+                    debtAccount: friendA,
+                    owedAmount: participantA.owedAmount,
+                    paymentLegs: [
+                        AdvancePaymentLegDraft(
+                            transactionID: nil,
+                            account: wallet,
+                            amount: 100,
+                            currencyCode: "HKD"
+                        )
+                    ]
+                )
+            ],
+            repayments: []
+        )
+
+        let preview = try AdvanceCaseEditingService.preview(draft, modelContext: context)
+        XCTAssertEqual(1, preview.removedParticipantCount)
+        XCTAssertEqual(1, preview.removedRepaymentCount)
+        try AdvanceCaseEditingService.apply(draft, modelContext: context)
+
+        XCTAssertEqual([participantA.id], advanceCase.participants.map(\.id))
+        XCTAssertTrue(advanceCase.repayments.isEmpty)
+        for groupID in removedGroupIDs {
+            XCTAssertTrue(try fetchGroup(groupID, context: context).isEmpty)
         }
-        XCTAssertEqual("Dinner", advanceCase.title)
-        XCTAssertEqual(.iAdvancedOthers, advanceCase.direction)
     }
 
     private func makeContext() throws -> ModelContext {

--- a/AI 記帳Tests/BackupCompatibilityTests.swift
+++ b/AI 記帳Tests/BackupCompatibilityTests.swift
@@ -690,6 +690,89 @@ final class BackupCompatibilityTests: XCTestCase {
         XCTAssertEqual(Decimal(100), exportedRepayment.normalizedAmount)
     }
 
+    func testSplitAdvancePaymentLegs_roundTripExplicitLinks() async throws {
+        let container = try makeInMemoryContainer()
+        let modelContext = ModelContext(container)
+        let wallet = Account(name: "Wallet", currency: "HKD", type: .cash, baseBalance: 0)
+        let card = Account(name: "Card", currency: "USD", type: .creditCard, baseBalance: 0)
+        let friend = Account(name: "Friend", currency: "JPY", type: .debt, baseBalance: 0)
+        [wallet, card, friend].forEach(modelContext.insert)
+        let advanceCase = try AdvanceService.createAdvanceCase(
+            title: "Japan",
+            date: Date(timeIntervalSince1970: 10),
+            currencyCode: "JPY",
+            myShareAmount: 0,
+            note: "",
+            payerAccount: wallet,
+            category: nil,
+            tags: [],
+            participants: [.init(debtAccount: friend, owedAmount: 1_000)],
+            modelContext: modelContext
+        )
+        let participant = try XCTUnwrap(advanceCase.participants.first)
+        try AdvanceCaseEditingService.apply(
+            AdvanceCaseEditDraft(
+                advanceCase: advanceCase,
+                title: advanceCase.title,
+                date: advanceCase.date,
+                direction: .iAdvancedOthers,
+                currencyCode: advanceCase.currencyCode,
+                note: "",
+                category: nil,
+                tags: [],
+                share: nil,
+                participants: [
+                    AdvanceParticipantDraft(
+                        participant: participant,
+                        name: participant.name,
+                        debtAccount: friend,
+                        owedAmount: 1_000,
+                        paymentLegs: [
+                            AdvancePaymentLegDraft(
+                                transactionID: nil,
+                                account: wallet,
+                                amount: 500,
+                                currencyCode: "HKD"
+                            ),
+                            AdvancePaymentLegDraft(
+                                transactionID: nil,
+                                account: card,
+                                amount: 30,
+                                currencyCode: "USD"
+                            ),
+                        ]
+                    )
+                ],
+                repayments: []
+            ),
+            modelContext: modelContext
+        )
+
+        let exported = BackupManager.shared.createBackupData(modelContext: modelContext)
+        let linked = exported.transactions.filter {
+            $0.advanceCaseID == advanceCase.id &&
+                $0.advanceParticipantID == participant.id
+        }
+        XCTAssertEqual(3, linked.count)
+        XCTAssertEqual(2, linked.filter { $0.advanceEntryRole == "InitialAsset" }.count)
+
+        let secondContainer = try makeInMemoryContainer()
+        let secondContext = ModelContext(secondContainer)
+        let url = try writeBackup(exported, named: "split-advance-roundtrip.json")
+        try await BackupManager.shared.restoreFromJSON(url: url, modelContext: secondContext)
+        let restored = try secondContext.fetch(FetchDescriptor<FinancialTransaction>())
+            .filter {
+                $0.advanceCaseID == advanceCase.id &&
+                    $0.advanceParticipantID == participant.id
+            }
+        XCTAssertEqual(3, restored.count)
+        XCTAssertEqual(2, restored.filter { $0.advanceEntryRole == .initialAsset }.count)
+        XCTAssertEqual(
+            Set(["HKD", "USD"]),
+            Set(restored.filter { $0.advanceEntryRole == .initialAsset }.map(\.currencyCode))
+        )
+    }
+
     func testCrossCurrencyAdvanceRepayment_semanticDebtBalanceUsesCaseCurrencyRemainingOnly() throws {
         let container = try makeInMemoryContainer()
         let modelContext = ModelContext(container)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/data/repository/AccountingRepository.kt
@@ -174,6 +174,66 @@ data class AdvanceInitialMetadataEditDraft(
     val tagIds: List<UUID>
 )
 
+data class AdvancePaymentLegStructuralDraft(
+    val transactionId: UUID? = null,
+    val accountId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String
+)
+
+data class AdvanceShareStructuralDraft(
+    val transactionId: UUID? = null,
+    val accountId: UUID,
+    val amount: BigDecimal,
+    val normalizedAmount: BigDecimal,
+    val currencyCode: String
+)
+
+data class AdvanceParticipantStructuralDraft(
+    val participantId: UUID? = null,
+    val name: String,
+    val debtAccountId: UUID,
+    val owedAmount: BigDecimal,
+    val paymentLegs: List<AdvancePaymentLegStructuralDraft>
+)
+
+data class AdvanceRepaymentStructuralDraft(
+    val repaymentId: UUID,
+    val receiveAccountId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val normalizedAmount: BigDecimal,
+    val date: Instant,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>
+)
+
+data class AdvanceCaseStructuralEditDraft(
+    val caseId: UUID,
+    val title: String,
+    val date: Instant,
+    val direction: AdvanceSettlementDirection,
+    val currencyCode: String,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>,
+    val share: AdvanceShareStructuralDraft?,
+    val participants: List<AdvanceParticipantStructuralDraft>,
+    val repayments: List<AdvanceRepaymentStructuralDraft>
+)
+
+data class AdvanceCaseStructuralImpact(
+    val changesDirection: Boolean,
+    val changesCurrency: Boolean,
+    val affectedTransactionCount: Int,
+    val affectedParticipantCount: Int,
+    val affectedRepaymentCount: Int,
+    val removedParticipantCount: Int,
+    val removedRepaymentCount: Int,
+    val warnings: List<String>
+)
+
 data class LegacyBorrowedAdvanceRepairResult(
     val repairedParticipantCount: Int,
     val removedInflatedAccountTransactionCount: Int
@@ -2271,6 +2331,550 @@ class AccountingRepository(
                 )
             }
             syncAllBudgetHistory()
+        }
+    }
+
+    suspend fun previewAdvanceCaseStructuralEdit(
+        draft: AdvanceCaseStructuralEditDraft
+    ): AdvanceCaseStructuralImpact {
+        return database.withTransaction {
+            val current = validateAdvanceCaseStructuralEdit(draft)
+            val retainedParticipantIds = draft.participants.mapNotNull { it.participantId }.toSet()
+            val retainedRepaymentIds = draft.repayments.map { it.repaymentId }.toSet()
+            val removedParticipants = current.participants.count { it.id !in retainedParticipantIds }
+            val removedRepayments = current.repayments.count { it.id !in retainedRepaymentIds }
+            val warnings = buildList {
+                if (draft.direction.name != current.advanceCase.direction) {
+                    add("改變方向會原子重建案件的初始分錄與普通還款分錄。")
+                }
+                if (!draft.currencyCode.equals(current.advanceCase.currencyCode, ignoreCase = true)) {
+                    add("案件幣種改變後，所有沖銷金額均以輸入值為準，不會自動換算。")
+                }
+                if (removedParticipants > 0) {
+                    add("刪除參與人會一併刪除其普通還款及相關底層分錄。")
+                } else if (removedRepayments > 0) {
+                    add("未保留的普通還款會連同底層分錄刪除。")
+                }
+            }
+            AdvanceCaseStructuralImpact(
+                changesDirection = draft.direction.name != current.advanceCase.direction,
+                changesCurrency = !draft.currencyCode.equals(
+                    current.advanceCase.currencyCode,
+                    ignoreCase = true
+                ),
+                affectedTransactionCount = advanceLinkedTransactions(current).size,
+                affectedParticipantCount = draft.participants.size,
+                affectedRepaymentCount = draft.repayments.size,
+                removedParticipantCount = removedParticipants,
+                removedRepaymentCount = removedRepayments,
+                warnings = warnings
+            )
+        }
+    }
+
+    suspend fun applyAdvanceCaseStructuralEdit(draft: AdvanceCaseStructuralEditDraft) {
+        database.withTransaction {
+            val current = validateAdvanceCaseStructuralEdit(draft)
+            val now = Instant.now()
+            val currency = draft.currencyCode.trim().uppercase()
+            val title = draft.title.trim()
+            val note = draft.note.trim()
+            val memo = note.ifBlank { title }
+            val currentParticipantsById = current.participants.associateBy { it.id }
+            val currentRepaymentsById = current.repayments.associateBy { it.id }
+            val normalizedByParticipant = draft.repayments
+                .groupBy { currentRepaymentsById.getValue(it.repaymentId).participantId }
+                .mapValues { (_, repayments) ->
+                    repayments.fold(BigDecimal.ZERO) { total, repayment ->
+                        total + repayment.normalizedAmount.abs()
+                    }
+                }
+
+            data class PreparedParticipant(
+                val draft: AdvanceParticipantStructuralDraft,
+                val entity: AdvanceParticipantEntity
+            )
+
+            val preparedParticipants = draft.participants.map { participantDraft ->
+                val existing = participantDraft.participantId?.let(currentParticipantsById::get)
+                val participantId = existing?.id ?: UUID.randomUUID()
+                val repaidAmount = normalizedByParticipant[participantId] ?: BigDecimal.ZERO
+                PreparedParticipant(
+                    draft = participantDraft,
+                    entity = AdvanceParticipantEntity(
+                        id = participantId,
+                        name = participantDraft.name.trim(),
+                        owedAmount = participantDraft.owedAmount.abs(),
+                        repaidAmount = repaidAmount,
+                        initialTransferGroupId = existing?.initialTransferGroupId ?: UUID.randomUUID(),
+                        createdAt = existing?.createdAt ?: now,
+                        updatedAt = now,
+                        advanceCaseId = current.advanceCase.id,
+                        debtAccountId = participantDraft.debtAccountId
+                    )
+                )
+            }
+            val preparedById = preparedParticipants.associateBy { it.entity.id }
+            val desiredParticipantIds = preparedById.keys
+            val desiredRepaymentIds = draft.repayments.map { it.repaymentId }.toSet()
+
+            for (repayment in current.repayments.filter { it.id !in desiredRepaymentIds }) {
+                advanceDao.deleteRepayment(repayment)
+            }
+            for (participant in current.participants.filter { it.id !in desiredParticipantIds }) {
+                advanceDao.deleteParticipant(participant)
+            }
+            advanceDao.upsertParticipants(preparedParticipants.map { it.entity })
+
+            val existingCaseTransactions = advanceLinkedTransactions(current)
+            val existingCaseTransactionsById = existingCaseTransactions.associateBy { it.id }
+            deleteTransactions(existingCaseTransactions)
+
+            val transactions = mutableListOf<TransactionEntity>()
+            val tagRefs = mutableListOf<TransactionTagCrossRef>()
+
+            fun addTransaction(
+                id: UUID,
+                amount: BigDecimal,
+                transactionCurrency: String,
+                date: Instant,
+                transactionNote: String,
+                type: TransactionType,
+                linkedTransactionId: UUID?,
+                transferGroupId: UUID?,
+                transferSide: TransferSide?,
+                participantId: UUID?,
+                repaymentId: UUID?,
+                role: AdvanceEntryRole,
+                accountId: UUID,
+                categoryId: UUID?,
+                tags: List<UUID>
+            ) {
+                transactions += TransactionEntity(
+                    id = id,
+                    amount = amount,
+                    currencyCode = transactionCurrency.trim().uppercase(),
+                    date = date,
+                    note = transactionNote,
+                    photoPath = null,
+                    type = type,
+                    linkedTransactionId = linkedTransactionId,
+                    transferGroupId = transferGroupId,
+                    transferSide = transferSide,
+                    createdAt = existingCaseTransactionsById[id]?.createdAt ?: now,
+                    updatedAt = now,
+                    accountId = accountId,
+                    categoryId = categoryId,
+                    advanceCaseId = current.advanceCase.id,
+                    advanceParticipantId = participantId,
+                    advanceRepaymentId = repaymentId,
+                    advanceEntryRole = role.name
+                )
+                tagRefs += tags.distinct().map { tagId -> TransactionTagCrossRef(id, tagId) }
+            }
+
+            draft.share?.let { share ->
+                addTransaction(
+                    id = share.transactionId
+                        ?: current.advanceCase.selfExpenseTransactionId
+                        ?: UUID.randomUUID(),
+                    amount = share.amount.abs().negate(),
+                    transactionCurrency = share.currencyCode,
+                    date = draft.date,
+                    transactionNote = "$memo (自己份額)",
+                    type = TransactionType.Expense,
+                    linkedTransactionId = null,
+                    transferGroupId = null,
+                    transferSide = null,
+                    participantId = null,
+                    repaymentId = null,
+                    role = AdvanceEntryRole.SelfExpense,
+                    accountId = share.accountId,
+                    categoryId = draft.categoryId,
+                    tags = draft.tagIds
+                )
+            }
+
+            preparedParticipants.forEach { prepared ->
+                val participant = prepared.entity
+                val participantDraft = prepared.draft
+                val groupId = requireNotNull(participant.initialTransferGroupId)
+                if (draft.direction == AdvanceSettlementDirection.OthersAdvancedMe) {
+                    addTransaction(
+                        id = UUID.randomUUID(),
+                        amount = participant.owedAmount.negate(),
+                        transactionCurrency = currency,
+                        date = draft.date,
+                        transactionNote = "$memo (他人代墊我：${participant.name})",
+                        type = TransactionType.Expense,
+                        linkedTransactionId = null,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Outgoing,
+                        participantId = participant.id,
+                        repaymentId = null,
+                        role = AdvanceEntryRole.InitialDebt,
+                        accountId = participantDraft.debtAccountId,
+                        categoryId = draft.categoryId,
+                        tags = draft.tagIds
+                    )
+                } else {
+                    val debtId = UUID.randomUUID()
+                    val assetIds = participantDraft.paymentLegs.map {
+                        it.transactionId ?: UUID.randomUUID()
+                    }
+                    participantDraft.paymentLegs.zip(assetIds).forEach { (leg, assetId) ->
+                        addTransaction(
+                            id = assetId,
+                            amount = leg.amount.abs().negate(),
+                            transactionCurrency = leg.currencyCode,
+                            date = draft.date,
+                            transactionNote = "$memo (代墊給 ${participant.name})",
+                            type = TransactionType.Transfer,
+                            linkedTransactionId = debtId,
+                            transferGroupId = groupId,
+                            transferSide = TransferSide.Outgoing,
+                            participantId = participant.id,
+                            repaymentId = null,
+                            role = AdvanceEntryRole.InitialAsset,
+                            accountId = leg.accountId,
+                            categoryId = null,
+                            tags = emptyList()
+                        )
+                    }
+                    addTransaction(
+                        id = debtId,
+                        amount = participant.owedAmount,
+                        transactionCurrency = currency,
+                        date = draft.date,
+                        transactionNote = "$memo (來自多付款來源)",
+                        type = TransactionType.Transfer,
+                        linkedTransactionId = assetIds.singleOrNull(),
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Incoming,
+                        participantId = participant.id,
+                        repaymentId = null,
+                        role = AdvanceEntryRole.InitialDebt,
+                        accountId = participantDraft.debtAccountId,
+                        categoryId = null,
+                        tags = emptyList()
+                    )
+                }
+            }
+
+            draft.repayments.forEach { repaymentDraft ->
+                val existingRepayment = currentRepaymentsById.getValue(repaymentDraft.repaymentId)
+                val participant = preparedById.getValue(
+                    requireNotNull(existingRepayment.participantId)
+                ).entity
+                val groupId = existingRepayment.linkedTransferGroupId ?: UUID.randomUUID()
+                val debtId = UUID.randomUUID()
+                val assetId = UUID.randomUUID()
+                val repaymentCurrency = repaymentDraft.currencyCode.trim().uppercase()
+                val repaymentMemo = repaymentDraft.note.trim().ifBlank { title }
+                if (draft.direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                    addTransaction(
+                        id = debtId,
+                        amount = repaymentDraft.amount.abs().negate(),
+                        transactionCurrency = repaymentCurrency,
+                        date = repaymentDraft.date,
+                        transactionNote = "$repaymentMemo (還款至帳戶)",
+                        type = TransactionType.Transfer,
+                        linkedTransactionId = assetId,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Outgoing,
+                        participantId = participant.id,
+                        repaymentId = existingRepayment.id,
+                        role = AdvanceEntryRole.RepaymentDebt,
+                        accountId = requireNotNull(participant.debtAccountId),
+                        categoryId = null,
+                        tags = emptyList()
+                    )
+                    addTransaction(
+                        id = assetId,
+                        amount = repaymentDraft.amount.abs(),
+                        transactionCurrency = repaymentCurrency,
+                        date = repaymentDraft.date,
+                        transactionNote = "$repaymentMemo (來自 ${participant.name})",
+                        type = TransactionType.Transfer,
+                        linkedTransactionId = debtId,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Incoming,
+                        participantId = participant.id,
+                        repaymentId = existingRepayment.id,
+                        role = AdvanceEntryRole.RepaymentAsset,
+                        accountId = repaymentDraft.receiveAccountId,
+                        categoryId = repaymentDraft.categoryId,
+                        tags = repaymentDraft.tagIds
+                    )
+                } else {
+                    addTransaction(
+                        id = assetId,
+                        amount = repaymentDraft.amount.abs().negate(),
+                        transactionCurrency = repaymentCurrency,
+                        date = repaymentDraft.date,
+                        transactionNote = "$repaymentMemo (還款給 ${participant.name})",
+                        type = TransactionType.Transfer,
+                        linkedTransactionId = debtId,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Outgoing,
+                        participantId = participant.id,
+                        repaymentId = existingRepayment.id,
+                        role = AdvanceEntryRole.RepaymentAsset,
+                        accountId = repaymentDraft.receiveAccountId,
+                        categoryId = repaymentDraft.categoryId,
+                        tags = repaymentDraft.tagIds
+                    )
+                    addTransaction(
+                        id = debtId,
+                        amount = repaymentDraft.amount.abs(),
+                        transactionCurrency = repaymentCurrency,
+                        date = repaymentDraft.date,
+                        transactionNote = "$repaymentMemo (來自帳戶)",
+                        type = TransactionType.Transfer,
+                        linkedTransactionId = assetId,
+                        transferGroupId = groupId,
+                        transferSide = TransferSide.Incoming,
+                        participantId = participant.id,
+                        repaymentId = existingRepayment.id,
+                        role = AdvanceEntryRole.RepaymentDebt,
+                        accountId = requireNotNull(participant.debtAccountId),
+                        categoryId = null,
+                        tags = emptyList()
+                    )
+                }
+                advanceDao.upsertRepayment(
+                    existingRepayment.copy(
+                        amount = repaymentDraft.amount.abs(),
+                        currencyCode = repaymentCurrency,
+                        normalizedAmount = repaymentDraft.normalizedAmount.abs(),
+                        date = repaymentDraft.date,
+                        note = repaymentDraft.note.trim(),
+                        linkedTransferGroupId = groupId,
+                        advanceCaseId = current.advanceCase.id,
+                        participantId = participant.id,
+                        receivedAccountId = repaymentDraft.receiveAccountId
+                    )
+                )
+            }
+
+            require(transactions.map { it.id }.distinct().size == transactions.size) {
+                "底層分錄識別碼重複。"
+            }
+            transactionDao.upsertAll(transactions)
+            if (tagRefs.isNotEmpty()) {
+                transactionDao.insertTransactionTags(tagRefs)
+            }
+
+            val paymentAccountIds = draft.participants
+                .flatMap { it.paymentLegs }
+                .map { it.accountId }
+                .distinct()
+            val selfExpenseId = transactions.firstOrNull {
+                it.advanceEntryRole == AdvanceEntryRole.SelfExpense.name
+            }?.id
+            advanceDao.upsertCase(
+                current.advanceCase.copy(
+                    title = title,
+                    date = draft.date,
+                    currencyCode = currency,
+                    myShareAmount = draft.share?.normalizedAmount?.abs() ?: BigDecimal.ZERO,
+                    note = note,
+                    selfExpenseTransactionId = selfExpenseId,
+                    updatedAt = now,
+                    payerAccountId = if (
+                        draft.direction == AdvanceSettlementDirection.IAdvancedOthers
+                    ) {
+                        paymentAccountIds.singleOrNull()
+                    } else {
+                        null
+                    },
+                    expenseCategoryId = draft.categoryId,
+                    direction = draft.direction.name
+                )
+            )
+            advanceDao.clearCaseTags(current.advanceCase.id)
+            if (draft.tagIds.isNotEmpty()) {
+                advanceDao.insertCaseTags(
+                    draft.tagIds.distinct().map { tagId ->
+                        AdvanceCaseTagCrossRef(current.advanceCase.id, tagId)
+                    }
+                )
+            }
+            syncAllBudgetHistory()
+        }
+    }
+
+    private suspend fun validateAdvanceCaseStructuralEdit(
+        draft: AdvanceCaseStructuralEditDraft
+    ): AdvanceCaseWithDetails {
+        val current = requireNotNull(advanceDao.getAdvanceCase(draft.caseId)) {
+            "找不到代墊案件。"
+        }
+        require(draft.title.isNotBlank()) { "請輸入案件名稱。" }
+        require(draft.currencyCode.isNotBlank()) { "請選擇案件幣種。" }
+        require(draft.participants.isNotEmpty()) { "請至少保留一位代墊對象。" }
+
+        val currentParticipantIds = current.participants.map { it.id }.toSet()
+        val participantIds = draft.participants.mapNotNull { it.participantId }
+        require(participantIds.all { it in currentParticipantIds }) {
+            "編輯草稿包含不屬於此案件的參與人。"
+        }
+        require(participantIds.distinct().size == participantIds.size) {
+            "同一參與人不可重複。"
+        }
+        require(
+            draft.participants.map { it.debtAccountId }.distinct().size ==
+                draft.participants.size
+        ) { "同一債務對象不可重複。" }
+
+        val currentRepaymentsById = current.repayments.associateBy { it.id }
+        val repaymentIds = draft.repayments.map { it.repaymentId }
+        require(repaymentIds.distinct().size == repaymentIds.size) { "同一筆還款不可重複。" }
+        require(repaymentIds.all(currentRepaymentsById::containsKey)) {
+            "編輯草稿包含不屬於此案件的還款。"
+        }
+        val requestedTransactionIds = buildList {
+            draft.share?.transactionId?.let(::add)
+            draft.participants.flatMap { it.paymentLegs }.mapNotNullTo(this) {
+                it.transactionId
+            }
+        }
+        require(requestedTransactionIds.distinct().size == requestedTransactionIds.size) {
+            "付款分錄識別碼不可重複。"
+        }
+        val selfExpenseId = current.advanceCase.selfExpenseTransactionId
+        val linkedTransactionIds = advanceLinkedTransactions(current).map { it.id }.toSet()
+        val conflictingTransaction = transactionDao.getAll().any {
+            it.id in requestedTransactionIds &&
+                it.id !in linkedTransactionIds &&
+                it.id != selfExpenseId
+        }
+        require(!conflictingTransaction) {
+            "付款分錄識別碼已屬於其他交易，無法安全重建。"
+        }
+        current.repayments
+            .filter { it.id !in repaymentIds }
+            .forEach {
+                require(!isMutualDebtOffset(it.note) && !isManualDebtSettlement(it.note)) {
+                    "債務抵銷或跨幣種平賬必須先整組撤銷。"
+                }
+            }
+
+        val retainedParticipantIds = participantIds.toSet()
+        val normalizedByParticipant = draft.repayments
+            .groupBy { currentRepaymentsById.getValue(it.repaymentId).participantId }
+            .mapValues { (_, repayments) ->
+                repayments.fold(BigDecimal.ZERO) { total, repayment ->
+                    total + repayment.normalizedAmount.abs()
+                }
+            }
+        draft.repayments.forEach { repayment ->
+            val existing = currentRepaymentsById.getValue(repayment.repaymentId)
+            require(
+                !isMutualDebtOffset(existing.note) &&
+                    !isManualDebtSettlement(existing.note)
+            ) { "債務抵銷或跨幣種平賬必須先整組撤銷。" }
+            require(existing.participantId in retainedParticipantIds) {
+                "還款對象必須保留在案件中。"
+            }
+            require(
+                repayment.amount > BigDecimal.ZERO &&
+                    repayment.normalizedAmount > BigDecimal.ZERO &&
+                    repayment.currencyCode.isNotBlank()
+            ) { "還款金額與沖銷金額必須大於 0。" }
+            val account = requireNotNull(accountDao.getAccount(repayment.receiveAccountId)) {
+                "找不到還款帳戶。"
+            }
+            require(account.type != AccountType.Debt && !account.isArchived) {
+                "請選擇未歸檔的非借貸帳戶。"
+            }
+            repayment.categoryId?.let { categoryId ->
+                val category = requireNotNull(categoryDao.getCategory(categoryId)) {
+                    "找不到所選分類。"
+                }
+                val expectedType = if (
+                    draft.direction == AdvanceSettlementDirection.IAdvancedOthers
+                ) {
+                    TransactionType.Income
+                } else {
+                    TransactionType.Expense
+                }
+                require(category.kind.supports(expectedType)) {
+                    "所選分類與這筆還款方向不相符。"
+                }
+            }
+        }
+
+        draft.participants.forEach { participant ->
+            val debtAccount = requireNotNull(accountDao.getAccount(participant.debtAccountId)) {
+                "找不到債務帳戶。"
+            }
+            require(debtAccount.type == AccountType.Debt && !debtAccount.isArchived) {
+                "請選擇未歸檔的借貸帳戶。"
+            }
+            require(participant.owedAmount > BigDecimal.ZERO) { "欠款金額必須大於 0。" }
+            val settled = normalizedByParticipant[participant.participantId] ?: BigDecimal.ZERO
+            require(participant.owedAmount >= settled) { "欠款金額不可低於已還金額。" }
+            if (draft.direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                require(participant.paymentLegs.isNotEmpty()) { "請至少保留一個付款來源。" }
+                participant.paymentLegs.forEach { leg ->
+                    val account = requireNotNull(accountDao.getAccount(leg.accountId)) {
+                        "找不到付款帳戶。"
+                    }
+                    require(
+                        account.type != AccountType.Debt &&
+                            !account.isArchived &&
+                            leg.amount > BigDecimal.ZERO &&
+                            leg.currencyCode.isNotBlank()
+                    ) { "付款來源、金額或幣種無效。" }
+                }
+            } else {
+                require(participant.paymentLegs.isEmpty()) {
+                    "他人代墊我不可包含付款來源。"
+                }
+            }
+        }
+
+        draft.share?.let { share ->
+            val account = requireNotNull(accountDao.getAccount(share.accountId)) {
+                "找不到自己份額的付款帳戶。"
+            }
+            require(
+                draft.direction == AdvanceSettlementDirection.IAdvancedOthers &&
+                    account.type != AccountType.Debt &&
+                    !account.isArchived &&
+                    share.amount > BigDecimal.ZERO &&
+                    share.normalizedAmount > BigDecimal.ZERO &&
+                    share.currencyCode.isNotBlank()
+            ) { "自己的份額、付款帳戶或幣種無效。" }
+        }
+
+        draft.categoryId?.let { categoryId ->
+            val category = requireNotNull(categoryDao.getCategory(categoryId)) {
+                "找不到所選分類。"
+            }
+            if (draft.direction == AdvanceSettlementDirection.OthersAdvancedMe) {
+                require(category.kind.supports(TransactionType.Expense)) {
+                    "他人代墊我的初始分錄只能使用支出分類。"
+                }
+            }
+        }
+        return current
+    }
+
+    private suspend fun advanceLinkedTransactions(
+        current: AdvanceCaseWithDetails
+    ): List<TransactionEntity> {
+        val groupIds = buildSet {
+            current.participants.mapNotNullTo(this) { it.initialTransferGroupId }
+            current.repayments.mapNotNullTo(this) { it.linkedTransferGroupId }
+        }
+        val caseId = current.advanceCase.id
+        val selfExpenseId = current.advanceCase.selfExpenseTransactionId
+        return transactionDao.getAll().filter {
+            it.advanceCaseId == caseId ||
+                it.transferGroupId in groupIds ||
+                it.id == selfExpenseId
         }
     }
 

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/AdvanceEditingTest.kt
@@ -24,6 +24,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceInitialMetadataEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceCaseStructuralEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvancePaymentLegStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentStructuralDraft
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentCreateDraft
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentEditDraft
@@ -630,6 +634,265 @@ class AdvanceEditingTest {
 
         val unchanged = requireNotNull(repository.getAdvanceCase(caseId))
         assertEquals(BigDecimal("40"), unchanged.repayments.single().amount)
+        assertEquals(BigDecimal("40"), unchanged.participants.single().repaidAmount)
+    }
+
+    @Test
+    fun structuralEdit_rebuildsDirectionAndRepaymentEntries() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Dinner",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val original = requireNotNull(repository.getAdvanceCase(caseId))
+        repository.recordAdvanceRepayment(
+            advanceCase = original.advanceCase,
+            participant = original.participants.single(),
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "Paid",
+            receiveAccount = wallet,
+            category = null,
+            tagIds = emptyList()
+        )
+        val current = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = current.participants.single()
+        val repayment = current.repayments.single()
+        val draft = AdvanceCaseStructuralEditDraft(
+            caseId = caseId,
+            title = "Changed",
+            date = current.advanceCase.date,
+            direction = org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSettlementDirection.OthersAdvancedMe,
+            currencyCode = "HKD",
+            note = "",
+            categoryId = expenseCategory.id,
+            tagIds = emptyList(),
+            share = null,
+            participants = listOf(
+                AdvanceParticipantStructuralDraft(
+                    participantId = participant.id,
+                    name = participant.name,
+                    debtAccountId = friend.id,
+                    owedAmount = BigDecimal("100"),
+                    paymentLegs = emptyList()
+                )
+            ),
+            repayments = listOf(
+                AdvanceRepaymentStructuralDraft(
+                    repaymentId = repayment.id,
+                    receiveAccountId = wallet.id,
+                    amount = BigDecimal("40"),
+                    currencyCode = "HKD",
+                    normalizedAmount = BigDecimal("40"),
+                    date = repayment.date,
+                    note = repayment.note,
+                    categoryId = expenseCategory.id,
+                    tagIds = emptyList()
+                )
+            )
+        )
+
+        val preview = repository.previewAdvanceCaseStructuralEdit(draft)
+        assertTrue(preview.changesDirection)
+        repository.applyAdvanceCaseStructuralEdit(draft)
+
+        val updated = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals("OthersAdvancedMe", updated.advanceCase.direction)
+        assertEquals(null, updated.advanceCase.payerAccountId)
+        val initial = database.transactionDao()
+            .getTransferGroup(requireNotNull(updated.participants.single().initialTransferGroupId))
+            .single()
+            .transaction
+        assertEquals(TransactionType.Expense, initial.type)
+        assertEquals(friend.id, initial.accountId)
+        assertEquals("InitialDebt", initial.advanceEntryRole)
+        val repaymentGroup = database.transactionDao()
+            .getTransferGroup(requireNotNull(updated.repayments.single().linkedTransferGroupId))
+            .map { it.transaction }
+        assertEquals(
+            wallet.id,
+            repaymentGroup.single { it.transferSide == TransferSide.Outgoing }.accountId
+        )
+        assertEquals(
+            friend.id,
+            repaymentGroup.single { it.transferSide == TransferSide.Incoming }.accountId
+        )
+        assertTrue(repaymentGroup.all { it.advanceRepaymentId == repayment.id })
+    }
+
+    @Test
+    fun structuralEdit_supportsSplitLegsAndNewParticipant() = runBlocking {
+        val friendB = account("Friend B", AccountType.Debt, 3)
+        repository.upsertAccount(friendB)
+        val caseId = repository.createAdvanceCase(
+            title = "Japan",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("1000")))
+        )
+        val current = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = current.participants.single()
+        val existingAsset = database.transactionDao()
+            .getTransferGroup(requireNotNull(participant.initialTransferGroupId))
+            .single { it.transaction.advanceEntryRole == "InitialAsset" }
+            .transaction
+
+        repository.applyAdvanceCaseStructuralEdit(
+            AdvanceCaseStructuralEditDraft(
+                caseId = caseId,
+                title = current.advanceCase.title,
+                date = current.advanceCase.date,
+                direction = org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSettlementDirection.IAdvancedOthers,
+                currencyCode = "JPY",
+                note = "",
+                categoryId = null,
+                tagIds = emptyList(),
+                share = null,
+                participants = listOf(
+                    AdvanceParticipantStructuralDraft(
+                        participantId = participant.id,
+                        name = participant.name,
+                        debtAccountId = friend.id,
+                        owedAmount = BigDecimal("1200"),
+                        paymentLegs = listOf(
+                            AdvancePaymentLegStructuralDraft(
+                                transactionId = existingAsset.id,
+                                accountId = wallet.id,
+                                amount = BigDecimal("500"),
+                                currencyCode = "HKD"
+                            ),
+                            AdvancePaymentLegStructuralDraft(
+                                accountId = bank.id,
+                                amount = BigDecimal("30"),
+                                currencyCode = "USD"
+                            )
+                        )
+                    ),
+                    AdvanceParticipantStructuralDraft(
+                        name = "Friend B",
+                        debtAccountId = friendB.id,
+                        owedAmount = BigDecimal("800"),
+                        paymentLegs = listOf(
+                            AdvancePaymentLegStructuralDraft(
+                                accountId = bank.id,
+                                amount = BigDecimal("40"),
+                                currencyCode = "USD"
+                            )
+                        )
+                    )
+                ),
+                repayments = emptyList()
+            )
+        )
+
+        val updated = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals(2, updated.participants.size)
+        assertEquals(null, updated.advanceCase.payerAccountId)
+        val updatedA = updated.participants.single { it.debtAccountId == friend.id }
+        val group = database.transactionDao()
+            .getTransferGroup(requireNotNull(updatedA.initialTransferGroupId))
+            .map { it.transaction }
+        assertEquals(3, group.size)
+        assertEquals(2, group.count { it.advanceEntryRole == "InitialAsset" })
+        assertEquals(
+            setOf("HKD", "USD"),
+            group.filter { it.advanceEntryRole == "InitialAsset" }.map { it.currencyCode }.toSet()
+        )
+    }
+
+    @Test
+    fun structuralEdit_invalidCurrencyAmountsRollBackWholeTransaction() = runBlocking {
+        val caseId = repository.createAdvanceCase(
+            title = "Dinner",
+            date = Instant.parse("2026-06-01T10:00:00Z"),
+            currencyCode = "HKD",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("100")))
+        )
+        val initial = requireNotNull(repository.getAdvanceCase(caseId))
+        repository.recordAdvanceRepayment(
+            advanceCase = initial.advanceCase,
+            participant = initial.participants.single(),
+            amount = BigDecimal("40"),
+            normalizedAmount = BigDecimal("40"),
+            currencyCode = "HKD",
+            date = Instant.parse("2026-06-02T10:00:00Z"),
+            note = "",
+            receiveAccount = wallet,
+            category = null,
+            tagIds = emptyList()
+        )
+        val current = requireNotNull(repository.getAdvanceCase(caseId))
+        val participant = current.participants.single()
+        val repayment = current.repayments.single()
+
+        try {
+            repository.applyAdvanceCaseStructuralEdit(
+                AdvanceCaseStructuralEditDraft(
+                    caseId = caseId,
+                    title = current.advanceCase.title,
+                    date = current.advanceCase.date,
+                    direction = org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSettlementDirection.IAdvancedOthers,
+                    currencyCode = "JPY",
+                    note = "",
+                    categoryId = null,
+                    tagIds = emptyList(),
+                    share = null,
+                    participants = listOf(
+                        AdvanceParticipantStructuralDraft(
+                            participantId = participant.id,
+                            name = participant.name,
+                            debtAccountId = friend.id,
+                            owedAmount = BigDecimal("499"),
+                            paymentLegs = listOf(
+                                AdvancePaymentLegStructuralDraft(
+                                    accountId = wallet.id,
+                                    amount = BigDecimal("25"),
+                                    currencyCode = "HKD"
+                                )
+                            )
+                        )
+                    ),
+                    repayments = listOf(
+                        AdvanceRepaymentStructuralDraft(
+                            repaymentId = repayment.id,
+                            receiveAccountId = wallet.id,
+                            amount = BigDecimal("40"),
+                            currencyCode = "HKD",
+                            normalizedAmount = BigDecimal("500"),
+                            date = repayment.date,
+                            note = "",
+                            categoryId = null,
+                            tagIds = emptyList()
+                        )
+                    )
+                )
+            )
+            fail("Expected invalid settled amount to reject the whole edit.")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message.orEmpty().contains("低於"))
+        }
+
+        val unchanged = requireNotNull(repository.getAdvanceCase(caseId))
+        assertEquals("HKD", unchanged.advanceCase.currencyCode)
+        assertEquals(BigDecimal("100"), unchanged.participants.single().owedAmount)
         assertEquals(BigDecimal("40"), unchanged.participants.single().repaidAmount)
     }
 

--- a/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
+++ b/android/app/src/test/java/org/duckdns/lhfser/aiaccounting/data/BackupRoundTripTest.kt
@@ -18,6 +18,10 @@ import org.duckdns.lhfser.aiaccounting.data.db.RecurringRuleEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
 import org.duckdns.lhfser.aiaccounting.data.db.TransactionEntity
 import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantInput
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceCaseStructuralEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvancePaymentLegStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSettlementDirection
 import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
 import org.duckdns.lhfser.aiaccounting.data.repository.ManualDebtSettlementDirection
 import org.duckdns.lhfser.aiaccounting.data.settlement.DebtSettlementBalanceCalculator
@@ -862,6 +866,109 @@ class BackupRoundTripTest {
             assertEquals(1, secondDatabase.recurringDao().getAllRules().size)
             assertEquals(1, secondDatabase.recurringDao().getAllOccurrences().size)
             assertNotNull(secondRepository.getTransaction(transactionId))
+        } finally {
+            secondDatabase.close()
+        }
+    }
+
+    @Test
+    fun splitAdvancePaymentLegs_roundTripExplicitLinks() = runBlocking {
+        val wallet = AccountEntity(
+            UUID.randomUUID(),
+            "Wallet",
+            "HKD",
+            AccountType.Cash,
+            BigDecimal.ZERO,
+            0,
+            false
+        )
+        val card = wallet.copy(
+            id = UUID.randomUUID(),
+            name = "Card",
+            currency = "USD",
+            type = AccountType.CreditCard,
+            sortOrder = 1
+        )
+        val friend = wallet.copy(
+            id = UUID.randomUUID(),
+            name = "Friend",
+            currency = "JPY",
+            type = AccountType.Debt,
+            sortOrder = 2
+        )
+        repository.upsertAccount(wallet)
+        repository.upsertAccount(card)
+        repository.upsertAccount(friend)
+        val caseId = repository.createAdvanceCase(
+            title = "Japan",
+            date = Instant.parse("2026-06-01T00:00:00Z"),
+            currencyCode = "JPY",
+            myShareAmount = BigDecimal.ZERO,
+            note = "",
+            payerAccount = wallet,
+            expenseCategory = null,
+            tagIds = emptyList(),
+            participants = listOf(AdvanceParticipantInput(friend, BigDecimal("1000")))
+        )
+        val participant = requireNotNull(repository.getAdvanceCase(caseId)).participants.single()
+        repository.applyAdvanceCaseStructuralEdit(
+            AdvanceCaseStructuralEditDraft(
+                caseId = caseId,
+                title = "Japan",
+                date = Instant.parse("2026-06-01T00:00:00Z"),
+                direction = AdvanceSettlementDirection.IAdvancedOthers,
+                currencyCode = "JPY",
+                note = "",
+                categoryId = null,
+                tagIds = emptyList(),
+                share = null,
+                participants = listOf(
+                    AdvanceParticipantStructuralDraft(
+                        participantId = participant.id,
+                        name = participant.name,
+                        debtAccountId = friend.id,
+                        owedAmount = BigDecimal("1000"),
+                        paymentLegs = listOf(
+                            AdvancePaymentLegStructuralDraft(
+                                accountId = wallet.id,
+                                amount = BigDecimal("500"),
+                                currencyCode = "HKD"
+                            ),
+                            AdvancePaymentLegStructuralDraft(
+                                accountId = card.id,
+                                amount = BigDecimal("30"),
+                                currencyCode = "USD"
+                            )
+                        )
+                    )
+                ),
+                repayments = emptyList()
+            )
+        )
+
+        val exportedJson = repository.exportBackupJson()
+        val exported = BackupJsonAdapter.gson.fromJson(exportedJson, FullBackupData::class.java)
+        val linked = exported.transactions.filter {
+            it.advanceCaseID == caseId && it.advanceParticipantID == participant.id
+        }
+        assertEquals(3, linked.size)
+        assertEquals(2, linked.count { it.advanceEntryRole == "InitialAsset" })
+
+        val secondDatabase = buildDatabase()
+        try {
+            val secondRepository = AccountingRepository(secondDatabase, currencyService)
+            secondRepository.importBackupJson(exportedJson, replaceExisting = true)
+            val restored = secondDatabase.transactionDao().getAll().filter {
+                it.advanceCaseId == caseId && it.advanceParticipantId == participant.id
+            }
+            assertEquals(3, restored.size)
+            assertEquals(2, restored.count { it.advanceEntryRole == "InitialAsset" })
+            assertEquals(
+                setOf("HKD", "USD"),
+                restored.filter { it.advanceEntryRole == "InitialAsset" }
+                    .map { it.currencyCode }
+                    .toSet()
+            )
         } finally {
             secondDatabase.close()
         }

--- a/docs/specs/android-ios-parity.md
+++ b/docs/specs/android-ios-parity.md
@@ -60,6 +60,8 @@
 - Debt flow: create transfer pair(s) matching iOS notes and entry modes.
 - Account detail flow: account list -> account detail -> edit transaction / transfer / account.
 - First-launch guide behavior stays aligned with iOS.
+- Advance structural editing uses the same preview and confirmation sequence on both platforms for direction changes, case currency changes, split payment sources, and participant additions/removals.
+- Both platforms rebuild linked bookkeeping atomically and reject partial edits of mutual offsets or manual settlements.
 
 ## Allowed Differences
 - Android widget is Android-only.

--- a/docs/specs/data-model.md
+++ b/docs/specs/data-model.md
@@ -2,7 +2,7 @@
 
 Status: Active  
 Last updated: 2026-03-03  
-Current backup JSON version: `1.5`
+Current backup JSON version: `1.9`
 
 ## Purpose
 
@@ -143,6 +143,18 @@ Invariants:
 - `receivedAccountID: UUID?`
 - `createdAt: Date`
 
+### Structural Advance Editing
+
+- Every structural edit follows `validate -> preview -> atomic apply -> rollback`.
+- Direction changes rebuild initial entries and ordinary repayment entries from explicit draft values.
+- Case currency changes never infer exchange rates. The user must explicitly confirm the normalized case-currency amount for the user's share, every participant, and every repayment.
+- A participant's new owed amount must not be lower than the sum of retained normalized repayments.
+- Multiple payment sources are represented by multiple `FinancialTransaction` rows with role `InitialAsset`, one shared `transferGroupID`, and explicit `advanceCaseID` / `advanceParticipantID` links. The matching debt leg uses role `InitialDebt`.
+- Adding a participant creates the participant and all linked initial entries in the same atomic operation.
+- Removing a participant removes that participant's ordinary repayments and all explicitly linked entries in the same atomic operation.
+- Mutual debt offsets and manual debt settlements cannot be edited as individual repayments. They must be rolled back as a whole group before structural editing.
+- New data must use explicit advance links. Note markers remain legacy/special-settlement compatibility signals only.
+
 ## Backup JSON Contract (`FullBackupData`)
 
 Top-level fields:
@@ -165,6 +177,7 @@ Compatibility behavior currently implemented on import:
 - `budgets[].isEnabled` missing -> default `true`
 - `advanceCases[].myShareAmount` missing -> default `0`
 - `advanceRepayments[].normalizedAmount` missing -> fallback to `amount`
+- explicit advance transaction links missing -> conservatively backfill from existing case/group identifiers when unambiguous
 
 ## Cross-Platform Behavior Rules
 


### PR DESCRIPTION
## 實際完成內容
- 新增 iOS 與 Android 對等的代墊結構性編輯 core API，統一採 validate → preview → atomic apply → rollback。
- 支援 `我代墊他人 ↔ 他人代墊我`，原子重建初始分錄與普通還款分錄。
- 支援案件幣種修改，所有自己份額、參與人欠款與還款沖銷額都必須由 draft 明確提供，不套用匯率。
- 支援多付款來源，每個 payment leg 保存帳戶、實際金額、幣種與明確 case/participant/role links。
- 支援建立後新增及刪除參與人；刪除時一併移除普通還款及底層分錄。
- 阻止把債務抵銷或手動結清拆成單筆修改，必須先整組撤銷。
- 增加 transaction ID ownership 驗證，避免覆寫非本案件交易。

## 帳務與資料模型影響
- 方向轉換會依 ADR 0002 重建帳務：`我代墊他人` 使用 transfer asset/debt legs；`他人代墊我` 使用 debt account expense。
- 還款維持 transfer/settlement 語義，不重複計入支出。
- split payment 以同一 `transferGroupID` 下多個 `InitialAsset` 加一個 `InitialDebt` 表示。
- 所有新分錄寫入 `advanceCaseID`、`advanceParticipantID`、`advanceRepaymentID`（適用時）及 `advanceEntryRole`。
- 新欠款不可低於保留還款的 normalized settlement 總額。

## Migration / backup compatibility
- 無 schema migration，backup version 維持 `1.9`。
- 舊 JSON 仍沿用既有 optional/default/backfill 路徑匯入。
- 新增 iOS/Android roundtrip 測試，確認 split payment legs 的明確 links 與實際幣種可保存。

## 測試結果
- iOS `build-for-testing` 多次通過，包含兩輪最終驗證。
- Android `testDebugUnitTest assembleDebug` 通過。
- Android `testDebugUnitTest assembleDebug --rerun-tasks` 通過。
- 本機 iOS runtime 測試因 CoreSimulator `launchd_sim` 無法 bind session 而未能啟動；test bundle 編譯通過，交由 CI 執行 runtime tests。

## 未完成內容
- iOS/Android 結構性 editor UI 尚未接線。
- XCUITest 與 Android Compose/UI Automator 尚未加入，將在第三條 PR 完成。

## 所作假設
- backup v1.9 的 explicit transaction links 足以表示多付款來源，不需新增 persisted entity。
- draft 中省略普通還款代表使用者在 impact preview/二次確認後刪除該還款。
- 自己份額 draft 為 `nil` 代表明確確認為 0。

## 需要項目決策者覆核的事項
- 無。此 PR 僅實作既有 ADR 與需求已定義的帳務語義，沒有新增破壞性 migration 或自動修改舊資料政策。

## 本機排除
- `AI 記帳.xcodeproj/xcshareddata/xcschemes/AI 記帳.xcscheme`
- `Localizable.xcstrings`
- `.codex/CURRENT_HANDOFF.md`
