### PR TITLE
Add cross-platform advance structural editor UI

### DIFF
--- a/AI 記帳/Views/Advances/AdvanceStructuralEditorView.swift
+++ b/AI 記帳/Views/Advances/AdvanceStructuralEditorView.swift
@@ -1,0 +1,782 @@
+import SwiftData
+import SwiftUI
+
+struct AdvanceStructuralEditorView: View {
+    fileprivate struct PaymentLegState: Identifiable {
+        let id: UUID
+        let transactionID: UUID?
+        var account: Account?
+        var amount = ""
+        var currencyCode = "HKD"
+
+        init(
+            id: UUID = UUID(),
+            transactionID: UUID? = nil,
+            account: Account? = nil,
+            amount: String = "",
+            currencyCode: String = "HKD"
+        ) {
+            self.id = id
+            self.transactionID = transactionID
+            self.account = account
+            self.amount = amount
+            self.currencyCode = currencyCode
+        }
+    }
+
+    fileprivate struct ParticipantState: Identifiable {
+        let id: UUID
+        let participant: AdvanceParticipant?
+        var name: String
+        var debtAccount: Account?
+        var owedAmount: String
+        var paymentLegs: [PaymentLegState]
+
+        init(
+            id: UUID = UUID(),
+            participant: AdvanceParticipant? = nil,
+            name: String = "",
+            debtAccount: Account? = nil,
+            owedAmount: String = "",
+            paymentLegs: [PaymentLegState] = []
+        ) {
+            self.id = id
+            self.participant = participant
+            self.name = name
+            self.debtAccount = debtAccount
+            self.owedAmount = owedAmount
+            self.paymentLegs = paymentLegs
+        }
+    }
+
+    fileprivate struct RepaymentState: Identifiable {
+        let id: UUID
+        let repayment: AdvanceRepayment
+        let participantID: UUID
+        var account: Account?
+        var amount: String
+        var currencyCode: String
+        var normalizedAmount: String
+        var date: Date
+        var note: String
+        var category: Category?
+        var tags: Set<Tag>
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Account.sortOrder) private var accounts: [Account]
+    @Query(sort: \Category.name) private var categories: [Category]
+    @Query(sort: \Tag.name) private var tags: [Tag]
+    @Query private var transactions: [FinancialTransaction]
+
+    let advanceCase: AdvanceCase
+
+    @State private var title = ""
+    @State private var date = Date()
+    @State private var direction: AdvanceDirection = .iAdvancedOthers
+    @State private var currencyCode = "HKD"
+    @State private var note = ""
+    @State private var category: Category?
+    @State private var selectedTags: Set<Tag> = []
+    @State private var includesShare = false
+    @State private var shareAccount: Account?
+    @State private var shareAmount = ""
+    @State private var shareCurrency = "HKD"
+    @State private var shareNormalizedAmount = ""
+    @State private var participants: [ParticipantState] = []
+    @State private var repayments: [RepaymentState] = []
+    @State private var confirmsCurrencyAmounts = true
+    @State private var pendingDraft: AdvanceCaseEditDraft?
+    @State private var pendingPreview: AdvanceCaseImpactPreview?
+    @State private var showingImpactPreview = false
+    @State private var showingError = false
+    @State private var errorMessage = ""
+
+    private let commonCurrencies = ["HKD", "TWD", "USD", "JPY", "CNY", "EUR", "GBP"]
+
+    private var ownAccounts: [Account] {
+        accounts.filter { !$0.isArchived && $0.type != .debt }
+    }
+
+    private var debtAccounts: [Account] {
+        accounts.filter { !$0.isArchived && $0.type == .debt }
+    }
+
+    private var availableCurrencies: [String] {
+        Array(Set(commonCurrencies + accounts.map(\.currency) + [advanceCase.currencyCode]))
+            .sorted()
+    }
+
+    private var expenseCategories: [Category] {
+        categories.filter { $0.kind.supports(.expense) }
+    }
+
+    private var repaymentCategories: [Category] {
+        let type: TransactionType = direction == .iAdvancedOthers ? .income : .expense
+        return categories.filter { $0.kind.supports(type) }
+    }
+
+    private var hasSpecialRepayments: Bool {
+        advanceCase.repayments.contains {
+            AdvanceService.repaymentRecordKind(note: $0.note) != .ordinary
+        }
+    }
+
+    private var impactMessage: String {
+        guard let preview = pendingPreview else { return "" }
+        var lines = preview.warnings
+        lines.append("將重建或更新 \(preview.affectedTransactionCount) 筆底層分錄。")
+        if preview.removedParticipantCount > 0 {
+            lines.append("將刪除 \(preview.removedParticipantCount) 位參與人。")
+        }
+        if preview.removedRepaymentCount > 0 {
+            lines.append("將刪除 \(preview.removedRepaymentCount) 筆還款。")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                caseSection
+                shareSection
+                participantsSection
+                repaymentsSection
+                confirmationSection
+            }
+            .interactiveKeyboardDismiss()
+            .navigationTitle("完整編輯代墊")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("預覽影響", action: previewAndConfirm)
+                        .disabled(hasSpecialRepayments)
+                        .accessibilityIdentifier("advance.structural.preview")
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("完成") { hideKeyboard() }
+                }
+            }
+            .alert("確認套用結構性變更？", isPresented: $showingImpactPreview) {
+                Button("取消", role: .cancel) {
+                    pendingDraft = nil
+                    pendingPreview = nil
+                }
+                Button("確認重建", role: .destructive, action: applyPendingDraft)
+                    .accessibilityIdentifier("advance.structural.apply")
+            } message: {
+                Text(impactMessage)
+            }
+            .alert("無法編輯", isPresented: $showingError) {
+                Button("好", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .onAppear(perform: load)
+            .onChange(of: currencyCode) { oldValue, newValue in
+                if oldValue.caseInsensitiveCompare(newValue) != .orderedSame {
+                    confirmsCurrencyAmounts = false
+                }
+            }
+            .onChange(of: direction) { _, newValue in
+                if newValue == .othersAdvancedMe {
+                    includesShare = false
+                    for index in participants.indices {
+                        participants[index].paymentLegs = []
+                    }
+                } else {
+                    for index in participants.indices where participants[index].paymentLegs.isEmpty {
+                        participants[index].paymentLegs = [
+                            PaymentLegState(
+                                account: ownAccounts.first,
+                                currencyCode: ownAccounts.first?.currency ?? currencyCode
+                            )
+                        ]
+                    }
+                }
+                if let category, !expenseCategories.contains(where: { $0.id == category.id }) {
+                    self.category = nil
+                }
+                for index in repayments.indices {
+                    if let selected = repayments[index].category,
+                       !repaymentCategories.contains(where: { $0.id == selected.id }) {
+                        repayments[index].category = nil
+                    }
+                }
+            }
+        }
+    }
+
+    private var caseSection: some View {
+        Section("案件") {
+            Picker("方向", selection: $direction) {
+                Text("我代墊他人").tag(AdvanceDirection.iAdvancedOthers)
+                Text("他人代墊我").tag(AdvanceDirection.othersAdvancedMe)
+            }
+            .pickerStyle(.segmented)
+
+            TextField("案件名稱", text: $title)
+                .accessibilityIdentifier("advance.structural.title")
+            DatePicker("日期", selection: $date)
+            Picker("案件幣種", selection: $currencyCode) {
+                ForEach(availableCurrencies, id: \.self) { code in
+                    Text(code).tag(code)
+                }
+            }
+            .accessibilityIdentifier("advance.structural.currency")
+
+            Picker("支出分類", selection: $category) {
+                Text("無分類").tag(nil as Category?)
+                ForEach(expenseCategories) { item in
+                    Text(item.name).tag(item as Category?)
+                }
+            }
+
+            TagSelection(tags: tags, selected: $selectedTags)
+
+            TextField("備註", text: $note)
+        }
+    }
+
+    @ViewBuilder
+    private var shareSection: some View {
+        if direction == .iAdvancedOthers {
+            Section("自己的份額") {
+                Toggle("包含自己的份額", isOn: $includesShare)
+                if includesShare {
+                    Picker("付款帳戶", selection: $shareAccount) {
+                        Text("請選擇").tag(nil as Account?)
+                        ForEach(ownAccounts) { account in
+                            Text(account.name).tag(account as Account?)
+                        }
+                    }
+                    AmountCurrencyRow(
+                        amount: $shareAmount,
+                        currency: $shareCurrency,
+                        currencies: availableCurrencies,
+                        label: "實際付款"
+                    )
+                    TextField(
+                        "案件份額 \(currencyCode)",
+                        text: decimalBinding($shareNormalizedAmount)
+                    )
+                    .keyboardType(.decimalPad)
+                    Text("實際付款與案件份額都必須明確確認，不會自動套用匯率。")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var participantsSection: some View {
+        Section {
+            ForEach($participants) { $participant in
+                ParticipantEditor(
+                    participant: $participant,
+                    direction: direction,
+                    caseCurrency: currencyCode,
+                    ownAccounts: ownAccounts,
+                    debtAccounts: debtAccounts,
+                    currencies: availableCurrencies,
+                    canRemove: participants.count > 1,
+                    onAddPaymentLeg: {
+                        participant.paymentLegs.append(
+                            PaymentLegState(
+                                account: ownAccounts.first,
+                                currencyCode: ownAccounts.first?.currency ?? currencyCode
+                            )
+                        )
+                    },
+                    onRemovePaymentLeg: { legID in
+                        participant.paymentLegs.removeAll { $0.id == legID }
+                    },
+                    onRemove: {
+                        removeParticipant(participant.id)
+                    }
+                )
+            }
+
+            Button {
+                participants.append(
+                    ParticipantState(
+                        paymentLegs: direction == .iAdvancedOthers
+                            ? [
+                                PaymentLegState(
+                                    account: ownAccounts.first,
+                                    currencyCode: ownAccounts.first?.currency ?? currencyCode
+                                )
+                            ]
+                            : []
+                    )
+                )
+            } label: {
+                Label("新增參與人", systemImage: "person.badge.plus")
+            }
+            .accessibilityIdentifier("advance.structural.addParticipant")
+        } header: {
+            Text(direction == .iAdvancedOthers ? "代墊對象與付款來源" : "我欠的人")
+        } footer: {
+            Text("刪除已有還款的參與人時，下一步會列出影響並要求再次確認。")
+        }
+    }
+
+    private var repaymentsSection: some View {
+        Section {
+            if repayments.isEmpty {
+                Text("沒有可編輯的普通還款。")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach($repayments) { $repayment in
+                    RepaymentEditor(
+                        repayment: $repayment,
+                        participantName: participantName(for: repayment.participantID),
+                        accounts: ownAccounts,
+                        categories: repaymentCategories,
+                        tags: tags,
+                        currencies: availableCurrencies,
+                        caseCurrency: currencyCode
+                    )
+                }
+            }
+        } header: {
+            Text("普通還款沖銷")
+        } footer: {
+            Text("改變案件幣種時，每筆沖銷額都必須重新確認。")
+        }
+    }
+
+    private var confirmationSection: some View {
+        Section("安全確認") {
+            if hasSpecialRepayments {
+                Label(
+                    "此案件含債務抵銷或手動結清。請返回詳情先整組撤銷，才能進行結構性編輯。",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .foregroundStyle(.orange)
+            }
+            if currencyCode.caseInsensitiveCompare(advanceCase.currencyCode) != .orderedSame {
+                Toggle(
+                    "我已重新確認所有 \(currencyCode) 案件金額與還款沖銷額",
+                    isOn: $confirmsCurrencyAmounts
+                )
+                .accessibilityIdentifier("advance.structural.confirmCurrency")
+            }
+            Text("儲存前會先顯示影響預覽；確認後才原子重建，任何失敗都不會留下部分變更。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func load() {
+        title = advanceCase.title
+        date = advanceCase.date
+        direction = advanceCase.direction ?? .iAdvancedOthers
+        currencyCode = advanceCase.currencyCode
+        note = advanceCase.note
+        category = advanceCase.expenseCategory
+        selectedTags = Set(tags.filter { advanceCase.tagIDs.contains($0.id) })
+
+        if let shareID = advanceCase.selfExpenseTransactionID,
+           let transaction = transactions.first(where: { $0.id == shareID }) {
+            includesShare = true
+            shareAccount = transaction.account
+            shareAmount = decimalString(abs(transaction.amount))
+            shareCurrency = transaction.currencyCode
+            shareNormalizedAmount = decimalString(advanceCase.myShareAmount)
+        } else {
+            includesShare = false
+            shareAccount = ownAccounts.first
+            shareCurrency = ownAccounts.first?.currency ?? advanceCase.currencyCode
+        }
+
+        participants = advanceCase.participants
+            .sorted { $0.createdAt < $1.createdAt }
+            .map { participant in
+                let group = participant.initialTransferGroupID.map(transactionsForGroup) ?? []
+                let legs = group
+                    .filter { $0.advanceEntryRole == .initialAsset }
+                    .map {
+                        PaymentLegState(
+                            transactionID: $0.id,
+                            account: $0.account,
+                            amount: decimalString(abs($0.amount)),
+                            currencyCode: $0.currencyCode
+                        )
+                    }
+                return ParticipantState(
+                    id: participant.id,
+                    participant: participant,
+                    name: participant.name,
+                    debtAccount: participant.debtAccount,
+                    owedAmount: decimalString(participant.owedAmount),
+                    paymentLegs: direction == .iAdvancedOthers ? legs : []
+                )
+            }
+
+        repayments = advanceCase.repayments
+            .filter { AdvanceService.repaymentRecordKind(note: $0.note) == .ordinary }
+            .sorted { $0.date < $1.date }
+            .compactMap { repayment in
+                guard let participantID = repayment.participant?.id else { return nil }
+                let group = repayment.linkedTransferGroupID.map(transactionsForGroup) ?? []
+                let ownLeg = group.first { $0.advanceEntryRole == .repaymentAsset }
+                return RepaymentState(
+                    id: repayment.id,
+                    repayment: repayment,
+                    participantID: participantID,
+                    account: repayment.receivedAccount,
+                    amount: decimalString(repayment.amount),
+                    currencyCode: repayment.currencyCode,
+                    normalizedAmount: decimalString(repayment.normalizedAmount),
+                    date: repayment.date,
+                    note: repayment.note,
+                    category: ownLeg?.category,
+                    tags: Set(ownLeg?.tags ?? [])
+                )
+            }
+    }
+
+    private func previewAndConfirm() {
+        guard confirmsCurrencyAmounts else {
+            showError("請先確認新案件幣種下的所有金額與還款沖銷額。")
+            return
+        }
+        do {
+            let draft = try makeDraft()
+            pendingPreview = try AdvanceCaseEditingService.preview(
+                draft,
+                modelContext: modelContext
+            )
+            pendingDraft = draft
+            showingImpactPreview = true
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+
+    private func applyPendingDraft() {
+        guard let pendingDraft else { return }
+        do {
+            try AdvanceCaseEditingService.apply(pendingDraft, modelContext: modelContext)
+            dismiss()
+        } catch {
+            showError(error.localizedDescription)
+        }
+        self.pendingDraft = nil
+        pendingPreview = nil
+    }
+
+    private func makeDraft() throws -> AdvanceCaseEditDraft {
+        let participantDrafts = try participants.map { participant -> AdvanceParticipantDraft in
+            guard let debtAccount = participant.debtAccount else {
+                throw AdvanceCaseEditingError.invalidDebtAccount
+            }
+            guard let owedAmount = positiveDecimal(participant.owedAmount) else {
+                throw AdvanceServiceError.invalidAdjustedOwedAmount
+            }
+            let paymentLegs: [AdvancePaymentLegDraft]
+            if direction == .iAdvancedOthers {
+                paymentLegs = try participant.paymentLegs.map { leg in
+                    guard let account = leg.account,
+                          let amount = positiveDecimal(leg.amount)
+                    else {
+                        throw AdvanceCaseEditingError.invalidPaymentLeg
+                    }
+                    return AdvancePaymentLegDraft(
+                        transactionID: leg.transactionID,
+                        account: account,
+                        amount: amount,
+                        currencyCode: leg.currencyCode
+                    )
+                }
+            } else {
+                paymentLegs = []
+            }
+            return AdvanceParticipantDraft(
+                participant: participant.participant,
+                name: participant.name,
+                debtAccount: debtAccount,
+                owedAmount: owedAmount,
+                paymentLegs: paymentLegs
+            )
+        }
+
+        let repaymentDrafts = try repayments.map { state -> AdvanceRepaymentDraft in
+            guard participants.contains(where: {
+                $0.participant?.id == state.participantID
+            }) else {
+                throw AdvanceCaseEditingError.repaymentNotInCase
+            }
+            guard let account = state.account,
+                  let amount = positiveDecimal(state.amount),
+                  let normalizedAmount = positiveDecimal(state.normalizedAmount)
+            else {
+                throw AdvanceServiceError.invalidRepaymentAmount
+            }
+            return AdvanceRepaymentDraft(
+                repayment: state.repayment,
+                account: account,
+                amount: amount,
+                currencyCode: state.currencyCode,
+                normalizedAmount: normalizedAmount,
+                date: state.date,
+                note: state.note,
+                category: state.category,
+                tags: Array(state.tags)
+            )
+        }
+
+        let shareDraft: AdvanceShareDraft?
+        if direction == .iAdvancedOthers, includesShare {
+            guard let account = shareAccount,
+                  let amount = positiveDecimal(shareAmount),
+                  let normalizedAmount = positiveDecimal(shareNormalizedAmount)
+            else {
+                throw AdvanceCaseEditingError.invalidShare
+            }
+            shareDraft = AdvanceShareDraft(
+                transactionID: advanceCase.selfExpenseTransactionID,
+                account: account,
+                amount: amount,
+                normalizedAmount: normalizedAmount,
+                currencyCode: shareCurrency
+            )
+        } else {
+            shareDraft = nil
+        }
+
+        return AdvanceCaseEditDraft(
+            advanceCase: advanceCase,
+            title: title,
+            date: date,
+            direction: direction,
+            currencyCode: currencyCode,
+            note: note,
+            category: category,
+            tags: Array(selectedTags),
+            share: shareDraft,
+            participants: participantDrafts,
+            repayments: repaymentDrafts
+        )
+    }
+
+    private func removeParticipant(_ id: UUID) {
+        guard participants.count > 1 else { return }
+        let participantID = participants.first(where: { $0.id == id })?.participant?.id
+        participants.removeAll { $0.id == id }
+        if let participantID {
+            repayments.removeAll { $0.participantID == participantID }
+        }
+    }
+
+    private func transactionsForGroup(_ groupID: UUID) -> [FinancialTransaction] {
+        transactions.filter { $0.transferGroupID == groupID }
+    }
+
+    private func participantName(for participantID: UUID) -> String {
+        participants.first(where: {
+            $0.participant?.id == participantID
+        })?.name ?? "已移除對象"
+    }
+
+    private func decimalBinding(_ value: Binding<String>) -> Binding<String> {
+        Binding(
+            get: { value.wrappedValue },
+            set: { value.wrappedValue = sanitizeDecimal($0) }
+        )
+    }
+
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+    }
+}
+
+private struct ParticipantEditor: View {
+    @Binding var participant: AdvanceStructuralEditorView.ParticipantState
+    let direction: AdvanceDirection
+    let caseCurrency: String
+    let ownAccounts: [Account]
+    let debtAccounts: [Account]
+    let currencies: [String]
+    let canRemove: Bool
+    let onAddPaymentLeg: () -> Void
+    let onRemovePaymentLeg: (UUID) -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            TextField("姓名", text: $participant.name)
+            Picker("債務帳戶", selection: $participant.debtAccount) {
+                Text("請選擇").tag(nil as Account?)
+                ForEach(debtAccounts) { account in
+                    Text(account.name).tag(account as Account?)
+                }
+            }
+            TextField(
+                "\(caseCurrency) 欠款金額",
+                text: Binding(
+                    get: { participant.owedAmount },
+                    set: { participant.owedAmount = sanitizeDecimal($0) }
+                )
+            )
+            .keyboardType(.decimalPad)
+
+            if direction == .iAdvancedOthers {
+                ForEach($participant.paymentLegs) { $leg in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Picker("付款帳戶", selection: $leg.account) {
+                            Text("請選擇").tag(nil as Account?)
+                            ForEach(ownAccounts) { account in
+                                Text(account.name).tag(account as Account?)
+                            }
+                        }
+                        AmountCurrencyRow(
+                            amount: $leg.amount,
+                            currency: $leg.currencyCode,
+                            currencies: currencies,
+                            label: "實際付款"
+                        )
+                        if participant.paymentLegs.count > 1 {
+                            Button("刪除此付款來源", role: .destructive) {
+                                onRemovePaymentLeg(leg.id)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+                    .padding(.leading, 12)
+                }
+                Button("新增付款來源", action: onAddPaymentLeg)
+                    .accessibilityIdentifier("advance.structural.addPaymentLeg")
+            }
+
+            if canRemove {
+                Button("刪除此參與人", role: .destructive, action: onRemove)
+                    .buttonStyle(.borderless)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+private struct RepaymentEditor: View {
+    @Binding var repayment: AdvanceStructuralEditorView.RepaymentState
+    let participantName: String
+    let accounts: [Account]
+    let categories: [Category]
+    let tags: [Tag]
+    let currencies: [String]
+    let caseCurrency: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(participantName)
+                .font(.headline)
+            Picker("帳戶", selection: $repayment.account) {
+                Text("請選擇").tag(nil as Account?)
+                ForEach(accounts) { account in
+                    Text(account.name).tag(account as Account?)
+                }
+            }
+            AmountCurrencyRow(
+                amount: $repayment.amount,
+                currency: $repayment.currencyCode,
+                currencies: currencies,
+                label: "實際還款"
+            )
+            TextField(
+                "\(caseCurrency) 沖銷額",
+                text: Binding(
+                    get: { repayment.normalizedAmount },
+                    set: { repayment.normalizedAmount = sanitizeDecimal($0) }
+                )
+            )
+            .keyboardType(.decimalPad)
+            DatePicker("日期", selection: $repayment.date)
+            Picker("分類", selection: $repayment.category) {
+                Text("無分類").tag(nil as Category?)
+                ForEach(categories) { category in
+                    Text(category.name).tag(category as Category?)
+                }
+            }
+            TagSelection(tags: tags, selected: $repayment.tags)
+            TextField("備註", text: $repayment.note)
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+private struct AmountCurrencyRow: View {
+    @Binding var amount: String
+    @Binding var currency: String
+    let currencies: [String]
+    let label: String
+
+    var body: some View {
+        HStack {
+            TextField(
+                label,
+                text: Binding(
+                    get: { amount },
+                    set: { amount = sanitizeDecimal($0) }
+                )
+            )
+            .keyboardType(.decimalPad)
+            Picker("幣種", selection: $currency) {
+                ForEach(currencies, id: \.self) { code in
+                    Text(code).tag(code)
+                }
+            }
+        }
+    }
+}
+
+private struct TagSelection: View {
+    let tags: [Tag]
+    @Binding var selected: Set<Tag>
+
+    var body: some View {
+        ForEach(tags) { tag in
+            Toggle(
+                tag.name,
+                isOn: Binding(
+                    get: { selected.contains(tag) },
+                    set: { isSelected in
+                        if isSelected {
+                            selected.insert(tag)
+                        } else {
+                            selected.remove(tag)
+                        }
+                    }
+                )
+            )
+        }
+    }
+}
+
+private func sanitizeDecimal(_ value: String) -> String {
+    let allowed = value.filter { $0.isNumber || $0 == "." }
+    var result = ""
+    var hasDot = false
+    for character in allowed {
+        if character == "." {
+            if hasDot { continue }
+            hasDot = true
+        }
+        result.append(character)
+    }
+    return result == "." ? "" : result
+}
+
+private func positiveDecimal(_ value: String) -> Decimal? {
+    Decimal(string: value).flatMap { $0 > 0 ? $0 : nil }
+}
+
+private func decimalString(_ value: Decimal) -> String {
+    NSDecimalNumber(decimal: value).stringValue
+}

--- a/AI 記帳/Views/Advances/AdvancesView.swift
+++ b/AI 記帳/Views/Advances/AdvancesView.swift
@@ -423,7 +423,7 @@ struct AdvanceCaseDetailView: View {
             }
         }
         .sheet(isPresented: $showingCaseEditor) {
-            EditAdvanceCaseView(advanceCase: advanceCase)
+            AdvanceStructuralEditorView(advanceCase: advanceCase)
         }
         .sheet(item: $selectedParticipantForRepayment) { participant in
             AddAdvanceRepaymentView(advanceCase: advanceCase, participant: participant)

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.duckdns.lhfser.aiaccounting.core.model.AccountType
@@ -141,6 +142,7 @@ fun AdvanceDetailScreen(caseId: String?) {
     var initialTags by remember { mutableStateOf<List<TagEntity>>(emptyList()) }
     var initialDate by remember { mutableStateOf(Instant.now()) }
     var initialNote by remember { mutableStateOf("") }
+    var showingStructuralEditor by remember { mutableStateOf(false) }
 
     if (advanceCase == null) {
         Column(modifier = Modifier.padding(AppSpacing.screenHorizontal)) {
@@ -297,6 +299,12 @@ fun AdvanceDetailScreen(caseId: String?) {
                     Text("幣種：$caseCurrency")
                     Text("備註：${caseData.advanceCase.note.ifBlank { "-" }}")
                     if (!isEditingInitialMetadata) {
+                        TextButton(
+                            modifier = Modifier.testTag("advance.structural.open"),
+                            onClick = { showingStructuralEditor = true }
+                        ) {
+                            Text("完整結構編輯")
+                        }
                         TextButton(onClick = {
                             initialTitle = caseData.advanceCase.title
                             initialPayerAccount = receiveAccounts.firstOrNull {
@@ -1130,6 +1138,19 @@ fun AdvanceDetailScreen(caseId: String?) {
             },
             dismissButton = {
                 TextButton(onClick = { participantToEdit = null }) { Text("取消") }
+            }
+        )
+    }
+
+    if (showingStructuralEditor) {
+        AdvanceStructuralEditorDialog(
+            advanceCase = caseData,
+            accounts = accounts,
+            categories = categories,
+            tags = tags,
+            onDismiss = { showingStructuralEditor = false },
+            onApplied = {
+                advanceCase = repository.getAdvanceCase(caseData.advanceCase.id)
             }
         )
     }

--- a/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceStructuralEditorDialog.kt
+++ b/android/app/src/main/java/org/duckdns/lhfser/aiaccounting/ui/screens/AdvanceStructuralEditorDialog.kt
@@ -1,0 +1,1004 @@
+package org.duckdns.lhfser.aiaccounting.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import kotlinx.coroutines.launch
+import org.duckdns.lhfser.aiaccounting.core.model.AccountType
+import org.duckdns.lhfser.aiaccounting.core.model.TransactionType
+import org.duckdns.lhfser.aiaccounting.data.db.AccountEntity
+import org.duckdns.lhfser.aiaccounting.data.db.AdvanceCaseWithDetails
+import org.duckdns.lhfser.aiaccounting.data.db.CategoryEntity
+import org.duckdns.lhfser.aiaccounting.data.db.TagEntity
+import org.duckdns.lhfser.aiaccounting.data.repository.AccountingRepository
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceCaseStructuralEditDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceCaseStructuralImpact
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceParticipantStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvancePaymentLegStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceRepaymentStructuralDraft
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceSettlementDirection
+import org.duckdns.lhfser.aiaccounting.data.repository.AdvanceShareStructuralDraft
+import org.duckdns.lhfser.aiaccounting.ui.LocalRepository
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyButtonStyle
+import org.duckdns.lhfser.aiaccounting.ui.components.CurrencyPicker
+import org.duckdns.lhfser.aiaccounting.ui.components.SectionCard
+import java.math.BigDecimal
+import java.util.UUID
+
+private data class StructuralPaymentLegUi(
+    val id: UUID = UUID.randomUUID(),
+    val transactionId: UUID? = null,
+    val accountId: UUID? = null,
+    val amount: String = "",
+    val currencyCode: String = "HKD"
+)
+
+private data class StructuralParticipantUi(
+    val id: UUID,
+    val participantId: UUID? = null,
+    val name: String = "",
+    val debtAccountId: UUID? = null,
+    val owedAmount: String = "",
+    val paymentLegs: List<StructuralPaymentLegUi> = emptyList()
+)
+
+private data class StructuralRepaymentUi(
+    val id: UUID,
+    val participantId: UUID,
+    val receiveAccountId: UUID?,
+    val amount: String,
+    val currencyCode: String,
+    val normalizedAmount: String,
+    val date: java.time.Instant,
+    val note: String,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>
+)
+
+private data class StructuralShareUi(
+    val transactionId: UUID?,
+    val accountId: UUID?,
+    val amount: String,
+    val currencyCode: String,
+    val normalizedAmount: String
+)
+
+@Composable
+fun AdvanceStructuralEditorDialog(
+    advanceCase: AdvanceCaseWithDetails,
+    accounts: List<AccountEntity>,
+    categories: List<CategoryEntity>,
+    tags: List<TagEntity>,
+    onDismiss: () -> Unit,
+    onApplied: suspend () -> Unit
+) {
+    val repository = LocalRepository.current
+    val scope = rememberCoroutineScope()
+    val ownAccounts = accounts.filter { it.type != AccountType.Debt && !it.isArchived }
+    val debtAccounts = accounts.filter { it.type == AccountType.Debt && !it.isArchived }
+    val expenseCategories = categories.filter { it.kind.supports(TransactionType.Expense) }
+
+    var title by remember { mutableStateOf(advanceCase.advanceCase.title) }
+    var direction by remember {
+        mutableStateOf(
+            runCatching {
+                AdvanceSettlementDirection.valueOf(
+                    advanceCase.advanceCase.direction ?: ""
+                )
+            }.getOrDefault(
+                if (advanceCase.advanceCase.payerAccountId == null) {
+                    AdvanceSettlementDirection.OthersAdvancedMe
+                } else {
+                    AdvanceSettlementDirection.IAdvancedOthers
+                }
+            )
+        )
+    }
+    var currencyCode by remember { mutableStateOf(advanceCase.advanceCase.currencyCode) }
+    var note by remember { mutableStateOf(advanceCase.advanceCase.note) }
+    var categoryId by remember { mutableStateOf(advanceCase.advanceCase.expenseCategoryId) }
+    var selectedTagIds by remember { mutableStateOf(emptyList<UUID>()) }
+    var includesShare by remember {
+        mutableStateOf(advanceCase.advanceCase.selfExpenseTransactionId != null)
+    }
+    var share by remember {
+        mutableStateOf(
+            StructuralShareUi(
+                transactionId = advanceCase.advanceCase.selfExpenseTransactionId,
+                accountId = null,
+                amount = "",
+                currencyCode = advanceCase.advanceCase.currencyCode,
+                normalizedAmount = advanceCase.advanceCase.myShareAmount.toPlainString()
+            )
+        )
+    }
+    var participants by remember { mutableStateOf(emptyList<StructuralParticipantUi>()) }
+    var repayments by remember { mutableStateOf(emptyList<StructuralRepaymentUi>()) }
+    var confirmsCurrencyAmounts by remember { mutableStateOf(true) }
+    var loaded by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var pendingDraft by remember { mutableStateOf<AdvanceCaseStructuralEditDraft?>(null) }
+    var pendingImpact by remember { mutableStateOf<AdvanceCaseStructuralImpact?>(null) }
+
+    val hasSpecialRepayments = advanceCase.repayments.any {
+        AccountingRepository.isMutualDebtOffset(it.note) ||
+            AccountingRepository.isManualDebtSettlement(it.note)
+    }
+
+    LaunchedEffect(advanceCase.advanceCase.id) {
+        selectedTagIds = repository.exportBackup().advanceCases
+            .orEmpty()
+            .firstOrNull { it.id == advanceCase.advanceCase.id }
+            ?.tagIDs
+            .orEmpty()
+        share = advanceCase.advanceCase.selfExpenseTransactionId?.let { transactionId ->
+            repository.getTransaction(transactionId)?.let { transaction ->
+                StructuralShareUi(
+                    transactionId = transactionId,
+                    accountId = transaction.transaction.accountId,
+                    amount = transaction.transaction.amount.abs().toPlainString(),
+                    currencyCode = transaction.transaction.currencyCode,
+                    normalizedAmount = advanceCase.advanceCase.myShareAmount.toPlainString()
+                )
+            }
+        } ?: share.copy(accountId = ownAccounts.firstOrNull()?.id)
+
+        participants = advanceCase.participants.map { participant ->
+            val group = participant.initialTransferGroupId
+                ?.let { repository.getTransferGroup(it) }
+                .orEmpty()
+            val legs = group
+                .filter { it.transaction.advanceEntryRole == "InitialAsset" }
+                .map { item ->
+                    StructuralPaymentLegUi(
+                        transactionId = item.transaction.id,
+                        accountId = item.transaction.accountId,
+                        amount = item.transaction.amount.abs().toPlainString(),
+                        currencyCode = item.transaction.currencyCode
+                    )
+                }
+            StructuralParticipantUi(
+                id = participant.id,
+                participantId = participant.id,
+                name = participant.name,
+                debtAccountId = participant.debtAccountId,
+                owedAmount = participant.owedAmount.toPlainString(),
+                paymentLegs = if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                    legs.ifEmpty {
+                        listOf(
+                            StructuralPaymentLegUi(
+                                accountId = ownAccounts.firstOrNull()?.id,
+                                currencyCode = ownAccounts.firstOrNull()?.currency ?: currencyCode
+                            )
+                        )
+                    }
+                } else {
+                    emptyList()
+                }
+            )
+        }
+        repayments = advanceCase.repayments
+            .filter {
+                !AccountingRepository.isMutualDebtOffset(it.note) &&
+                    !AccountingRepository.isManualDebtSettlement(it.note)
+            }
+            .mapNotNull { repayment ->
+                val participantId = repayment.participantId ?: return@mapNotNull null
+                val group = repayment.linkedTransferGroupId
+                    ?.let { repository.getTransferGroup(it) }
+                    .orEmpty()
+                val ownLeg = group.firstOrNull {
+                    it.transaction.advanceEntryRole == "RepaymentAsset"
+                }
+                StructuralRepaymentUi(
+                    id = repayment.id,
+                    participantId = participantId,
+                    receiveAccountId = repayment.receivedAccountId,
+                    amount = repayment.amount.toPlainString(),
+                    currencyCode = repayment.currencyCode,
+                    normalizedAmount = repayment.normalizedAmount.toPlainString(),
+                    date = repayment.date,
+                    note = repayment.note,
+                    categoryId = ownLeg?.transaction?.categoryId,
+                    tagIds = ownLeg?.tags?.map { it.id }.orEmpty()
+                )
+            }
+        loaded = true
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 6.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 760.dp)
+                .imePadding()
+                .testTag("advance.structural.editor")
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text("完整編輯代墊", style = MaterialTheme.typography.titleLarge)
+                if (!loaded) {
+                    Text("載入中...")
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.weight(1f, fill = false),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        item {
+                            SectionCard {
+                                Text("方向", style = MaterialTheme.typography.titleSmall)
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    AdvanceSettlementDirection.values().forEach { item ->
+                                        FilterChip(
+                                            modifier = Modifier.testTag(
+                                                "advance.structural.direction.${item.name}"
+                                            ),
+                                            selected = direction == item,
+                                            onClick = {
+                                                direction = item
+                                                if (item == AdvanceSettlementDirection.OthersAdvancedMe) {
+                                                    includesShare = false
+                                                    participants = participants.map {
+                                                        it.copy(paymentLegs = emptyList())
+                                                    }
+                                                } else {
+                                                    participants = participants.map { participant ->
+                                                        if (participant.paymentLegs.isEmpty()) {
+                                                            participant.copy(
+                                                                paymentLegs = listOf(
+                                                                    StructuralPaymentLegUi(
+                                                                        accountId = ownAccounts.firstOrNull()?.id,
+                                                                        currencyCode = ownAccounts.firstOrNull()?.currency
+                                                                            ?: currencyCode
+                                                                    )
+                                                                )
+                                                            )
+                                                        } else {
+                                                            participant
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            label = {
+                                                Text(
+                                                    if (item == AdvanceSettlementDirection.IAdvancedOthers) {
+                                                        "我代墊他人"
+                                                    } else {
+                                                        "他人代墊我"
+                                                    }
+                                                )
+                                            }
+                                        )
+                                    }
+                                }
+                                OutlinedTextField(
+                                    value = title,
+                                    onValueChange = { title = it },
+                                    label = { Text("案件名稱") },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions =
+                                        org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+                                )
+                                Text("案件幣種", style = MaterialTheme.typography.titleSmall)
+                                CurrencyPicker(
+                                    selected = currencyCode,
+                                    onSelect = {
+                                        if (!it.equals(currencyCode, ignoreCase = true)) {
+                                            confirmsCurrencyAmounts = false
+                                        }
+                                        currencyCode = it
+                                    },
+                                    buttonStyle = CurrencyButtonStyle.Tonal
+                                )
+                                StructuralPicker(
+                                    label = "支出分類",
+                                    value = expenseCategories.firstOrNull { it.id == categoryId },
+                                    options = expenseCategories,
+                                    optionLabel = { it.name },
+                                    onSelect = { categoryId = it?.id }
+                                )
+                                StructuralTagPicker(
+                                    tags = tags,
+                                    selectedIds = selectedTagIds,
+                                    onChange = { selectedTagIds = it }
+                                )
+                                OutlinedTextField(
+                                    value = note,
+                                    onValueChange = { note = it },
+                                    label = { Text("備註") },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions =
+                                        org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+                                )
+                            }
+                        }
+
+                        if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                            item {
+                                SectionCard {
+                                    FilterChip(
+                                        selected = includesShare,
+                                        onClick = { includesShare = !includesShare },
+                                        label = { Text("包含自己的份額") }
+                                    )
+                                    if (includesShare) {
+                                        StructuralPicker(
+                                            label = "自己份額付款帳戶",
+                                            value = ownAccounts.firstOrNull { it.id == share.accountId },
+                                            options = ownAccounts,
+                                            optionLabel = { it.name },
+                                            onSelect = { share = share.copy(accountId = it?.id) }
+                                        )
+                                        StructuralAmountRow(
+                                            label = "實際付款",
+                                            amount = share.amount,
+                                            currency = share.currencyCode,
+                                            onAmountChange = { share = share.copy(amount = sanitizeStructuralAmount(it)) },
+                                            onCurrencyChange = { share = share.copy(currencyCode = it) }
+                                        )
+                                        StructuralNumberField(
+                                            label = "$currencyCode 案件份額",
+                                            value = share.normalizedAmount,
+                                            onChange = {
+                                                share = share.copy(
+                                                    normalizedAmount = sanitizeStructuralAmount(it)
+                                                )
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        participants.forEach { participant ->
+                            item(key = participant.id) {
+                                StructuralParticipantEditor(
+                                    participant = participant,
+                                    direction = direction,
+                                    caseCurrency = currencyCode,
+                                    ownAccounts = ownAccounts,
+                                    debtAccounts = debtAccounts,
+                                    onChange = { updated ->
+                                        participants = participants.map {
+                                            if (it.id == participant.id) updated else it
+                                        }
+                                    },
+                                    onRemove = if (participants.size > 1) {
+                                        {
+                                            participants = participants.filterNot {
+                                                it.id == participant.id
+                                            }
+                                            participant.participantId?.let { participantId ->
+                                                repayments = repayments.filterNot {
+                                                    it.participantId == participantId
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        null
+                                    }
+                                )
+                            }
+                        }
+
+                        item {
+                            TextButton(
+                                modifier = Modifier.testTag("advance.structural.addParticipant"),
+                                onClick = {
+                                    participants = participants + StructuralParticipantUi(
+                                        id = UUID.randomUUID(),
+                                        paymentLegs =
+                                            if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                                                listOf(
+                                                    StructuralPaymentLegUi(
+                                                        accountId = ownAccounts.firstOrNull()?.id,
+                                                        currencyCode = ownAccounts.firstOrNull()?.currency
+                                                            ?: currencyCode
+                                                    )
+                                                )
+                                            } else {
+                                                emptyList()
+                                            }
+                                    )
+                                }
+                            ) {
+                                Text("新增參與人")
+                            }
+                        }
+
+                        repayments.forEach { repayment ->
+                            item(key = repayment.id) {
+                                StructuralRepaymentEditor(
+                                    repayment = repayment,
+                                    participantName = participants.firstOrNull {
+                                        it.participantId == repayment.participantId
+                                    }?.name ?: "已移除對象",
+                                    accounts = ownAccounts,
+                                    caseCurrency = currencyCode,
+                                    onChange = { updated ->
+                                        repayments = repayments.map {
+                                            if (it.id == repayment.id) updated else it
+                                        }
+                                    }
+                                )
+                            }
+                        }
+
+                        item {
+                            SectionCard {
+                                if (hasSpecialRepayments) {
+                                    Text(
+                                        "此案件含債務抵銷或手動結清。請先返回詳情整組撤銷。",
+                                        color = MaterialTheme.colorScheme.error
+                                    )
+                                }
+                                if (!currencyCode.equals(
+                                        advanceCase.advanceCase.currencyCode,
+                                        ignoreCase = true
+                                    )
+                                ) {
+                                    FilterChip(
+                                        modifier = Modifier.testTag(
+                                            "advance.structural.confirmCurrency"
+                                        ),
+                                        selected = confirmsCurrencyAmounts,
+                                        onClick = {
+                                            confirmsCurrencyAmounts = !confirmsCurrencyAmounts
+                                        },
+                                        label = {
+                                            Text("我已重新確認所有 $currencyCode 金額與沖銷額")
+                                        }
+                                    )
+                                }
+                                Text(
+                                    "儲存前會先顯示影響預覽；確認後才原子重建。",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    errorMessage?.let {
+                        Text(it, color = MaterialTheme.colorScheme.error)
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = onDismiss) { Text("取消") }
+                        Button(
+                            modifier = Modifier.testTag("advance.structural.preview"),
+                            onClick = {
+                                scope.launch {
+                                    runCatching {
+                                        require(confirmsCurrencyAmounts) {
+                                            "請先重新確認新案件幣種下的所有金額。"
+                                        }
+                                        val draft = buildStructuralDraft(
+                                            advanceCase = advanceCase,
+                                            title = title,
+                                            direction = direction,
+                                            currencyCode = currencyCode,
+                                            note = note,
+                                            categoryId = categoryId,
+                                            tagIds = selectedTagIds,
+                                            includesShare = includesShare,
+                                            share = share,
+                                            participants = participants,
+                                            repayments = repayments
+                                        )
+                                        val impact = repository.previewAdvanceCaseStructuralEdit(draft)
+                                        draft to impact
+                                    }.onSuccess { (draft, impact) ->
+                                        pendingDraft = draft
+                                        pendingImpact = impact
+                                        errorMessage = null
+                                    }.onFailure {
+                                        errorMessage = it.localizedMessage ?: "無法預覽變更。"
+                                    }
+                                }
+                            },
+                            enabled = !hasSpecialRepayments
+                        ) {
+                            Text("預覽影響")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pendingImpact?.let { impact ->
+        AlertDialog(
+            onDismissRequest = {
+                pendingImpact = null
+                pendingDraft = null
+            },
+            title = { Text("確認套用結構性變更？") },
+            text = {
+                Text(
+                    buildList {
+                        addAll(impact.warnings)
+                        add("將重建或更新 ${impact.affectedTransactionCount} 筆底層分錄。")
+                        if (impact.removedParticipantCount > 0) {
+                            add("將刪除 ${impact.removedParticipantCount} 位參與人。")
+                        }
+                        if (impact.removedRepaymentCount > 0) {
+                            add("將刪除 ${impact.removedRepaymentCount} 筆還款。")
+                        }
+                    }.joinToString("\n")
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    modifier = Modifier.testTag("advance.structural.apply"),
+                    onClick = {
+                        val draft = pendingDraft ?: return@TextButton
+                        scope.launch {
+                            runCatching {
+                                repository.applyAdvanceCaseStructuralEdit(draft)
+                                onApplied()
+                            }.onSuccess {
+                                pendingDraft = null
+                                pendingImpact = null
+                                onDismiss()
+                            }.onFailure {
+                                errorMessage = it.localizedMessage ?: "無法套用變更。"
+                                pendingDraft = null
+                                pendingImpact = null
+                            }
+                        }
+                    }
+                ) {
+                    Text("確認重建")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    pendingImpact = null
+                    pendingDraft = null
+                }) {
+                    Text("取消")
+                }
+            }
+        )
+    }
+}
+
+private fun buildStructuralDraft(
+    advanceCase: AdvanceCaseWithDetails,
+    title: String,
+    direction: AdvanceSettlementDirection,
+    currencyCode: String,
+    note: String,
+    categoryId: UUID?,
+    tagIds: List<UUID>,
+    includesShare: Boolean,
+    share: StructuralShareUi,
+    participants: List<StructuralParticipantUi>,
+    repayments: List<StructuralRepaymentUi>
+): AdvanceCaseStructuralEditDraft {
+    val participantDrafts = participants.map { participant ->
+        val debtAccountId = requireNotNull(participant.debtAccountId) {
+            "請為每位參與人選擇債務帳戶。"
+        }
+        val owedAmount = requireNotNull(parseStructuralPositive(participant.owedAmount)) {
+            "請輸入大於 0 的欠款金額。"
+        }
+        AdvanceParticipantStructuralDraft(
+            participantId = participant.participantId,
+            name = participant.name,
+            debtAccountId = debtAccountId,
+            owedAmount = owedAmount,
+            paymentLegs =
+                if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+                    participant.paymentLegs.map { leg ->
+                        AdvancePaymentLegStructuralDraft(
+                            transactionId = leg.transactionId,
+                            accountId = requireNotNull(leg.accountId) {
+                                "請選擇付款帳戶。"
+                            },
+                            amount = requireNotNull(parseStructuralPositive(leg.amount)) {
+                                "請輸入大於 0 的付款金額。"
+                            },
+                            currencyCode = leg.currencyCode
+                        )
+                    }
+                } else {
+                    emptyList()
+                }
+        )
+    }
+    val retainedParticipantIds = participantDrafts.mapNotNull { it.participantId }.toSet()
+    val repaymentDrafts = repayments.map { repayment ->
+        require(repayment.participantId in retainedParticipantIds) {
+            "還款對象已被移除。"
+        }
+        AdvanceRepaymentStructuralDraft(
+            repaymentId = repayment.id,
+            receiveAccountId = requireNotNull(repayment.receiveAccountId) {
+                "請選擇還款帳戶。"
+            },
+            amount = requireNotNull(parseStructuralPositive(repayment.amount)) {
+                "請輸入大於 0 的還款金額。"
+            },
+            currencyCode = repayment.currencyCode,
+            normalizedAmount = requireNotNull(
+                parseStructuralPositive(repayment.normalizedAmount)
+            ) {
+                "請輸入大於 0 的沖銷額。"
+            },
+            date = repayment.date,
+            note = repayment.note,
+            categoryId = repayment.categoryId,
+            tagIds = repayment.tagIds
+        )
+    }
+    val shareDraft = if (
+        direction == AdvanceSettlementDirection.IAdvancedOthers && includesShare
+    ) {
+        AdvanceShareStructuralDraft(
+            transactionId = share.transactionId,
+            accountId = requireNotNull(share.accountId) { "請選擇自己份額付款帳戶。" },
+            amount = requireNotNull(parseStructuralPositive(share.amount)) {
+                "請輸入自己份額的實際付款。"
+            },
+            normalizedAmount = requireNotNull(
+                parseStructuralPositive(share.normalizedAmount)
+            ) {
+                "請輸入案件中的自己份額。"
+            },
+            currencyCode = share.currencyCode
+        )
+    } else {
+        null
+    }
+    return AdvanceCaseStructuralEditDraft(
+        caseId = advanceCase.advanceCase.id,
+        title = title,
+        date = advanceCase.advanceCase.date,
+        direction = direction,
+        currencyCode = currencyCode,
+        note = note,
+        categoryId = categoryId,
+        tagIds = tagIds,
+        share = shareDraft,
+        participants = participantDrafts,
+        repayments = repaymentDrafts
+    )
+}
+
+@Composable
+private fun StructuralParticipantEditor(
+    participant: StructuralParticipantUi,
+    direction: AdvanceSettlementDirection,
+    caseCurrency: String,
+    ownAccounts: List<AccountEntity>,
+    debtAccounts: List<AccountEntity>,
+    onChange: (StructuralParticipantUi) -> Unit,
+    onRemove: (() -> Unit)?
+) {
+    SectionCard {
+        OutlinedTextField(
+            value = participant.name,
+            onValueChange = { onChange(participant.copy(name = it)) },
+            label = { Text("姓名") },
+            modifier = Modifier.fillMaxWidth(),
+            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions =
+                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+        )
+        StructuralPicker(
+            label = "債務帳戶",
+            value = debtAccounts.firstOrNull { it.id == participant.debtAccountId },
+            options = debtAccounts,
+            optionLabel = { it.name },
+            onSelect = { onChange(participant.copy(debtAccountId = it?.id)) }
+        )
+        StructuralNumberField(
+            label = "$caseCurrency 欠款金額",
+            value = participant.owedAmount,
+            onChange = {
+                onChange(participant.copy(owedAmount = sanitizeStructuralAmount(it)))
+            }
+        )
+        if (direction == AdvanceSettlementDirection.IAdvancedOthers) {
+            participant.paymentLegs.forEach { leg ->
+                Column(
+                    modifier = Modifier.padding(start = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    StructuralPicker(
+                        label = "付款帳戶",
+                        value = ownAccounts.firstOrNull { it.id == leg.accountId },
+                        options = ownAccounts,
+                        optionLabel = { it.name },
+                        onSelect = { selected ->
+                            onChange(
+                                participant.copy(
+                                    paymentLegs = participant.paymentLegs.map {
+                                        if (it.id == leg.id) {
+                                            it.copy(
+                                                accountId = selected?.id,
+                                                currencyCode = selected?.currency ?: it.currencyCode
+                                            )
+                                        } else {
+                                            it
+                                        }
+                                    }
+                                )
+                            )
+                        }
+                    )
+                    StructuralAmountRow(
+                        label = "實際付款",
+                        amount = leg.amount,
+                        currency = leg.currencyCode,
+                        onAmountChange = { amount ->
+                            onChange(
+                                participant.copy(
+                                    paymentLegs = participant.paymentLegs.map {
+                                        if (it.id == leg.id) {
+                                            it.copy(amount = sanitizeStructuralAmount(amount))
+                                        } else {
+                                            it
+                                        }
+                                    }
+                                )
+                            )
+                        },
+                        onCurrencyChange = { currency ->
+                            onChange(
+                                participant.copy(
+                                    paymentLegs = participant.paymentLegs.map {
+                                        if (it.id == leg.id) it.copy(currencyCode = currency) else it
+                                    }
+                                )
+                            )
+                        }
+                    )
+                    if (participant.paymentLegs.size > 1) {
+                        TextButton(onClick = {
+                            onChange(
+                                participant.copy(
+                                    paymentLegs = participant.paymentLegs.filterNot {
+                                        it.id == leg.id
+                                    }
+                                )
+                            )
+                        }) {
+                            Text("刪除此付款來源")
+                        }
+                    }
+                }
+            }
+            TextButton(
+                modifier = Modifier.testTag("advance.structural.addPaymentLeg"),
+                onClick = {
+                    onChange(
+                        participant.copy(
+                            paymentLegs = participant.paymentLegs + StructuralPaymentLegUi(
+                                accountId = ownAccounts.firstOrNull()?.id,
+                                currencyCode = ownAccounts.firstOrNull()?.currency ?: caseCurrency
+                            )
+                        )
+                    )
+                }
+            ) {
+                Text("新增付款來源")
+            }
+        }
+        onRemove?.let {
+            TextButton(onClick = it) {
+                Text("刪除此參與人", color = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StructuralRepaymentEditor(
+    repayment: StructuralRepaymentUi,
+    participantName: String,
+    accounts: List<AccountEntity>,
+    caseCurrency: String,
+    onChange: (StructuralRepaymentUi) -> Unit
+) {
+    SectionCard {
+        Text("$participantName 的普通還款", style = MaterialTheme.typography.titleSmall)
+        StructuralPicker(
+            label = "帳戶",
+            value = accounts.firstOrNull { it.id == repayment.receiveAccountId },
+            options = accounts,
+            optionLabel = { it.name },
+            onSelect = { onChange(repayment.copy(receiveAccountId = it?.id)) }
+        )
+        StructuralAmountRow(
+            label = "實際還款",
+            amount = repayment.amount,
+            currency = repayment.currencyCode,
+            onAmountChange = {
+                onChange(repayment.copy(amount = sanitizeStructuralAmount(it)))
+            },
+            onCurrencyChange = { onChange(repayment.copy(currencyCode = it)) }
+        )
+        StructuralNumberField(
+            label = "$caseCurrency 沖銷額",
+            value = repayment.normalizedAmount,
+            onChange = {
+                onChange(repayment.copy(normalizedAmount = sanitizeStructuralAmount(it)))
+            }
+        )
+    }
+}
+
+@Composable
+private fun StructuralAmountRow(
+    label: String,
+    amount: String,
+    currency: String,
+    onAmountChange: (String) -> Unit,
+    onCurrencyChange: (String) -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        CurrencyPicker(
+            selected = currency,
+            onSelect = onCurrencyChange,
+            buttonStyle = CurrencyButtonStyle.Text
+        )
+        OutlinedTextField(
+            value = amount,
+            onValueChange = onAmountChange,
+            label = { Text(label) },
+            modifier = Modifier.weight(1f),
+            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions =
+                org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+        )
+    }
+}
+
+@Composable
+private fun StructuralNumberField(
+    label: String,
+    value: String,
+    onChange: (String) -> Unit
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onChange,
+        label = { Text(label) },
+        modifier = Modifier.fillMaxWidth(),
+        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+            keyboardType = KeyboardType.Decimal,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions =
+            org.duckdns.lhfser.aiaccounting.ui.components.keyboardDoneActions()
+    )
+}
+
+@Composable
+private fun <T> StructuralPicker(
+    label: String,
+    value: T?,
+    options: List<T>,
+    optionLabel: (T) -> String,
+    onSelect: (T?) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(label, style = MaterialTheme.typography.titleSmall)
+        TextButton(onClick = { expanded = true }) {
+            Text(value?.let(optionLabel) ?: "請選擇")
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text("不設定") },
+                onClick = {
+                    expanded = false
+                    onSelect(null)
+                }
+            )
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(optionLabel(option)) },
+                    onClick = {
+                        expanded = false
+                        onSelect(option)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StructuralTagPicker(
+    tags: List<TagEntity>,
+    selectedIds: List<UUID>,
+    onChange: (List<UUID>) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("標籤", style = MaterialTheme.typography.titleSmall)
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            tags.forEach { tag ->
+                FilterChip(
+                    selected = tag.id in selectedIds,
+                    onClick = {
+                        onChange(
+                            if (tag.id in selectedIds) {
+                                selectedIds - tag.id
+                            } else {
+                                selectedIds + tag.id
+                            }
+                        )
+                    },
+                    label = { Text(tag.name) }
+                )
+            }
+        }
+    }
+}
+
+private fun sanitizeStructuralAmount(value: String): String {
+    val allowed = value.filter { it.isDigit() || it == '.' }
+    var hasDot = false
+    return buildString {
+        allowed.forEach { character ->
+            if (character == '.') {
+                if (hasDot) return@forEach
+                hasDot = true
+            }
+            append(character)
+        }
+    }.let { if (it == ".") "" else it }
+}
+
+private fun parseStructuralPositive(value: String): BigDecimal? {
+    return value.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO }
+}


### PR DESCRIPTION
## 實際完成內容
- iOS 代墊詳情改接專用完整結構編輯器。
- Android 代墊詳情新增對等的完整結構編輯 dialog。
- 兩端支援方向轉換、案件幣種明確重確認、自己份額、付款來源 legs、新增/刪除參與人與普通還款沖銷額編輯。
- 所有儲存流程均先產生 impact preview，使用者第二次確認後才呼叫 atomic apply。
- 特殊抵銷與手動結清案件會阻止拆開結構編輯，要求先整組撤銷。
- 加入穩定 accessibility/test identifiers，供後續 UI automation 使用。

## 帳務與資料模型影響
- 本 PR 不新增帳務語義或資料模型；UI 僅組裝 PR #145 已合併的 structural edit drafts。
- 方向、幣種、payment legs、參與人與普通還款變更仍由 repository/service 驗證並原子重建。
- 刪除參與人會在 draft 中同時移除其普通還款，實際刪除範圍於 impact preview 明示。

## Migration / backup compatibility
- 無 schema migration。
- 備份版本維持 1.9；UI 不依賴 note marker 建立新連結。
- 舊資料讀取及新版 explicit advance links roundtrip 行為由 PR #145 核心與測試維持。

## 測試結果
- iOS `xcodebuild ... build`：PASS。
- iOS `xcodebuild ... build-for-testing`：PASS。
- Android `:app:assembleDebug :app:testDebugUnitTest`：PASS。
- Android 同組工作 `--rerun-tasks`：PASS。
- `git diff --check`：PASS。

## 未完成內容
- XCUITest 與 Android Compose/UI Automator 自動化留在第三條 PR。
- 本機 CoreSimulator 仍因 `launchd_sim could not bind to session` 無法執行 runtime UI 驗證；CI 將提供 iOS runtime gate。

## 所作假設
- ADR 0001/0002 與 PR #145 的 structural editing invariants 為唯一帳務語義來源。
- 至少保留一位參與人；特殊結算必須先整組撤銷。

## 需要項目決策者覆核的事項
- 無。